### PR TITLE
Integrating the new docker build system

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ commands:
       - run:
           name: Setup automation
           command: |
+            ./deps/readies/bin/getpy3
             make setup
 
   ci_steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,6 @@ commands:
       - run:
           name: Setup automation
           command: |
-            ./deps/readies/bin/getpy3
             make setup
 
   ci_steps:
@@ -139,7 +138,10 @@ commands:
       - early-returns
       - setup-executor
       - checkout-all
-      - setup-automation
+      - run:
+          name: Install dependencies
+          command: |
+            ./deps/readies/bin/getpy3
       - run:
           name: Build for platform (docker build)
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ commands:
               circleci step halt
             fi
 
-  early_returns:
+  early-returns:
     steps:
       - run:
           name: Early return if this is a docs build
@@ -75,7 +75,7 @@ commands:
         type: string
         default: ""
     steps:
-      - early_returns
+      - early-returns
       - checkout-all
       - setup-automation
       - run:
@@ -129,6 +129,26 @@ commands:
               --upload_results_s3 \
               --triggering_env circleci \
               --push_results_redistimeseries
+
+  platform-build-steps:
+    parameters:
+      platform:
+        type: string
+    steps:
+      - early-returns
+      - setup-executor
+      - checkout-all
+      - setup-automation
+      - run:
+          name: Build for platform (docker build)
+          command: |
+            make -C build/docker build DOCKER_SUFFIX=".<<parameters.platform>>" OSNICK=<<parameters.platform>> PACK=1 TEST=1 VERBOSE=1
+      - early_return_for_forked_pull_requests
+      - run:
+          name: Build for platform (docker publish)
+          command: |
+            docker login -u redisfab -p $DOCKER_REDISFAB_PWD
+            make -C build/docker build DOCKER_SUFFIX=".<<parameters.platform>>" OSNICK=<<parameters.platform>> PACK=1 TEST=1 VERBOSE=1 PUBLISH=1 DOCKERWRAPPER_EXTRA_VARS="DOCKER_PUSH_ONLY=1"
 
 jobs:
   lint:
@@ -189,6 +209,16 @@ jobs:
             - '*.so'
             - ramp.yml
             - build
+
+  platform_build:
+    parameters:
+      platform:
+        type: string
+    docker:
+      - image: debian:bullseye
+    steps:
+      - platform-build-steps:
+          platform: <<parameters.platform>>
 
   package_branch:
     docker:
@@ -350,52 +380,63 @@ on-integ-and-version-tags: &on-integ-and-version-tags
     tags:
       only: /^v[0-9].*/
 
+context: &context
+  context:
+    - common
+
 #----------------------------------------------------------------------------------------------------------------------------------
 
 workflows:
   version: 2
   build_and_package:
     jobs:
-      - lint:
+#      - lint:
+#          <<: *on-any-branch
+#      - static-analysis-infer:
+#          <<: *on-any-branch
+#      - build:
+#          <<: *on-any-branch
+#          requires:
+#            - lint
+#      - valgrind:
+#          <<: *on-any-branch
+#          requires:
+#            - lint
+#      - performance-automation:
+#          <<: *on-integ-and-version-tags
+#          requires:
+#            - lint
+#          context: common
+#      - package_branch:
+#          <<: *on-integ-branch
+#          requires:
+#            - build
+#      - package_release:
+#          <<: *on-version-tags
+#          requires:
+#            - build
+      - platform_build:
+          <<: *context
+#         <<: *on-integ-and-version-tags
           <<: *on-any-branch
-      - static-analysis-infer:
-          <<: *on-any-branch
-      - build:
-          <<: *on-any-branch
-          requires:
-            - lint
-      - valgrind:
-          <<: *on-any-branch
-          requires:
-            - lint
-      - performance-automation:
-          <<: *on-integ-and-version-tags
-          requires:
-            - lint
-          context: common
-      - package_branch:
-          <<: *on-integ-branch
-          requires:
-            - build
-      - package_release:
-          <<: *on-version-tags
-          requires:
-            - build
-      - deploy_branch:
-          context: common
-          <<: *on-integ-branch
-          requires:
-            - package_branch
-      - deploy_release:
-          context: common
-          <<: *on-version-tags
-          requires:
-            - package_release
-      - release_automation:
-          context: common
-          <<: *on-version-tags
-          requires:
-            - deploy_release
+          matrix:
+            parameters:
+              platform: [bionic]
+#      - deploy_branch:
+#          context: common
+#          <<: *on-integ-branch
+#          requires:
+#            - package_branch
+#      - deploy_release:
+#          context: common
+#          <<: *on-version-tags
+#          requires:
+#            - package_release
+#      - release_automation:
+#          context: common
+#          <<: *on-version-tags
+#          requires:
+#            - deploy_release
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,13 +145,13 @@ commands:
       - run:
           name: Build for platform (docker build)
           command: |
-            make -C build/docker build DOCKER_SUFFIX=".<<parameters.platform>>" OSNICK=<<parameters.platform>> PACK=1 TEST=1 VERBOSE=1
+            make -C build/docker build DOCKER_SUFFIX=".<<parameters.platform>>" OSNICK=<<parameters.platform>> TEST=1 VERBOSE=1
       - early_return_for_forked_pull_requests
       - run:
           name: Build for platform (docker publish)
           command: |
             docker login -u redisfab -p $DOCKER_REDISFAB_PWD
-            make -C build/docker build DOCKER_SUFFIX=".<<parameters.platform>>" OSNICK=<<parameters.platform>> PACK=1 TEST=1 VERBOSE=1 PUBLISH=1 DOCKERWRAPPER_EXTRA_VARS="DOCKER_PUSH_ONLY=1"
+            make -C build/docker build DOCKER_SUFFIX=".<<parameters.platform>>" OSNICK=<<parameters.platform>> TEST=1 VERBOSE=1 PUBLISH=1 DOCKERWRAPPER_EXTRA_VARS="DOCKER_PUSH_ONLY=1"
 
 jobs:
   lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,7 +421,7 @@ workflows:
           <<: *on-any-branch
           matrix:
             parameters:
-              platform: [bionic]
+              platform: [buster]
 #      - deploy_branch:
 #          context: common
 #          <<: *on-integ-branch

--- a/build/docker/Makefile
+++ b/build/docker/Makefile
@@ -1,0 +1,9 @@
+REDIS_VERSION=6.2.5
+PRODUCT=rebloom
+
+OSNICK ?= buster
+OSNICK_OFFICIAL ?= buster
+
+ROOT=../../
+READIES=${ROOT}/deps/readies
+include ${READIES}/mk/docker.rules

--- a/build/docker/dockerfile.tmpl
+++ b/build/docker/dockerfile.tmpl
@@ -1,0 +1,33 @@
+ARG REDIS_VER={{REDIS_VERSION}}
+
+# stretch|bionic|buster
+ARG OSNICK={{REDIS_OSNICK}}
+
+# ARCH=x64|arm64v8|arm32v7
+ARG ARCH=x64
+
+#----------------------------------------------------------------------------------------------
+FROM redisfab/redis:{{REDIS_VERSION}}-{{REDIS_ARCH}}-{{REDIS_OSNICK}} AS builder
+
+ADD ./ /build
+WORKDIR /build
+
+RUN ./deps/readies/bin/getpy3
+RUN ./deps/readies/bin/getupdates
+RUN ./system-setup.py
+
+RUN make fetch
+RUN make all
+
+#----------------------------------------------------------------------------------------------
+FROM redisfab/redis:{{REDIS_VERSION}}-{{REDIS_ARCH}}-{{REDIS_OSNICK}}
+
+ARG REDIS_VER
+ENV LIBDIR /usr/lib/redis/modules
+WORKDIR /data
+RUN mkdir -p "$LIBDIR"
+
+COPY --from=builder /build/redisbloom.so "$LIBDIR"
+
+EXPOSE 6379
+CMD ["redis-server", "--loadmodule", "/usr/lib/redis/modules/redisbloom.so"]


### PR DESCRIPTION
From now on circle builds our dockers, and pushed accordingly. This ensures we generate the docker file, and make use of the new docker build system.  

Note to approver: DO NOT MERGE, just approve. I need to delete the _master_ auto-build from dockerhub once approved.