### PR TITLE
Using normalized Dockerfile ( with python3 ) and system-setup.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,8 @@ commands:
     steps:
       - run:
           name: Pull Submodules
-          command: git submodule update --init --recursive
+          command: |
+            make fetch
       - run:
           name: Setup automation
           command: |
@@ -39,12 +40,7 @@ commands:
         default: ""
     steps:
       - checkout
-      - run:
-          name: Pull Submodules
-          command: git submodule update --init --recursive
-      - run:
-          name: Install prerequisites
-          command: make setup
+      - setup-automation
       - run:
           name: Install Redis
           command: python3 ./deps/readies/bin/getredis -v 6 <<parameters.getredis_params>>
@@ -65,6 +61,7 @@ jobs:
       - image: redislabsmodules/llvm-toolset:latest
     steps:
       - checkout
+      - setup-automation
       - run:
           name: lint
           command: |
@@ -77,7 +74,8 @@ jobs:
       - checkout
       - run:
           name: Submodule checkout
-          command: git submodule update --init --recursive
+          command: |
+            make fetch
       - run:
           name: run fbinfer
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,35 @@
-FROM redisfab/rmbuilder:6.0.9-x64-bionic as builder
+# BUILD redisfab/redistimeseries:${VERSION}-${ARCH}-${OSNICK}
 
-# Build the source
-ADD . /
-WORKDIR /
-RUN set -ex;\
-    make clean; \
-    make all -j 4; \
-    make test;
+ARG REDIS_VER=6.0.9
 
-# Package the runner
-FROM redisfab/redis:6.0-latest-x64-bionic
+# stretch|bionic|buster
+ARG OSNICK=buster
+
+# ARCH=x64|arm64v8|arm32v7
+ARG ARCH=x64
+
+#----------------------------------------------------------------------------------------------
+FROM redisfab/redis:${REDIS_VER}-${ARCH}-${OSNICK} AS builder
+
+ARG REDIS_VER
+
+ADD ./ /build
+WORKDIR /build
+
+RUN ./deps/readies/bin/getpy3
+RUN ./system-setup.py
+RUN make fetch
+RUN make all
+
+#----------------------------------------------------------------------------------------------
+FROM redisfab/redis:${REDIS_VER}-${ARCH}-${OSNICK}
+
+ARG REDIS_VER
 ENV LIBDIR /usr/lib/redis/modules
 WORKDIR /data
-RUN set -ex;\
-    mkdir -p "$LIBDIR";
-COPY --from=builder /redisbloom.so "$LIBDIR"
+RUN mkdir -p "$LIBDIR"
 
+COPY --from=builder /build/redisbloom.so "$LIBDIR"
+
+EXPOSE 6379
 CMD ["redis-server", "--loadmodule", "/usr/lib/redis/modules/redisbloom.so"]

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,8 @@ $(LIBTDIGEST):
 
 libtdigest: $(LIBTDIGEST)
 
+fetch:
+	-@git submodule update --init --recursive
 
 build: all
 	$(MAKE) -C tests

--- a/system-setup.py
+++ b/system-setup.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import argparse
+
+ROOT = HERE = os.path.abspath(os.path.dirname(__file__))
+READIES = os.path.join(ROOT, "deps/readies")
+sys.path.insert(0, READIES)
+import paella
+
+#----------------------------------------------------------------------------------------------
+
+class RedisTimeSeriesSetup(paella.Setup):
+    def __init__(self, nop=False):
+        paella.Setup.__init__(self, nop)
+
+    def common_first(self):
+        self.pip_install("wheel")
+        self.pip_install("setuptools --upgrade")
+
+        self.install("git jq curl")
+
+    def debian_compat(self):
+        self.run("%s/bin/getgcc" % READIES)
+
+    def redhat_compat(self):
+        self.group_install("'Development Tools'")
+        self.install("redhat-lsb-core")
+        if self.dist == "amzn":
+            self.run("amazon-linux-extras install epel")
+            self.install("python3-devel")
+        elif self.dist == "centos" and self.ver == "8":
+            self.install("epel-release dnf-plugins-core")
+            self.run("yum config-manager --set-enabled powertools")
+        else:
+            self.install("epel-release")
+            self.install("python3-devel libaec-devel")
+
+    def arch_compat(self):
+        pass
+
+    def fedora(self):
+        self.run("%s/bin/getgcc" % READIES)
+        self.install("python3-networkx")
+
+    def common_last(self):
+        if self.dist == "centos" and self.ver == "8":
+            self.install("https://pkgs.dyn.su/el8/base/x86_64/lcov-1.14-3.el8.noarch.rpm")
+        elif self.dist == "arch":
+            self.install("lcov-git", aur=True)
+        else:
+            self.install("lcov")
+        self.run("python3 %s/bin/getrmpytools" % READIES)
+        self.run("python3 {READIES}/bin/getcmake".format(READIES=READIES))
+        self.pip_install("-r tests/flow/requirements.txt")
+
+#----------------------------------------------------------------------------------------------
+
+parser = argparse.ArgumentParser(description='Set up system for build.')
+parser.add_argument('-n', '--nop', action="store_true", help='no operation')
+args = parser.parse_args()
+
+RedisTimeSeriesSetup(nop = args.nop).setup()


### PR DESCRIPTION
Following @chayim pinpoint about docker steps failing due to the current changes not working on python2 env I believe the best approach is to normalize the used dockerfile and system-setup.py so we have the same look and feel across all steps.