### PR TITLE
Raised APBF minimum capacity to 64

### DIFF
--- a/contrib/agingBloom.c
+++ b/contrib/agingBloom.c
@@ -278,6 +278,7 @@ ageBloom_t* APBF_createHighLevelAPI(int error, uint64_t capacity, int8_t level) 
   default: break;
   }
 
+  assert(capacity > l); // To avoid a mod 0 on the shift code
   uint64_t sliceSize = (capacity * k) / (l * log(2));
 
   ageBloom_t* bf = APBF_createLowLevelAPI(k, l, ceil(sliceSize));

--- a/src/rm_apbf.c
+++ b/src/rm_apbf.c
@@ -39,8 +39,11 @@ static int parseCreateArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     if ((RedisModule_StringToLongLong(argv[2], error) != REDISMODULE_OK) || *error < 1 || *error > 5) {
         INNER_ERROR("APBF: invalid error");
     }
-    if ((RedisModule_StringToLongLong(argv[3], capacity) != REDISMODULE_OK) || *capacity < 32) {
-        INNER_ERROR("APBF: invalid capacity or less than 32");
+    // A minimum capacity of 64 ensures that assert (capacity > l) will hold
+    // for all (k,l) configurations, since max l is 63.
+    // It is possible to allow smaller capacity by finner testing against actual l
+    if ((RedisModule_StringToLongLong(argv[3], capacity) != REDISMODULE_OK) || *capacity < 64) {
+        INNER_ERROR("APBF: invalid capacity or less than 64");
     }
 
     return REDISMODULE_OK;


### PR DESCRIPTION
Raised minimum capacity to 64 to ensure that it is always greater than l and avoid a mod by 0 when shifting.