### PR TITLE
fix BFAofRewrite() save header`s iter not equal 1 (#258)

### DIFF
--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -1059,7 +1059,7 @@ static void BFAofRewrite(RedisModuleIO *aof, RedisModuleString *key, void *value
     SBChain *sb = value;
     size_t len;
     char *hdr = SBChain_GetEncodedHeader(sb, &len);
-    RedisModule_EmitAOF(aof, "BF.LOADCHUNK", "slb", key, 0, hdr, len);
+    RedisModule_EmitAOF(aof, "BF.LOADCHUNK", "slb", key, 1, hdr, len);
     SB_FreeEncodedHeader(hdr);
 
     long long iter = SB_CHUNKITER_INIT;


### PR DESCRIPTION
when the key not exist, the loadchunk read header will fail, because the iter not equal 1.

(cherry picked from commit 605086fc92f820257e45004440533060be90c23e)