### PR TITLE
[BUG] Fix crash and prevent warnings

### DIFF
--- a/src/cf.c
+++ b/src/cf.c
@@ -114,7 +114,6 @@ CuckooFilter *CFHeader_Load(const CFHeader *header) {
         cur->data =
             RedisModule_Calloc((size_t)cur->numBuckets * filter->bucketSize, sizeof(CuckooBucket));
     }
-    RedisModule_Free(header->filtersNumBucket);
     return filter;
 }
 

--- a/src/cf.c
+++ b/src/cf.c
@@ -82,7 +82,7 @@ int CF_LoadEncodedChunk(const CuckooFilter *cf, long long pos, const char *data,
     long long offset = pos - datalen - 1;
     long long currentSize;
     int filterIx = 0;
-    SubCF *filter;
+    SubCF *filter = NULL;
     for (; filterIx < cf->numFilters; ++filterIx) {
         filter = cf->filters + filterIx;
         currentSize = filter->bucketSize * filter->numBuckets;
@@ -110,7 +110,7 @@ CuckooFilter *CFHeader_Load(const CFHeader *header) {
     for (size_t ii = 0; ii < filter->numFilters; ++ii) {
         SubCF *cur = filter->filters + ii;
         cur->bucketSize = header->bucketSize;
-        cur->numBuckets = header->filtersNumBucket[ii];
+        cur->numBuckets = filter->numBuckets * pow(filter->expansion, ii);
         cur->data =
             RedisModule_Calloc((size_t)cur->numBuckets * filter->bucketSize, sizeof(CuckooBucket));
     }
@@ -126,9 +126,4 @@ void fillCFHeader(CFHeader *header, const CuckooFilter *cf) {
                          .bucketSize = cf->bucketSize,
                          .maxIterations = cf->maxIterations,
                          .expansion = cf->expansion};
-    header->filtersNumBucket =
-        RedisModule_Calloc(cf->numFilters, sizeof(*header->filtersNumBucket));
-    for (size_t ii = 0; ii < header->numFilters; ++ii) {
-        header->filtersNumBucket[ii] = cf->filters[ii].numBuckets;
-    }
 }

--- a/src/cf.h
+++ b/src/cf.h
@@ -14,7 +14,6 @@ typedef struct __attribute__((packed)) {
     uint16_t bucketSize;
     uint16_t maxIterations;
     uint16_t expansion;
-    uint32_t *filtersNumBucket;
 } CFHeader;
 
 CuckooFilter *CFHeader_Load(const CFHeader *header);

--- a/tests/flow/test_topk.py
+++ b/tests/flow/test_topk.py
@@ -58,7 +58,7 @@ class testTopK():
     def test_add_query_count(self):
         self.cmd('FLUSHALL')
         self.assertTrue(self.cmd('topk.reserve', 'topk', '20', '50', '5', '0.9'))
-        self.env.dumpAndReload()
+        self.env.dumpAndReload(restart=True) # prevent error `Background save already in progress`
 
         self.cmd('topk.add', 'topk', 'bar', 'baz', '42')
         self.assertEqual([1], self.cmd('topk.query', 'topk', 'bar'))


### PR DESCRIPTION
The bug was using an additional allocation (`header->filtersNumBucket`) in `CFHeader` but passing only `sizeof(CFHeader)`.
The fix calculates on the fly the size of all subfilters instead of getting them from the existing filters.

