### PR TITLE
Fix malloc memory report for 6.0.9 and null dereference warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
 
   build:
     docker:
-      - image: 'redisfab/rmbuilder:6.0.1-x64-bionic'
+      - image: 'redisfab/rmbuilder:6.0.9-x64-bionic'
     steps:
       - checkout
       - run:
@@ -56,7 +56,7 @@ jobs:
 
   package_branch:
     docker:
-      - image: 'redisfab/rmbuilder:6.0.1-x64-bionic'
+      - image: 'redisfab/rmbuilder:6.0.9-x64-bionic'
     steps:
       - attach_workspace:
           at: /workspace
@@ -74,7 +74,7 @@ jobs:
           path: /workspace/build
   package_release:
     docker:
-      - image: 'redisfab/rmbuilder:6.0.1-x64-bionic'
+      - image: 'redisfab/rmbuilder:6.0.9-x64-bionic'
     steps:
       - attach_workspace:
           at: /workspace
@@ -98,7 +98,7 @@ jobs:
           path: /workspace/build
   deploy_branch:
     docker:
-      - image: 'redisfab/rmbuilder:6.0.1-x64-bionic'
+      - image: 'redisfab/rmbuilder:6.0.9-x64-bionic'
     steps:
       - attach_workspace:
           at: /workspace
@@ -109,7 +109,7 @@ jobs:
             public-read --recursive --exclude "*" --include "*.zip"
   deploy_release:
     docker:
-      - image: 'redisfab/rmbuilder:6.0.1-x64-bionic'
+      - image: 'redisfab/rmbuilder:6.0.9-x64-bionic'
     steps:
       - attach_workspace:
           at: /workspace

--- a/contrib/bloom.c
+++ b/contrib/bloom.c
@@ -160,8 +160,8 @@ int bloom_init(struct bloom *bloom, uint64_t entries, double error, unsigned opt
         bloom->entries += itemDiff;
     }
 
-    if (bits % 8) {
-        bloom->bytes = (bits / 8) + 1;
+    if (bits % 64) {
+        bloom->bytes = ((bits / 64) + 1) * 8;
     } else {
         bloom->bytes = bits / 8;
     }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: RedisBloom Documentation
+site_name: RedisBloom - Probabilistic Datatypes Module for Redis
 site_url: http://redisbloom.io
 repo_url: https://github.com/RedisBloom/RedisBloom
 repo_name: RedisBloom/RedisBloom

--- a/rmutil/util.c
+++ b/rmutil/util.c
@@ -54,6 +54,7 @@ RMUtilInfo *RMUtil_GetRedisInfo(RedisModuleCtx *ctx) {
 
   int cap = 100;  // rough estimate of info lines
   RMUtilInfo *info = malloc(sizeof(RMUtilInfo));
+  if (!info) return NULL;
   info->entries = calloc(cap, sizeof(RMUtilInfoEntry));
 
   int i = 0;

--- a/src/sb.c
+++ b/src/sb.c
@@ -188,7 +188,8 @@ const char *SBChain_GetEncodedChunk(const SBChain *sb, long long *curIter, size_
 char *SBChain_GetEncodedHeader(const SBChain *sb, size_t *hdrlen) {
     *hdrlen = sizeof(dumpedChainHeader) + (sizeof(dumpedChainLink) * sb->nfilters);
     dumpedChainHeader *hdr = malloc(*hdrlen);
-    if (!hdr) return NULL;
+    if (!hdr)
+        return NULL;
     hdr->size = sb->size;
     hdr->nfilters = sb->nfilters;
     hdr->options = sb->options;

--- a/src/sb.c
+++ b/src/sb.c
@@ -188,6 +188,7 @@ const char *SBChain_GetEncodedChunk(const SBChain *sb, long long *curIter, size_
 char *SBChain_GetEncodedHeader(const SBChain *sb, size_t *hdrlen) {
     *hdrlen = sizeof(dumpedChainHeader) + (sizeof(dumpedChainLink) * sb->nfilters);
     dumpedChainHeader *hdr = malloc(*hdrlen);
+    if (!hdr) return NULL;
     hdr->size = sb->size;
     hdr->nfilters = sb->nfilters;
     hdr->options = sb->options;

--- a/tests/cms.py
+++ b/tests/cms.py
@@ -21,7 +21,7 @@ class CMSTest(ModuleTestCase('../redisbloom.so')):
         self.assertEqual([5L], self.cmd('cms.query', 'cms2', 'a'))
         self.assertEqual(['width', 2000, 'depth', 7, 'count', 5], 
                          self.cmd('cms.info', 'cms2'))
-        self.assertEqual(838, self.cmd('MEMORY USAGE', 'cms1'))
+        self.assertEqual(840, self.cmd('MEMORY USAGE', 'cms1'))
 
     def test_validation(self):
         for args in (

--- a/tests/cuckoo.py
+++ b/tests/cuckoo.py
@@ -67,8 +67,8 @@ class CuckooTestCase(ModuleTestCase('../redisbloom.so')):
         self.restart_and_reload()
         for x in xrange(100):
             self.assertEqual(1, self.cmd('cf.exists', 'smallCF2', str(x)))
-        self.assertEqual(573, self.cmd('MEMORY USAGE', 'smallCF'))
-        self.assertEqual(278, self.cmd('MEMORY USAGE', 'smallCF2'))
+        self.assertEqual(580, self.cmd('MEMORY USAGE', 'smallCF'))
+        self.assertEqual(284, self.cmd('MEMORY USAGE', 'smallCF2'))
 
     def test_setnx(self):
         self.assertEqual(1, self.cmd('cf.addnx', 'cf', 'k1'))
@@ -161,9 +161,9 @@ class CuckooTestCase(ModuleTestCase('../redisbloom.so')):
 
     def test_mem_usage(self):
         self.cmd('CF.RESERVE', 'cf', '1000')
-        self.assertEqual(1108, self.cmd('MEMORY USAGE', 'cf'))
+        self.assertEqual(1112, self.cmd('MEMORY USAGE', 'cf'))
         self.cmd('cf.insert', 'cf', 'nocreate', 'items', 'foo')
-        self.assertEqual(1108, self.cmd('MEMORY USAGE', 'cf'))
+        self.assertEqual(1112, self.cmd('MEMORY USAGE', 'cf'))
 
     def test_max_iterations(self):
         self.cmd('CF.RESERVE a 10 MAXITERATIONS 10')

--- a/tests/pytests.py
+++ b/tests/pytests.py
@@ -196,7 +196,7 @@ class RebloomTestCase(ModuleTestCase('../redisbloom.so')):
 
     def test_mem_usage(self):
         self.assertOk(self.cmd('bf.reserve', 'bf', '0.05', '1000'))
-        self.assertEqual(1084, self.cmd('MEMORY USAGE', 'bf'))
+        self.assertEqual(1088, self.cmd('MEMORY USAGE', 'bf'))
         self.assertEqual([1, 1, 1], self.cmd(
             'bf.madd', 'bf', 'foo', 'bar', 'baz'))
         self.assertEqual(1084, self.cmd('MEMORY USAGE', 'bf'))

--- a/tests/pytests.py
+++ b/tests/pytests.py
@@ -186,12 +186,12 @@ class RebloomTestCase(ModuleTestCase('../redisbloom.so')):
         rep = self.cmd('BF.INSERT', 'missingFilter', 'ERROR',
                        '0.001', 'CAPACITY', '50000', 'EXPANSION', 2, 'ITEMS', 'foo')
         self.assertEqual([1], rep)
-        self.assertEqual(['size:1', 'bytes:98877 bits:791016 hashes:11 hashwidth:64 capacity:50000 size:1 ratio:0.0005'],
+        self.assertEqual(['size:1', 'bytes:98880 bits:791040 hashes:11 hashwidth:64 capacity:50000 size:1 ratio:0.0005'],
                          [x.decode() for x in self.cmd('bf.debug', 'missingFilter')])
 
         rep = self.cmd('BF.INSERT', 'missingFilter', 'ERROR', '0.1', 'ITEMS', 'foo', 'bar', 'baz')
         self.assertEqual([0, 1, 1], rep)
-        self.assertEqual(['size:3', 'bytes:98877 bits:791016 hashes:11 hashwidth:64 capacity:50000 size:3 ratio:0.0005'],
+        self.assertEqual(['size:3', 'bytes:98880 bits:791040 hashes:11 hashwidth:64 capacity:50000 size:3 ratio:0.0005'],
                          [x.decode() for x in self.cmd('bf.debug', 'missingFilter')])
 
     def test_mem_usage(self):
@@ -199,7 +199,7 @@ class RebloomTestCase(ModuleTestCase('../redisbloom.so')):
         self.assertEqual(1088, self.cmd('MEMORY USAGE', 'bf'))
         self.assertEqual([1, 1, 1], self.cmd(
             'bf.madd', 'bf', 'foo', 'bar', 'baz'))
-        self.assertEqual(1084, self.cmd('MEMORY USAGE', 'bf'))
+        self.assertEqual(1088, self.cmd('MEMORY USAGE', 'bf'))
         with self.assertResponseError():
             self.cmd('bf.debug', 'bf', 'noexist')
         with self.assertResponseError():
@@ -234,10 +234,10 @@ class RebloomTestCase(ModuleTestCase('../redisbloom.so')):
         for i in range(100):
             self.cmd('bf.add', 'bf', str(i))
         self.assertEqual(self.cmd('bf.debug', 'bf'), ['size:99',
-                'bytes:14 bits:112 hashes:8 hashwidth:64 capacity:10 size:10 ratio:0.005',
+                'bytes:16 bits:128 hashes:8 hashwidth:64 capacity:10 size:10 ratio:0.005',
                 'bytes:32 bits:256 hashes:9 hashwidth:64 capacity:20 size:20 ratio:0.0025',
-                'bytes:70 bits:560 hashes:10 hashwidth:64 capacity:40 size:40 ratio:0.00125',
-                'bytes:154 bits:1232 hashes:11 hashwidth:64 capacity:80 size:29 ratio:0.000625'])
+                'bytes:72 bits:576 hashes:10 hashwidth:64 capacity:40 size:40 ratio:0.00125',
+                'bytes:160 bits:1280 hashes:11 hashwidth:64 capacity:80 size:29 ratio:0.000625'])
 
         self.cmd('del', 'bf')
         
@@ -245,17 +245,17 @@ class RebloomTestCase(ModuleTestCase('../redisbloom.so')):
         for i in range(4000):
             self.cmd('bf.add', 'bf', str(i))
         self.assertEqual(self.cmd('bf.debug', 'bf'), ['size:3997',
-                'bytes:198 bits:1584 hashes:11 hashwidth:64 capacity:100 size:100 ratio:0.0005',
+                'bytes:200 bits:1600 hashes:11 hashwidth:64 capacity:100 size:100 ratio:0.0005',
                 'bytes:432 bits:3456 hashes:12 hashwidth:64 capacity:200 size:200 ratio:0.00025',
                 'bytes:936 bits:7488 hashes:13 hashwidth:64 capacity:400 size:400 ratio:0.000125',
-                'bytes:2015 bits:16120 hashes:14 hashwidth:64 capacity:800 size:800 ratio:6.25e-05',
-                'bytes:4319 bits:34552 hashes:15 hashwidth:64 capacity:1600 size:1600 ratio:3.125e-05',
-                'bytes:9214 bits:73712 hashes:16 hashwidth:64 capacity:3200 size:897 ratio:1.5625e-05'])
+                'bytes:2016 bits:16128 hashes:14 hashwidth:64 capacity:800 size:800 ratio:6.25e-05',
+                'bytes:4320 bits:34560 hashes:15 hashwidth:64 capacity:1600 size:1600 ratio:3.125e-05',
+                'bytes:9216 bits:73728 hashes:16 hashwidth:64 capacity:3200 size:897 ratio:1.5625e-05'])
 
     def test_info(self):
         self.assertOk(self.cmd('bf.reserve', 'bf', '0.001', '100'))
         self.assertEqual(self.cmd('bf.info bf'), ['Capacity', 100,
-                                                  'Size', 350, 
+                                                  'Size', 352, 
                                                   'Number of filters', 1L, 
                                                   'Number of items inserted', 0L,
                                                   'Expansion rate', 2L])
@@ -304,7 +304,7 @@ class RebloomTestCase(ModuleTestCase('../redisbloom.so')):
         self.assertEqual([0L, 0L, 0L,],resp[:3])
         self.assertEqual('non scaling filter is full',str(resp[3]))
         info_actual = self.cmd('BF.INFO nonscaling_err')
-        info_expected = ['Capacity', 3L, 'Size', 156L, 'Number of filters', 1L,
+        info_expected = ['Capacity', 3L, 'Size', 160L, 'Number of filters', 1L,
          'Number of items inserted', 3L, 'Expansion rate', None]
         self.assertEqual(info_actual, info_expected)
 
@@ -314,7 +314,7 @@ class RebloomTestCase(ModuleTestCase('../redisbloom.so')):
         self.assertOk(self.cmd('bf.reserve bf', error_rate, capacity))
         info = ConvertInfo(self.cmd('bf.info bf'))
         self.assertEqual(info["Capacity"], 300000000)
-        self.assertEqual(info["Size"],    1132420284)
+        self.assertEqual(info["Size"],    1132420288)
 
 if __name__ == "__main__":
     import unittest

--- a/tests/topk.py
+++ b/tests/topk.py
@@ -119,7 +119,7 @@ class TopKTest(ModuleTestCase('../redisbloom.so')):
         self.cmd('topk.reserve', 'test', '3', '50', '5', '0.9')
         self.cmd('topk.add', 'test', 'foo')
         self.assertEqual([None, 'foo', None], self.cmd('topk.list', 'test'))
-        self.assertEqual(4190, self.cmd('MEMORY USAGE', 'test'))
+        self.assertEqual(4192, self.cmd('MEMORY USAGE', 'test'))
 
     def test_time(self):
         self.cmd('topk.reserve', 'topk', '100', '1000', '5', '0.9')


### PR DESCRIPTION
This PR includes fixes for:
- malloc memory report for 6.0.9 ( #249 )
- Potential null Dereference at rmutil/util.c:57, and src/sb.c:191 ( #250 )