### PR TITLE
Update docs with regards to submodules usage

### DIFF
--- a/docs/Quick_Start.md
+++ b/docs/Quick_Start.md
@@ -19,7 +19,7 @@ A pre-compiled version can be downloaded from [RedisLabs download center](https:
 ## Building
 
 ```sh
-git clone https://github.com/RedisBloom/RedisBloom.git
+git clone --recursive https://github.com/RedisBloom/RedisBloom.git
 cd redisbloom
 make
 ```


### PR DESCRIPTION
This PR fixes the docs with regards to submodules usage (readies/t-digest-c)
Further reference:
https://github.com/RedisBloom/RedisBloom/issues/296