### PR TITLE
Add NRedisBloom client library to the docs and readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ $ redis-server --loadmodule /path/to/redisbloom.so
 | StackExchange.Redis (extensions) | .NET | MIT | [StackExchange](https://github.com/StackExchange/StackExchange.Redis) | [GitHub](https://gist.github.com/naile/96de4e9548c7b5fd6c0614009ffec755) |
 | redis-modules-sdk | TypeScript | BSD-3-Clause | [Dani Tseitlin](https://github.com/danitseitlin) | [GitHub](https://github.com/danitseitlin/redis-modules-sdk) |
 | redis-modules-java | Java | Apache License 2.0 | [dengliming](https://github.com/dengliming) | [GitHub](https://github.com/dengliming/redis-modules-java) |
+| NRedisBloom | .NET | MIT | [yadazula](https://github.com/yadazula) | [GitHub](https://github.com/yadazula/NRedisBloom) |
 
 ## Documentation
 Documentation and full command reference at [redisbloom.io](http://redisbloom.io).

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ See each driver's README for details and documentation.
 | phpRebloom | PHP | MIT | [Alessandro Balasco](https://github.com/palicao) | [GitHub](https://github.com/palicao/phpRebloom) |
 | redis-modules-sdk | TypeScript | BSD-3-Clause | [Dani Tseitlin](https://github.com/danitseitlin) | [GitHub](https://github.com/danitseitlin/redis-modules-sdk) |
 | redis-modules-java | Java | Apache License 2.0 | [dengliming](https://github.com/dengliming) | [GitHub](https://github.com/dengliming/redis-modules-java) |
+| NRedisBloom | .NET | MIT | [yadazula](https://github.com/yadazula) | [GitHub](https://github.com/yadazula/NRedisBloom) |
 
 ## References
 ### Webinars


### PR DESCRIPTION
Hi,

I noticed that there was no .NET client exist and I built a project for that one: https://github.com/yadazula/NRedisBloom

I updated relevant documentation for the client libraries section. Hope it will be useful for others.

BTW, I guess a new data structure T-Digest will be introduced with the new version. I'm going to add support for it as well.