### PR TITLE
Fixed error in `BF.INFO` description

### DIFF
--- a/docs/Bloom_Commands.md
+++ b/docs/Bloom_Commands.md
@@ -362,7 +362,7 @@ Return information about `key`
 
 ### Parameters
 
-* **key**: Name of the key to restore
+* **key**: Name of the key to return information about
 
 ### Complexity O
 


### PR DESCRIPTION
It said `key` was the name of the key to "restore".  Changed to name of the key to "return information about".