### PR TITLE
[BUG] Free only latest filter to avoid double free

### DIFF
--- a/src/cuckoo.h
+++ b/src/cuckoo.h
@@ -1,6 +1,7 @@
 #ifndef CUCKOO_H
 #define CUCKOO_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include "murmurhash2.h"
@@ -63,6 +64,6 @@ CuckooInsertStatus CuckooFilter_Insert(CuckooFilter *filter, CuckooHash hash);
 int CuckooFilter_Delete(CuckooFilter *filter, CuckooHash hash);
 int CuckooFilter_Check(const CuckooFilter *filter, CuckooHash hash);
 uint64_t CuckooFilter_Count(const CuckooFilter *filter, CuckooHash);
-void CuckooFilter_Compact(CuckooFilter *filter);
+void CuckooFilter_Compact(CuckooFilter *filter, bool cont);
 void CuckooFilter_GetInfo(const CuckooFilter *cf, CuckooHash hash, CuckooKey *out);
 #endif

--- a/src/cuckoo.h
+++ b/src/cuckoo.h
@@ -63,6 +63,6 @@ CuckooInsertStatus CuckooFilter_Insert(CuckooFilter *filter, CuckooHash hash);
 int CuckooFilter_Delete(CuckooFilter *filter, CuckooHash hash);
 int CuckooFilter_Check(const CuckooFilter *filter, CuckooHash hash);
 uint64_t CuckooFilter_Count(const CuckooFilter *filter, CuckooHash);
-uint64_t CuckooFilter_Compact(CuckooFilter *filter);
+void CuckooFilter_Compact(CuckooFilter *filter);
 void CuckooFilter_GetInfo(const CuckooFilter *cf, CuckooHash hash, CuckooKey *out);
 #endif

--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -766,7 +766,7 @@ static int CFCompact_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     if (status != SB_OK) {
         return RedisModule_ReplyWithError(ctx, "Cuckoo filter was not found");
     }
-    CuckooFilter_Compact(cf);
+    CuckooFilter_Compact(cf, true);
     RedisModule_ReplicateVerbatim(ctx);
     return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }


### PR DESCRIPTION
In addition, if `CuckooFilter_Compact` is called during `CF.DEL` call and the latest filter cannot be freed, break to shorten the time of execution. If `CuckooFilter_Compact` is called using `CF.COMPACT`, continue to enhance compaction on lower filters.
Replaces #368 