### PR TITLE
SB_NewChainFromHeader init growth always equal 0

### DIFF
--- a/src/sb.c
+++ b/src/sb.c
@@ -224,7 +224,7 @@ SBChain *SB_NewChainFromHeader(const char *buf, size_t bufLen, const char **errm
     sb->nfilters = header->nfilters;
     sb->options = header->options;
     sb->size = header->size;
-    sb->growth = sb->growth;
+    sb->growth = header->growth;
 
     for (size_t ii = 0; ii < header->nfilters; ++ii) {
         SBLink *dstlink = sb->filters + ii;


### PR DESCRIPTION
1. This may cause redis-server core when the bloom expand.
2. Or use redis comamnd dump, restore it use bf.info command the expansion is 0.