### PR TITLE
[BUG] Fix CF.SCANDUMP for cuckoo filter

### DIFF
--- a/src/cf.c
+++ b/src/cf.c
@@ -34,51 +34,66 @@ static uint8_t *getBucketPos(const CuckooFilter *cf, long long pos, size_t *offs
 
 const char *CF_GetEncodedChunk(const CuckooFilter *cf, long long *pos, size_t *buflen,
                                size_t bytelimit) {
-    size_t offset;
-    uint8_t *bucket = getBucketPos(cf, *pos, &offset);
-    if (!bucket) {
+    // First find filter
+    long long offset = *pos - 1;
+    long long currentSize;
+    int filterIx = 0;
+    SubCF *filter;
+    for (; filterIx < cf->numFilters; ++filterIx) {
+        filter = cf->filters + filterIx;
+        currentSize = filter->bucketSize * filter->numBuckets;
+        if (offset < currentSize) {
+            break;
+        }
+        offset -= currentSize;
+    }
+
+    // all filters already returned
+    if (filterIx == cf->numFilters) {
         return NULL;
     }
-    size_t chunksz = cf->numBuckets - offset;
-    size_t max_buckets = (bytelimit / cf->bucketSize);
-    if (chunksz > max_buckets) {
-        chunksz = max_buckets;
+
+    if (currentSize <= bytelimit) {
+        // filter size is smaller than the limit. Add it all
+        *buflen = currentSize;
+        *pos += currentSize;
+        return (const char *)filter->data;
+    } else {
+        size_t remaining = currentSize - offset;
+        if (remaining > bytelimit) {
+            // return another piece from the filter
+            *buflen = bytelimit;
+            *pos += bytelimit;
+        } else {
+            // return the rest of the filter
+            *buflen = remaining;
+            *pos += remaining;
+        }
+        return (const char *)filter->data + offset;
     }
-    *pos += chunksz;
-    *buflen = chunksz * cf->bucketSize;
-    return (const char *)bucket;
 }
 
 int CF_LoadEncodedChunk(const CuckooFilter *cf, long long pos, const char *data, size_t datalen) {
-    if (datalen == 0 || datalen % cf->bucketSize != 0) {
-        // printf("problem with datalen!\n");
+    if (datalen == 0) {
         return REDISMODULE_ERR;
     }
 
-    size_t nbuckets = datalen / cf->bucketSize;
-    if (nbuckets > pos) {
-        // printf("nbuckets>pos. pos=%lu. nbuckets=%lu\n", nbuckets, pos);
-        return REDISMODULE_ERR;
+    // calculate offset
+    long long offset = pos - datalen - 1;
+    long long currentSize;
+    int filterIx = 0;
+    SubCF *filter;
+    for (; filterIx < cf->numFilters; ++filterIx) {
+        filter = cf->filters + filterIx;
+        currentSize = filter->bucketSize * filter->numBuckets;
+        if (offset < currentSize) {
+            break;
+        }
+        offset -= currentSize;
     }
 
-    pos -= nbuckets;
-
-    size_t offset;
-    uint8_t *bucketpos = getBucketPos(cf, pos, &offset);
-    if (bucketpos == NULL) {
-        // printf("bucketpos=NULL\n");
-        return REDISMODULE_ERR;
-    }
-
-    // printf("OFFSET: %lu\n", offset);
-
-    if (offset + nbuckets > cf->numBuckets) {
-        // printf("offset+nbuckets > cf->numBuckets. offset=%lu, nbuckets=%lu, numBuckets=%lu\n",
-        //        offset, nbuckets, cf->numBuckets);
-        return REDISMODULE_ERR;
-    }
-
-    memcpy(bucketpos, data, datalen);
+    // copy data to filter
+    memcpy(filter->data + offset, data, datalen);
     return REDISMODULE_OK;
 }
 

--- a/src/cf.c
+++ b/src/cf.c
@@ -36,7 +36,7 @@ const char *CF_GetEncodedChunk(const CuckooFilter *cf, long long *pos, size_t *b
                                size_t bytelimit) {
     // First find filter
     long long offset = *pos - 1;
-    long long currentSize;
+    long long currentSize = 0;
     int filterIx = 0;
     SubCF *filter;
     for (; filterIx < cf->numFilters; ++filterIx) {

--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -806,7 +806,7 @@ static int CFScanDump_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
         return REDISMODULE_OK;
     }
 
-    size_t chunkLen;
+    size_t chunkLen = 0;
     const char *chunk = CF_GetEncodedChunk(cf, &pos, &chunkLen, MAX_SCANDUMP_SIZE);
     if (chunk == NULL) {
         RedisModule_ReplyWithLongLong(ctx, 0);

--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -401,7 +401,7 @@ static int BFDebug_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, i
     return REDISMODULE_OK;
 }
 
-#define MAX_SCANDUMP_SIZE 535822336 // 511MB
+#define MAX_SCANDUMP_SIZE (1024 * 1024 * 16)
 
 /**
  * BF.SCANDUMP <KEY> <ITER>

--- a/tests/flow/test_cuckoo.py
+++ b/tests/flow/test_cuckoo.py
@@ -97,41 +97,6 @@ class testCuckoo():
         self.assertEqual(1, self.cmd('cf.add', 'cf', 'k1'))
         self.assertEqual(2, self.cmd('cf.count', 'cf', 'k1'))
 
-    def test_scandump(self):
-        self.cmd('FLUSHALL')
-        maxrange = 500
-        self.cmd('cf.reserve', 'cf', int(maxrange / 4))
-        self.cmd('cf.scandump', 'cf', '0')
-        for x in xrange(maxrange):
-            self.cmd('cf.add', 'cf', str(x))
-        for x in xrange(maxrange):
-            self.assertEqual(1, self.cmd('cf.exists', 'cf', str(x)))
-
-        # Start with scandump
-        self.assertRaises(ResponseError, self.cmd, 'cf.scandump', 'cf')
-        self.assertRaises(ResponseError, self.cmd, 'cf.scandump', 'cf', 'str')
-        self.assertRaises(ResponseError, self.cmd, 'cf.scandump', 'noexist', '0')
-        # TODO: re-enable this portion after RLTest migration
-        # chunks = []
-        # while True:
-        #     last_pos = chunks[-1][0] if chunks else 0
-        #     chunk = self.cmd('cf.scandump', 'cf', last_pos)
-        #     if not chunk[0]:
-        #         break
-        #     chunks.append(chunk)
-        #     # print("Scaning chunk... (P={}. Len={})".format(chunk[0], len(chunk[1])))
-
-        # self.cmd('del', 'cf')
-        # self.assertRaises(ResponseError, self.cmd, 'cf.loadchunk', 'cf')
-        # self.assertRaises(ResponseError, self.cmd, 'cf.loadchunk', 'cf', 'str')
-        # for chunk in chunks:
-        #     print("Loading chunk... (P={}. Len={})".format(chunk[0], len(chunk[1])))
-        #     self.cmd('cf.loadchunk', 'cf', *chunk)
-
-        # for x in xrange(maxrange):
-        #     self.assertEqual(1, self.cmd('cf.exists', 'cf', str(x)))
-        # self.env = Env(decodeResponses=True)
-
     def test_insert(self):
         self.cmd('FLUSHALL')
         # Ensure insert with default capacity works
@@ -238,6 +203,30 @@ class testCuckoo():
         self.assertRaises(ResponseError, self.cmd, 'CF.COMPACT a b')
         self.env = Env(decodeResponses=True)
 
+
+    def test_compact(self):
+        self.env = Env()
+        self.cmd('FLUSHALL')
+        q = 100
+        self.cmd('CF.RESERVE cf 8 MAXITERATIONS 50')
+
+        for x in xrange(q):
+            self.cmd('cf.add cf', str(x))
+
+        for x in xrange(q):
+            self.assertEqual(1, self.cmd('cf.exists cf', str(x)))
+
+        str1 = self.cmd('cf.debug cf')[49:52]
+        self.assertGreaterEqual(str1, "130")  # In experiments was larger than 130
+        self.assertEqual(self.cmd('cf.compact cf'), 'OK')
+        str2 = self.cmd('cf.debug cf')[49:52]
+        self.assertGreaterEqual(str1, str2)  # Expect to see reduction after compaction
+
+        self.assertRaises(ResponseError, self.cmd, 'CF.COMPACT a')
+        self.assertRaises(ResponseError, self.cmd, 'CF.COMPACT a b')
+        self.env = Env(decodeResponses=True)
+
+
     def test_max_expansions(self):
         self.cmd('FLUSHALL')
         self.cmd('CF.RESERVE', 'cf', '4')
@@ -310,3 +299,113 @@ class testCuckoo():
             self.cmd('cf.info', 'bf')
         with self.assertResponseError():
             self.cmd('cf.info')
+
+
+class testCuckooNoCodec():
+    def __init__(self):
+        self.env = Env(decodeResponses=False)
+        self.assertOk = self.env.assertTrue
+        self.cmd = self.env.cmd
+        self.assertEqual = self.env.assertEqual
+        self.assertRaises = self.env.assertRaises
+        self.assertTrue = self.env.assertTrue
+        self.assertAlmostEqual = self.env.assertAlmostEqual
+        self.assertGreater = self.env.assertGreater
+        self.restart_and_reload = self.env.restartAndReload
+        self.assertResponseError = self.env.assertResponseError
+        self.retry_with_rdb_reload = self.env.dumpAndReload
+        self.assertNotEqual = self.env.assertNotEqual
+        self.assertGreaterEqual = self.env.assertGreaterEqual
+
+    def test_scandump(self):
+        self.cmd('FLUSHALL')
+        maxrange = 500
+        self.cmd('cf.reserve', 'cf', int(maxrange / 8))
+        self.assertEqual([0, None], self.cmd('cf.scandump', 'cf', '0'))
+        for x in xrange(maxrange):
+            self.cmd('cf.add', 'cf', str(x))
+        for x in xrange(maxrange):
+            self.assertEqual(1, self.cmd('cf.exists', 'cf', str(x)))
+        # Start with scandump
+        self.assertRaises(ResponseError, self.cmd, 'cf.scandump', 'cf')
+        self.assertRaises(ResponseError, self.cmd, 'cf.scandump', 'cf', 'str')
+        self.assertRaises(ResponseError, self.cmd, 'cf.scandump', 'noexist', '0')
+        chunks = []
+        while True:
+            last_pos = chunks[-1][0] if chunks else 0
+            chunk = self.cmd('cf.scandump', 'cf', last_pos)
+            if not chunk[0]:
+                break
+            chunks.append(chunk)
+            # print("Scaning chunk... (P={}. Len={})".format(chunk[0], len(chunk[1])))
+        self.cmd('del', 'cf')
+        self.assertRaises(ResponseError, self.cmd, 'cf.loadchunk', 'cf')
+        self.assertRaises(ResponseError, self.cmd, 'cf.loadchunk', 'cf', 'str')
+        for chunk in chunks:
+            print("Loading chunk... (P={}. Len={})".format(chunk[0], len(chunk[1])))
+            self.cmd('cf.loadchunk', 'cf', *chunk)
+        for x in xrange(maxrange):
+            self.assertEqual(1, self.cmd('cf.exists', 'cf', str(x)))
+
+    def test_scandump_with_expansion(self):
+        self.cmd('FLUSHALL')
+        maxrange = 500
+    
+        self.cmd('cf.reserve', 'cf', int(maxrange / 8), 'expansion', '2')
+        self.assertEqual([0, None], self.cmd('cf.scandump', 'cf', '0'))
+        for x in xrange(maxrange):
+            self.cmd('cf.add', 'cf', str(x))
+        for x in xrange(maxrange):
+            self.assertEqual(1, self.cmd('cf.exists', 'cf', str(x)))
+
+        chunks = []
+        while True:
+            i = 0
+            last_pos = chunks[-1][0] if chunks else 0
+            chunk = self.cmd('cf.scandump', 'cf', last_pos)
+            if not chunk[0]:
+                break
+            chunks.append(chunk)
+            print("Scaning chunk... (P={}. Len={})".format(chunk[0], len(chunk[1])))
+        # delete filter
+        self.cmd('del', 'cf')
+
+        self.assertRaises(ResponseError, self.cmd, 'cf.loadchunk', 'cf')
+        self.assertRaises(ResponseError, self.cmd, 'cf.loadchunk', 'cf', 'str')
+        for chunk in chunks:
+            print("Loading chunk... (P={}. Len={})".format(chunk[0], len(chunk[1])))
+            self.cmd('cf.loadchunk', 'cf', *chunk)
+        # check loaded filter
+        for x in xrange(maxrange):
+            self.assertEqual(1, self.cmd('cf.exists', 'cf', str(x)))
+    
+    def test_scandump_huge(self):
+        self.cmd('FLUSHALL')
+    
+        self.cmd('cf.reserve', 'cf', 1024 * 1024 * 1024)
+        self.assertEqual([0, None], self.cmd('cf.scandump', 'cf', '0'))
+        for x in xrange(6):
+            self.cmd('cf.add', 'cf', 'foo')
+        for x in xrange(6):
+            self.assertEqual(1, self.cmd('cf.exists', 'cf', 'foo'))
+
+        chunks = []
+        while True:
+            i = 0
+            last_pos = chunks[-1][0] if chunks else 0
+            chunk = self.cmd('cf.scandump', 'cf', last_pos)
+            if not chunk[0]:
+                break
+            chunks.append(chunk)
+            print("Scaning chunk... (P={}. Len={})".format(chunk[0], len(chunk[1])))
+        # delete filter
+        self.cmd('del', 'cf')
+
+        self.assertRaises(ResponseError, self.cmd, 'cf.loadchunk', 'cf')
+        self.assertRaises(ResponseError, self.cmd, 'cf.loadchunk', 'cf', 'str')
+        for chunk in chunks:
+            print("Loading chunk... (P={}. Len={})".format(chunk[0], len(chunk[1])))
+            self.cmd('cf.loadchunk', 'cf', *chunk)
+        # check loaded filter
+        for x in xrange(6):
+            self.assertEqual(1, self.cmd('cf.exists', 'cf', 'foo'))

--- a/tests/flow/test_cuckoo.py
+++ b/tests/flow/test_cuckoo.py
@@ -382,7 +382,7 @@ class testCuckooNoCodec():
     def test_scandump_huge(self):
         self.cmd('FLUSHALL')
     
-        self.cmd('cf.reserve', 'cf', 1024 * 1024 * 1024)
+        self.cmd('cf.reserve', 'cf', 1024 * 1024 * 64)
         self.assertEqual([0, None], self.cmd('cf.scandump', 'cf', '0'))
         for x in xrange(6):
             self.cmd('cf.add', 'cf', 'foo')

--- a/tests/flow/test_overall.py
+++ b/tests/flow/test_overall.py
@@ -440,7 +440,7 @@ class testRedisBloomNoCodec():
     def test_scandump_huge(self):
         self.cmd('FLUSHALL')
     
-        self.cmd('bf.reserve', 'bf', 0.01, 1024 * 1024 * 1024)
+        self.cmd('bf.reserve', 'bf', 0.01, 1024 * 1024 * 64)
         for x in xrange(6):
             self.cmd('bf.add', 'bf', 'foo')
         for x in xrange(6):

--- a/tests/flow/test_overall.py
+++ b/tests/flow/test_overall.py
@@ -357,3 +357,112 @@ class testRedisBloom():
         info = ConvertInfo(self.cmd('bf.info bf'))
         self.assertEqual(info["Capacity"], 300000000)
         self.assertEqual(info["Size"], 1132420288)
+
+class testRedisBloomNoCodec():
+    def __init__(self):
+        self.env = Env(decodeResponses=False)
+        self.assertOk = self.env.assertTrue
+        self.cmd = self.env.cmd
+        self.assertEqual = self.env.assertEqual
+        self.assertRaises = self.env.assertRaises
+        self.assertTrue = self.env.assertTrue
+        self.assertAlmostEqual = self.env.assertAlmostEqual
+        self.assertGreater = self.env.assertGreater
+        self.restart_and_reload = self.env.restartAndReload
+        self.assertResponseError = self.env.assertResponseError
+        self.retry_with_rdb_reload = self.env.dumpAndReload
+        self.assertNotEqual = self.env.assertNotEqual
+        self.assertGreaterEqual = self.env.assertGreaterEqual
+        self.assertLessEqual = self.env.assertLessEqual
+        self.assertLess = self.env.assertLess
+
+
+    def test_scandump(self):
+        self.cmd('FLUSHALL')
+        maxrange = 500
+        self.cmd('bf.reserve', 'bf', 0.01, int(maxrange / 8))
+        for x in xrange(maxrange):
+            self.cmd('bf.add', 'bf', str(x))
+        for x in xrange(maxrange):
+            self.assertEqual(1, self.cmd('bf.exists', 'bf', str(x)))
+        # Start with scandump
+        self.assertRaises(ResponseError, self.cmd, 'bf.scandump', 'bf')
+        self.assertRaises(ResponseError, self.cmd, 'bf.scandump', 'bf', 'str')
+        self.assertRaises(ResponseError, self.cmd, 'bf.scandump', 'noexist', '0')
+        chunks = []
+        while True:
+            last_pos = chunks[-1][0] if chunks else 0
+            chunk = self.cmd('bf.scandump', 'bf', last_pos)
+            if not chunk[0]:
+                break
+            chunks.append(chunk)
+            # print("Scaning chunk... (P={}. Len={})".format(chunk[0], len(chunk[1])))
+        self.cmd('del', 'bf')
+        self.assertRaises(ResponseError, self.cmd, 'bf.loadchunk', 'bf')
+        self.assertRaises(ResponseError, self.cmd, 'bf.loadchunk', 'bf', 'str')
+        for chunk in chunks:
+            print("Loading chunk... (P={}. Len={})".format(chunk[0], len(chunk[1])))
+            self.cmd('bf.loadchunk', 'bf', *chunk)
+        for x in xrange(maxrange):
+            self.assertEqual(1, self.cmd('bf.exists', 'bf', str(x)))
+
+    def test_scandump_with_expansion(self):
+        self.cmd('FLUSHALL')
+        maxrange = 500
+    
+        self.cmd('bf.reserve', 'bf', 0.01, int(maxrange / 8), 'expansion', '2')
+        for x in xrange(maxrange):
+            self.cmd('bf.add', 'bf', str(x))
+        for x in xrange(maxrange):
+            self.assertEqual(1, self.cmd('bf.exists', 'bf', str(x)))
+
+        chunks = []
+        while True:
+            i = 0
+            last_pos = chunks[-1][0] if chunks else 0
+            chunk = self.cmd('bf.scandump', 'bf', last_pos)
+            if not chunk[0]:
+                break
+            chunks.append(chunk)
+            print("Scaning chunk... (P={}. Len={})".format(chunk[0], len(chunk[1])))
+        # delete filter
+        self.cmd('del', 'bf')
+
+        self.assertRaises(ResponseError, self.cmd, 'bf.loadchunk', 'bf')
+        self.assertRaises(ResponseError, self.cmd, 'bf.loadchunk', 'bf', 'str')
+        for chunk in chunks:
+            print("Loading chunk... (P={}. Len={})".format(chunk[0], len(chunk[1])))
+            self.cmd('bf.loadchunk', 'bf', *chunk)
+        # check loaded filter
+        for x in xrange(maxrange):
+            self.assertEqual(1, self.cmd('bf.exists', 'bf', str(x)))
+    
+    def test_scandump_huge(self):
+        self.cmd('FLUSHALL')
+    
+        self.cmd('bf.reserve', 'bf', 0.01, 1024 * 1024 * 1024)
+        for x in xrange(6):
+            self.cmd('bf.add', 'bf', 'foo')
+        for x in xrange(6):
+            self.assertEqual(1, self.cmd('bf.exists', 'bf', 'foo'))
+
+        chunks = []
+        while True:
+            i = 0
+            last_pos = chunks[-1][0] if chunks else 0
+            chunk = self.cmd('bf.scandump', 'bf', last_pos)
+            if not chunk[0]:
+                break
+            chunks.append(chunk)
+            print("Scaning chunk... (P={}. Len={})".format(chunk[0], len(chunk[1])))
+        # delete filter
+        self.cmd('del', 'bf')
+
+        self.assertRaises(ResponseError, self.cmd, 'bf.loadchunk', 'bf')
+        self.assertRaises(ResponseError, self.cmd, 'bf.loadchunk', 'bf', 'str')
+        for chunk in chunks:
+            print("Loading chunk... (P={}. Len={})".format(chunk[0], len(chunk[1])))
+            self.cmd('bf.loadchunk', 'bf', *chunk)
+        # check loaded filter
+        for x in xrange(6):
+            self.assertEqual(1, self.cmd('bf.exists', 'bf', 'foo'))


### PR DESCRIPTION
Fixes #139 

Q: WDYT about `MAX_SCANDUMP_SIZE` optimal size? It must be under 512MB, but the max size causes the server to freeze while the large binary representation is being returned? 