### PR TITLE
MOD-2082 Add intershard_tls_pass support

### DIFF
--- a/ramp.yml
+++ b/ramp.yml
@@ -21,3 +21,4 @@ capabilities:
     - clustering
     - flash
     - intershard_tls
+    - intershard_tls_pass


### PR DESCRIPTION
RedisBloom support intershard_tls_pass by default since it doesn't have cross shards communication