### PR TITLE
Patch TOPK List Duplicate Bug

### DIFF
--- a/src/topk.c
+++ b/src/topk.c
@@ -171,7 +171,6 @@ char *TopK_Add(TopK *topk, const char *item, size_t itemlen, uint32_t increment)
 
     if (maxCount >= heapMin && heapSearched == false) {
         itemHeapPtr = checkExistInHeap(topk, item, itemlen);
-        heapSearched = true;
     }
 
     // update heap

--- a/src/topk.c
+++ b/src/topk.c
@@ -169,7 +169,7 @@ char *TopK_Add(TopK *topk, const char *item, size_t itemlen, uint32_t increment)
         }
     }
 
-    if (*countPtr >= heapMin && heapSearched == false) {
+    if (maxCount >= heapMin && heapSearched == false) {
         itemHeapPtr = checkExistInHeap(topk, item, itemlen);
         heapSearched = true;
     }

--- a/src/topk.c
+++ b/src/topk.c
@@ -169,6 +169,11 @@ char *TopK_Add(TopK *topk, const char *item, size_t itemlen, uint32_t increment)
         }
     }
 
+    if (*countPtr >= heapMin && heapSearched == false) {
+        itemHeapPtr = checkExistInHeap(topk, item, itemlen);
+        heapSearched = true;
+    }
+
     // update heap
     if (itemHeapPtr != NULL) {
         itemHeapPtr->count = maxCount; // Not max of the two, as it might have been decayed

--- a/tests/flow/test_topk.py
+++ b/tests/flow/test_topk.py
@@ -166,3 +166,10 @@ class testTopK():
         info = self.cmd('topk.info', 'topk')
         expected_info = ['k', 3, 'width', 8, 'depth', 7, 'decay', '0.90000000000000002']
         self.assertEqual(expected_info, info)
+
+    def test_list_no_duplicates(self):
+        self.cmd('FLUSHALL')
+        self.cmd('topk.reserve', 'topk', '10', '8', '7', '1')
+        self.cmd('topk.add', 'topk', 'j', 'h', 'd', 'j', 'h', 'h', 'j', 'g', 'e', 'g', 'i', 'f', 'g', 'f', 'a', 'j', 'c', 'i', 'a', 'd')
+        heapList = self.cmd('topk.list', 'topk')
+        self.assertEqual(len(set(heapList)), len(heapList))


### PR DESCRIPTION
I'm working on a project that uses RedisBloom's TOPK commands.  After deploying the project to production traffic for a few weeks, I started noticing that a small fraction of keys contained duplicate values.  I did some fuzz testing and was able to identify reproduction steps for this issue.  For example:

```
127.0.0.1:6379> TOPK.RESERVE topk 10 8 7 0.9
OK
127.0.0.1:6379> TOPK.ADD topk j h d j h h j g e g i f g f a j c i a d
...
127.0.0.1:6379> TOPK.LIST topk
 1) d
 2) d
 3) c
 4) i
 5) e
 6) f
 7) a
 8) j
 9) h
10) g
127.0.0.1:6379>  
``` 
I've included the case above as a regression test in this PR.

It's possible to add an element to the heap without first checking whether that element is already in the heap.  Suppose element A was already in the heap with count 0.  For this to be possible, it must have been added to the heap and then had it's count decayed.  There also must be less than k elements in the heap (otherwise it would have been ejected).  If we add A back to the heap, it will never get into the else if case [here](https://github.com/RedisBloom/RedisBloom/blob/master/src/topk.c#L138) because it is not present in any of the buckets (since it's count is 0).  A new heapitem with value A will be added since it's count of one is sufficient to add it to the heap and the heap was never checked for A.

The solution I'm proposing in this PR is to check if the element is in the heap before adding it.  Since `checkExistsInHeap` is rather expensive, it's only called when the element could be added to the heap (i.e. `maxCount > heapMin`) and the heap has not been checked during this call to `Topk_Add`.
