### PR TITLE
Corrected CFLAGS settings for OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ else
 		SHOBJ_LDFLAGS ?= -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 	endif
 	CC=clang
-	SHOBJ_CFLAGS ?= -dynamic -fno-common -g -ggdb
+	CFLAGS ?= -dynamic -fcommon -g -ggdb
 	SHOBJ_LDFLAGS += -dylib -exported_symbol _RedisModule_OnLoad
 endif
 


### PR DESCRIPTION
Replaced -fno-common with -fcommon to avoid "duplicate symbol" linker error messages.