### PR TITLE
Fixed link to License file

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,4 +48,4 @@ Each driver comes with its own documentation in the Readme of the driver repo.
 Got questions? Feel free to ask at the [RedisBloom mailing list](https://groups.google.com/forum/#!forum/redisbloom).
 
 ## License
-Redis Source Available License Agreement - see [LICENSE](LICENSE)
+Redis Source Available License Agreement - see [LICENSE](https://raw.githubusercontent.com/RedisBloom/RedisBloom/master/LICENSE)


### PR DESCRIPTION
Old link was to a /docs license file which didn't exist and produced a 404.
Now linking to License file under root, the same way other Redis module repositories do.