### PR TITLE
Enable static code analysis on CI and development machines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
 
   static-analysis-infer:
     docker:
-      - image: redislabsmodules/llvm-toolset:latest
+      - image: redisfab/rmbuilder:6.0.1-x64-bionic
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,9 @@ jobs:
           command: git submodule update --init --recursive
       - run:
           name: install dependencies
-          command: make setup
+          command: |
+            make setup
+            sudo apt install libmpfr-dev libsqlite3-dev ninja-build -y
       - run:
           name: run fbinfer
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,30 @@ jobs:
           command: |
             make lint
 
+  static-analysis-infer:
+    docker:
+      - image: redislabsmodules/llvm-toolset:latest
+    steps:
+      - checkout
+      - run:
+          name: Submodule checkout
+          command: git submodule update --init --recursive
+      - run:
+          name: install dependencies
+          command: make setup
+      - run:
+          name: run fbinfer
+          command: |
+            make static-analysis
+
   build:
     docker:
       - image: 'redisfab/rmbuilder:6.0.1-x64-bionic'
     steps:
       - checkout
+      - run:
+          name: Submodule checkout
+          command: git submodule update --init --recursive
       - run:
           name: Build
           command: make -j 8
@@ -124,6 +143,7 @@ workflows:
   build_and_package:
     jobs:
       - lint 
+      - static-analysis-infer
       - build:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - run:
           name: run fbinfer
           command: |
-            make static-analysis
+            CC=clang INFER=infer make static-analysis
 
   build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           name: install dependencies
           command: |
             make setup
-            sudo apt install libmpfr-dev libsqlite3-dev ninja-build -y
+            apt install libmpfr-dev libsqlite3-dev ninja-build -y
       - run:
           name: run fbinfer
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,17 +26,12 @@ jobs:
 
   static-analysis-infer:
     docker:
-      - image: redisfab/rmbuilder:6.0.1-x64-bionic
+      - image: redisbench/infer-linux64:1.0.0
     steps:
       - checkout
       - run:
           name: Submodule checkout
           command: git submodule update --init --recursive
-      - run:
-          name: install dependencies
-          command: |
-            make setup
-            apt install libmpfr-dev libsqlite3-dev ninja-build -y
       - run:
           name: run fbinfer
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ tests/test-perf
 tests/test-cuckoo
 site/
 venv/
+deps/
+infer-out/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "opt/readies"]
+	path = opt/readies
+	url = https://github.com/RedisLabsModules/readies.git

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 CC?=gcc
 INFER?=./deps/infer
+INFER_DOCKER?=redisbench/infer-linux64:1.0.0
+# in the future add --bufferoverrun to infer args
+INFER_ARGS?= --fail-on-issue --biabduction --skip-analysis-in-path ".*rmutil.*"
 
 DEBUGFLAGS = -g -ggdb -O2
 ifeq ($(DEBUG), 1)
@@ -71,10 +74,13 @@ lint:
 setup:
 	./opt/build/get-fbinfer.sh
 
+static-analysis-docker:
+	$(MAKE) clean
+	docker run -v $(ROOT)/:/RedisBloom/ $(INFER_DOCKER) bash -c "cd RedisBloom && CC=clang infer $(INFER_ARGS) run -- make"
+
 static-analysis:
 	$(MAKE) clean
-	$(INFER) --fail-on-issue --bufferoverrun --biabduction --skip-analysis-in-path ".*rmutil.*" run -- $(MAKE)
-	# in the future add --bufferoverrun 
+	$(INFER) $(INFER_ARGS) run -- $(MAKE)
 	
 format:
 	clang-format -style=file -i $(SRCDIR)/*

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC?=gcc
 INFER?=./deps/infer
 INFER_DOCKER?=redisbench/infer-linux64:1.0.0
 # in the future add --bufferoverrun to infer args
-INFER_ARGS?= --fail-on-issue --biabduction --skip-analysis-in-path ".*rmutil.*"
+INFER_ARGS?=--fail-on-issue --biabduction --skip-analysis-in-path ".*rmutil.*"
 
 DEBUGFLAGS = -g -ggdb -O2
 ifeq ($(DEBUG), 1)
@@ -76,11 +76,11 @@ setup:
 
 static-analysis-docker:
 	$(MAKE) clean
-	docker run -v $(ROOT)/:/RedisBloom/ $(INFER_DOCKER) bash -c "cd RedisBloom && CC=clang infer $(INFER_ARGS) run -- make"
+	docker run -v $(ROOT)/:/RedisBloom/ $(INFER_DOCKER) bash -c "cd RedisBloom && CC=clang infer run $(INFER_ARGS) -- make"
 
 static-analysis:
 	$(MAKE) clean
-	$(INFER) $(INFER_ARGS) run -- $(MAKE)
+	$(INFER) run $(INFER_ARGS) -- $(MAKE)
 	
 format:
 	clang-format -style=file -i $(SRCDIR)/*

--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,9 @@ setup:
 
 static-analysis:
 	$(MAKE) clean
-	$(INFER) --fail-on-issue  --skip-analysis-in-path ".*rmutil.*" run -- $(MAKE)
-
+	$(INFER) --fail-on-issue --bufferoverrun --biabduction --skip-analysis-in-path ".*rmutil.*" run -- $(MAKE)
+	# in the future add --bufferoverrun 
+	
 format:
 	clang-format -style=file -i $(SRCDIR)/*
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+CC?=gcc
+INFER?=./deps/infer
+
 DEBUGFLAGS = -g -ggdb -O2
 ifeq ($(DEBUG), 1)
 	DEBUGFLAGS = -g -ggdb -O0 -pedantic
@@ -10,8 +13,7 @@ CPPFLAGS =  -Wall -Wno-unused-function $(DEBUGFLAGS) -fPIC -std=gnu99 -D_GNU_SOU
 
 # Compile flags for linux / osx
 ifeq ($(uname_S),Linux)
-	CC=gcc
-	LD=gcc
+	LD=$(CC)
 	SHOBJ_CFLAGS ?=  -fno-common -g -ggdb
 	SHOBJ_LDFLAGS ?= -shared -Wl,-Bsymbolic,-Bsymbolic-functions
 else
@@ -65,6 +67,13 @@ perf:
 
 lint:
 	clang-format -style=file -Werror -n $(SRCDIR)/*
+
+setup:
+	./opt/build/get-fbinfer.sh
+
+static-analysis:
+	$(MAKE) clean
+	$(INFER) --fail-on-issue  --skip-analysis-in-path ".*rmutil.*" run -- $(MAKE)
 
 format:
 	clang-format -style=file -i $(SRCDIR)/*

--- a/README.md
+++ b/README.md
@@ -57,7 +57,15 @@ In this case, `1` means that the `foo` is most likely in the set represented by 
 A value `0` means that `bar` is definitely not in the set. Bloom filters do not allow for false negatives.
 
 ## Building and Loading RedisBloom
-To use RedisBloom, first build its shared library by running `make`. If the build is successful, you'll have a shared library called `redisbloom.so`.
+
+To build RedisBloom, ensure you have the proper submodules, and afterwards run `make` in the project's directory.
+
+```
+git submodule update --init --recursive
+make
+```
+
+If the build is successful, you'll have a shared library called `redisbloom.so`.
 
 To load the library, pass its path to the `loadmodule` directive when starting `redis-server`:
 ```

--- a/opt/build/get-fbinfer.sh
+++ b/opt/build/get-fbinfer.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+[[ $VERBOSE == 1 ]] && set -x
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+ROOT=$HERE/../..
+ROOT=$(realpath $ROOT)
+OS=$(python3 $ROOT/opt/readies/bin/platform --os)
+
+VERSION=${VERSION:-1.0.0}
+TARGET_DIR=${TARGET_DIR:-"$ROOT/deps"}
+
+mkdir -p ${TARGET_DIR}
+FBINFER_ARCHIVE=infer-${OS}64-v$VERSION.tar.xz
+
+if [ ! -f ${FBINFER_ARCHIVE} ]; then
+    echo "Downloading fbinfer to ${TARGET_DIR}/${FBINFER_ARCHIVE}"
+    wget --quiet --show-progress --progress=bar:force:noscroll --no-check-certificate \
+        https://github.com/facebook/infer/releases/download/v$VERSION/${FBINFER_ARCHIVE}
+fi
+
+tar xvf ${FBINFER_ARCHIVE} -C ${TARGET_DIR}/
+
+if [ ! -f ${TARGET_DIR}/infer ]; then
+    echo "Linking fbinfer ${TARGET_DIR}/infer-${OS}64-v$VERSION/bin/infer to ${TARGET_DIR}/infer"
+    ln -s "${TARGET_DIR}/infer-${OS}64-v$VERSION/bin/infer" ${TARGET_DIR}/infer
+fi
+
+rm -rf ${FBINFER_ARCHIVE}

--- a/rmutil/util.c
+++ b/rmutil/util.c
@@ -53,8 +53,8 @@ RMUtilInfo *RMUtil_GetRedisInfo(RedisModuleCtx *ctx) {
   }
 
   int cap = 100;  // rough estimate of info lines
-  RMUtilInfo *info = malloc(sizeof(RMUtilInfo));
-  info->entries = calloc(cap, sizeof(RMUtilInfoEntry));
+  RMUtilInfo *info = RedisModule_Calloc(1, sizeof(RMUtilInfo));
+  info->entries = RedisModule_Calloc(cap, sizeof(RMUtilInfoEntry));
 
   int i = 0;
   size_t sz;
@@ -70,12 +70,12 @@ RMUtilInfo *RMUtil_GetRedisInfo(RedisModuleCtx *ctx) {
     }
 
     char *key = strsep(&line, ":");
-    info->entries[i].key = strdup(key);
-    info->entries[i].val = strdup(line);
+    info->entries[i].key = RedisModule_Strdup(key);
+    info->entries[i].val = RedisModule_Strdup(line);
     i++;
     if (i >= cap) {
       cap *= 2;
-      info->entries = realloc(info->entries, cap * sizeof(RMUtilInfoEntry));
+      info->entries = RedisModule_Realloc(info->entries, cap * sizeof(RMUtilInfoEntry));
     }
   }
   info->numEntries = i;
@@ -84,11 +84,11 @@ RMUtilInfo *RMUtil_GetRedisInfo(RedisModuleCtx *ctx) {
 }
 void RMUtilRedisInfo_Free(RMUtilInfo *info) {
   for (int i = 0; i < info->numEntries; i++) {
-    free(info->entries[i].key);
-    free(info->entries[i].val);
+    RedisModule_Free(info->entries[i].key);
+    RedisModule_Free(info->entries[i].val);
   }
-  free(info->entries);
-  free(info);
+  RedisModule_Free(info->entries);
+  RedisModule_Free(info);
 }
 
 int RMUtilInfo_GetInt(RMUtilInfo *info, const char *key, long long *val) {

--- a/src/sb.c
+++ b/src/sb.c
@@ -187,7 +187,7 @@ const char *SBChain_GetEncodedChunk(const SBChain *sb, long long *curIter, size_
 
 char *SBChain_GetEncodedHeader(const SBChain *sb, size_t *hdrlen) {
     *hdrlen = sizeof(dumpedChainHeader) + (sizeof(dumpedChainLink) * sb->nfilters);
-    dumpedChainHeader *hdr = malloc(*hdrlen);
+    dumpedChainHeader *hdr = RedisModule_Calloc(1, *hdrlen);
     hdr->size = sb->size;
     hdr->nfilters = sb->nfilters;
     hdr->options = sb->options;
@@ -204,7 +204,7 @@ char *SBChain_GetEncodedHeader(const SBChain *sb, size_t *hdrlen) {
     return (char *)hdr;
 }
 
-void SB_FreeEncodedHeader(char *s) { free(s); }
+void SB_FreeEncodedHeader(char *s) { RedisModule_Free(s); }
 
 SBChain *SB_NewChainFromHeader(const char *buf, size_t bufLen, const char **errmsg) {
     const dumpedChainHeader *header = (const void *)buf;


### PR DESCRIPTION
This PR:
-  enables static code analysis checks both on CI and on dev machines, by adding the `make static-analysis` rule 
- It adds opt/readies as a submodule ( like on other modules ) -- @rafie wanted to double check you see no problem on adding this submodule
- Apart from it, @rafie wanted to double check your opinion on the `make setup` that downloads infer and adds it to deps

PS: wanted to use this project as example for the other modules flow as well
