### PR TITLE
[bug] fix bf.loadchunk replicate failed

### DIFF
--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -469,6 +469,7 @@ static int BFLoadChunk_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **arg
             return RedisModule_ReplyWithError(ctx, errmsg);
         } else {
             RedisModule_ModuleTypeSetValue(key, BFType, sb);
+            RedisModule_ReplicateVerbatim(ctx);
             return RedisModule_ReplyWithSimpleString(ctx, "OK");
         }
     } else if (status != SB_OK) {


### PR DESCRIPTION
when BFLoadChunk_RedisCommand function is called for the first time, in other words, parmeter iter == 1,  RedisModule_ReplicateVerbatim function was not called after success. Causes the loadchunk command not to replicate to the replica node.