### PR TITLE
Fix Cuckoo filter compact cause deleted by mistake

### DIFF
--- a/src/cuckoo.c
+++ b/src/cuckoo.c
@@ -180,8 +180,8 @@ uint64_t CuckooFilter_Count(const CuckooFilter *filter, CuckooHash hash) {
 int CuckooFilter_Delete(CuckooFilter *filter, CuckooHash hash) {
     LookupParams params;
     getLookupParams(hash, &params);
-    for (uint16_t ii = 0; ii < filter->numFilters; ++ii) {
-        if (Filter_Delete(&filter->filters[ii], &params)) {
+    for (uint16_t ii = filter->numFilters; ii > 0; --ii) {
+        if (Filter_Delete(&filter->filters[ii - 1], &params)) {
             filter->numItems--;
             filter->numDeletes++;
             if (filter->numFilters > 1 && filter->numDeletes > (double)filter->numItems * 0.10) {
@@ -339,14 +339,15 @@ static int relocateSlot(CuckooFilter *cf, CuckooBucket bucket, uint16_t filterIx
  * Attempt to strip a single filter moving it down a slot
  */
 static uint64_t CuckooFilter_CompactSingle(CuckooFilter *cf, uint16_t filterIx) {
-    MyCuckooBucket *filter = cf->filters[filterIx].data;
+    SubCF *currentFilter = &cf->filters[filterIx];
+    MyCuckooBucket *filter = currentFilter->data;
     int dirty = 0;
     uint64_t numRelocs = 0;
 
-    for (uint64_t bucketIx = 0; bucketIx < cf->numBuckets; ++bucketIx) {
-        for (uint16_t slotIx = 0; slotIx < cf->bucketSize; ++slotIx) {
-            int status =
-                relocateSlot(cf, &filter[bucketIx * cf->bucketSize], filterIx, bucketIx, slotIx);
+    for (uint64_t bucketIx = 0; bucketIx < currentFilter->numBuckets; ++bucketIx) {
+        for (uint16_t slotIx = 0; slotIx < currentFilter->bucketSize; ++slotIx) {
+            int status = relocateSlot(cf, &filter[bucketIx * currentFilter->bucketSize], filterIx,
+                                      bucketIx, slotIx);
             if (status == RELOC_FAIL) {
                 dirty = 1;
             } else if (status == RELOC_OK) {

--- a/tests/test-cuckoo.c
+++ b/tests/test-cuckoo.c
@@ -177,6 +177,17 @@ TEST_F(cuckoo, testBulkDel) {
     CuckooFilter_Free(&ck);
 }
 
+TEST_F(cuckoo, testBulkDelwithExpansion) {
+    CuckooFilter ck;
+    CuckooFilter_Init(&ck, NUM_BULK / 8, DEFAULT_BUCKETSIZE, 500, 2);
+    doFill(&ck);
+    for (size_t ii = 0; ii < NUM_BULK; ++ii) {
+        ASSERT_EQ(1, CuckooFilter_Delete(&ck, CUCKOO_GEN_HASH(&ii, sizeof ii)));
+    }
+    ASSERT_EQ(0, ck.numItems);
+    CuckooFilter_Free(&ck);
+}
+
 TEST_F(cuckoo, testBucketSize) {
     CuckooFilter ck;
     CuckooFilter_Init(&ck, NUM_BULK / 10, 1, 50, 1);

--- a/tests/test-perf.c
+++ b/tests/test-perf.c
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
     RedisModule_Free = free_wrap;
     RedisModule_Realloc = realloc;
 
-    SBChain *chain = SB_NewChain(NUM_ITEMS, ERROR_RATE, 0);
+    SBChain *chain = SB_NewChain(NUM_ITEMS, ERROR_RATE, 0, 2);
     for (size_t ii = 0; ii < NUM_ITERATIONS; ++ii) {
         size_t elem = ii % NUM_ITEMS;
         SBChain_Add(chain, &elem, sizeof elem);


### PR DESCRIPTION
This PR fixes the issue reported on [#259](https://github.com/RedisBloom/RedisBloom/issues/259).

This is can be reproduced using the test-cuckoo.c file (testBulkDelwithExpansion function) without change. Because the Cuckoo Filter Compact only relocate previous `cf->numBuckets`, but not the total SubCF.

```sh
--- TEST cuckoo.testBulkDelwithExpansion (6/7) ---
Assertion failed at test-cuckoo.c:185
Expected: 1 == CuckooFilter_Delete(&ck, MurmurHash64A_Bloom(&ii, sizeof ii, 0))
        1: U=1 I=1 H=0x1
        CuckooFilter_Delete(&ck, MurmurHash64A_Bloom(&ii, sizeof ii, 0)): U=0 I=0 H=0x0
Aborted (core dumped)
```