### PR TITLE
SB_NewChainFromHeader init growth always equal 0 (#392)

### DIFF
--- a/src/sb.c
+++ b/src/sb.c
@@ -223,7 +223,7 @@ SBChain *SB_NewChainFromHeader(const char *buf, size_t bufLen, const char **errm
     sb->nfilters = header->nfilters;
     sb->options = header->options;
     sb->size = header->size;
-    sb->growth = sb->growth;
+    sb->growth = header->growth;
 
     for (size_t ii = 0; ii < header->nfilters; ++ii) {
         SBLink *dstlink = sb->filters + ii;

--- a/tests/test-basic.c
+++ b/tests/test-basic.c
@@ -219,6 +219,10 @@ TEST_F(encoding, testEncodingSimple) {
     const char *errmsg;
     SBChain *chain2 = SB_NewChainFromHeader(hdr, len, &errmsg);
     ASSERT_NE(NULL, chain2);
+    ASSERT_EQ(chain->size, chain2->size);
+    ASSERT_EQ(chain->growth, chain2->growth);
+    ASSERT_EQ(chain->options, chain2->options);
+    ASSERT_EQ(chain->nfilters, chain2->nfilters);
 
     for (size_t ii = 0; ii < numEncs; ++ii) {
         ASSERT_EQ(0, SBChain_LoadEncodedChunk(chain2, encs[ii].iter, encs[ii].buf, encs[ii].nbuf,


### PR DESCRIPTION
This may due to redis-server core when the bloom expand.

(cherry picked from commit dc77e75645a9de860f9d79c7d6a6d6779669240f)