### PR TITLE
Fix scaling of bloom

### DIFF
--- a/src/sb.c
+++ b/src/sb.c
@@ -61,7 +61,7 @@ int SBChain_Add(SBChain *sb, const void *data, size_t len) {
             return 0;
         }
     }
-    
+
     // Determine if we need to add more items?
     SBLink *cur = CUR_FILTER(sb);
     if (cur->size >= cur->inner.entries) {

--- a/src/sb.c
+++ b/src/sb.c
@@ -61,11 +61,11 @@ int SBChain_Add(SBChain *sb, const void *data, size_t len) {
             return 0;
         }
     }
-
+    
     // Determine if we need to add more items?
     SBLink *cur = CUR_FILTER(sb);
     if (cur->size >= cur->inner.entries) {
-        double error = cur->inner.error * pow(ERROR_TIGHTENING_RATIO, sb->nfilters + 1);
+        double error = cur->inner.error * ERROR_TIGHTENING_RATIO;
         if (SBChain_AddLink(sb, cur->inner.entries * 2, error) != 0) {
             return -1;
         }
@@ -90,12 +90,12 @@ int SBChain_Check(const SBChain *sb, const void *data, size_t len) {
 }
 
 SBChain *SB_NewChain(size_t initsize, double error_rate, unsigned options) {
-    if (initsize == 0 || error_rate == 0) {
+    if (initsize == 0 || error_rate == 0 || error_rate >= 1) {
         return NULL;
     }
     SBChain *sb = RedisModule_Calloc(1, sizeof(*sb));
     sb->options = options;
-    if (SBChain_AddLink(sb, initsize, error_rate) != 0) {
+    if (SBChain_AddLink(sb, initsize, error_rate * ERROR_TIGHTENING_RATIO) != 0) {
         SBChain_Free(sb);
         sb = NULL;
     }

--- a/tests/test-basic.c
+++ b/tests/test-basic.c
@@ -46,7 +46,7 @@ TEST_F(basic, sbBasic) {
 TEST_F(basic, sbExpansion) {
     // Note that the chain auto-expands to 6 items by default with the given
     // error ratio. If you modify the error ratio, the expansion may change.
-    SBChain *chain = SB_NewChain(6, 0.01, 0);
+    SBChain *chain = SB_NewChain(8, 0.01, 0);
     ASSERT_NE(NULL, chain);
 
     // Add the first item
@@ -54,7 +54,7 @@ TEST_F(basic, sbExpansion) {
     ASSERT_EQ(1, chain->nfilters);
 
     // Insert 6 items
-    for (size_t ii = 0; ii < 6; ++ii) {
+    for (size_t ii = 0; ii < 16; ++ii) {
         ASSERT_EQ(0, SBChain_Check(chain, &ii, sizeof ii));
         ASSERT_NE(0, SBChain_Add(chain, &ii, sizeof ii));
     }
@@ -91,7 +91,7 @@ TEST_F(basic, testIssue7_Overflow) {
     ASSERT_EQ(33, inner->n2);
     ASSERT_EQ(0.000025, inner->error);
     ASSERT_EQ(1073741824, inner->bytes);
-    ASSERT_EQ(389468927, inner->entries);
+    ASSERT_EQ(365557102, inner->entries);
 
     SBChain_Free(chain);
 }
@@ -143,10 +143,11 @@ typedef struct {
     long long iter;
 } encodedInfo;
 
+/* TODO - check
 TEST_CLASS(encoding)
 
 TEST_F(encoding, testEncodingSimple) {
-    SBChain *chain = SB_NewChain(1000, 0.00001, 0);
+    SBChain *chain = SB_NewChain(1000, 0.001, 0);
     ASSERT_NE(NULL, chain);
 
     size_t nColls = 0;
@@ -159,7 +160,7 @@ TEST_F(encoding, testEncodingSimple) {
         }
     }
 
-    ASSERT_EQ(6, nColls);
+    ASSERT_EQ(89, nColls);
 
     // Dump the header
     size_t len = 0;
@@ -215,7 +216,7 @@ TEST_F(encoding, testEncodingSimple) {
     SBChain_Free(chain);
     SBChain_Free(chain2);
     free(encs);
-}
+} */
 
 int main(int argc, char **argv) {
     test__abort_on_fail = 1;

--- a/tests/test-basic.c
+++ b/tests/test-basic.c
@@ -143,24 +143,25 @@ typedef struct {
     long long iter;
 } encodedInfo;
 
-/* TODO - check
 TEST_CLASS(encoding)
 
 TEST_F(encoding, testEncodingSimple) {
     SBChain *chain = SB_NewChain(1000, 0.001, 0);
     ASSERT_NE(NULL, chain);
 
-    size_t nColls = 0;
     for (size_t ii = 1; ii < 100000; ++ii) {
         SBChain_Add(chain, &ii, sizeof ii);
-
+    }
+    
+    size_t nColls = 0;
+    for (size_t ii = 1; ii < 100000; ++ii) {
         size_t iiFlipped = ii << 31;
         if (SBChain_Check(chain, &iiFlipped, sizeof iiFlipped) != 0) {
             nColls++;
         }
     }
 
-    ASSERT_EQ(89, nColls);
+    ASSERT_EQ(94, nColls);
 
     // Dump the header
     size_t len = 0;
@@ -216,7 +217,7 @@ TEST_F(encoding, testEncodingSimple) {
     SBChain_Free(chain);
     SBChain_Free(chain2);
     free(encs);
-} */
+}
 
 int main(int argc, char **argv) {
     test__abort_on_fail = 1;

--- a/tests/test-bf-error-rate.py
+++ b/tests/test-bf-error-rate.py
@@ -1,0 +1,38 @@
+import requests
+import redis
+import time
+
+redis = redis.Redis(host='localhost', port=6379, db=0)
+redis_pipe = redis.pipeline()
+redis.flushall()
+
+start_time = time.time()
+error_rate = 0.001
+q = 10000
+
+redis.execute_command('BF.RESERVE bloom_filter ', error_rate, q / 10)
+
+for x in range(q):
+  redis_pipe.execute_command('bf.add bloom_filter ' + str(x))
+redis_pipe.execute()
+
+for x in range(q):
+  redis_pipe.execute_command('bf.exists bloom_filter ' + str(x))
+responses = redis_pipe.execute()
+
+for response in responses:
+  assert(response == 1)
+
+print 'Test for False Positives'
+for x in range(q, q * 101):
+  redis_pipe.execute_command('bf.exists bloom_filter ' + str(x))
+responses = redis_pipe.execute()
+
+false_positive = 0.0
+for response in responses:
+  if response == 1:
+    false_positive += 1
+
+print 'Error rate required ' + str(error_rate) + ', actual ' + str(false_positive / (q * 100))
+
+print redis.execute_command('bf.debug bloom_filter')


### PR DESCRIPTION
* The first filter didn't use tightening factor
* Consecutive filters used too many hash functions
* Error rate was higher than requested by the user (about 70% extra when the filter is full)

Issue #159 