### PR TITLE
Fixed leak: TopKRdbLoad L275 overwrites the heap allocated string causing a small leak on that scenario

### DIFF
--- a/src/rm_topk.c
+++ b/src/rm_topk.c
@@ -272,6 +272,7 @@ static void *TopKRdbLoad(RedisModuleIO *io, int encver) {
     for (uint32_t i = 0; i < topk->k; ++i) {
         topk->heap[i].item = RedisModule_LoadStringBuffer(io, &itemSize);
         if (itemSize == 1) {
+            RedisModule_Free(topk->heap[i].item);
             topk->heap[i].item = NULL;
         }
     }


### PR DESCRIPTION
fixes #277 