### PR TITLE
Remove use of implementation detail __compar_fn_t

### DIFF
--- a/src/topk.c
+++ b/src/topk.c
@@ -213,13 +213,15 @@ size_t TopK_Count(TopK *topk, const char *item, size_t itemlen) {
     return res;
 }
 
-int cmpHeapBucket(const HeapBucket *res1, const HeapBucket *res2) {
+int cmpHeapBucket(const void *tmp1, const void *tmp2) {
+    const HeapBucket *res1 = tmp1;
+    const HeapBucket *res2 = tmp2;
     return res1->count < res2->count ? 1 : res1->count > res2->count ? -1 : 0;
 }
 
 HeapBucket *TopK_List(TopK *topk) {
     HeapBucket *heapList = TOPK_CALLOC(topk->k, (sizeof(*heapList)));
     memcpy(heapList, topk->heap, topk->k * sizeof(HeapBucket));
-    qsort(heapList, topk->k, sizeof(*heapList), (__compar_fn_t)cmpHeapBucket);
+    qsort(heapList, topk->k, sizeof(*heapList), cmpHeapBucket);
     return heapList;
 }


### PR DESCRIPTION
`TopK_List` uses `__compar_fn_t` to cast `cmpHeapBucket` to the correct
signature and fails to compile using implementations without the
`__compar_fn_t` `typedef`. This patch makes that cast unnecessary.

Signed-off-by: Ted Lyngmo <ted@lyncon.se>