### PR TITLE
Fixed artifact build on perf automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,7 @@ jobs:
       - setup-automation
       - run:
           name: build artifact
-          command: make build
+          command: make `pwd`/redisbloom.so
       - benchmark-steps
 
 #----------------------------------------------------------------------------------------------------------------------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,7 +349,7 @@ on-integ-and-version-tags: &on-integ-and-version-tags
         - master
         - /^\d+\.\d+.*$/
         - /^feature-.*$/
-        - /^perf-.*$/
+        - /^perf.*$/
     tags:
       only: /^v[0-9].*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,7 @@ jobs:
       - setup-automation
       - run:
           name: build artifact
-          command: make `pwd`/redisbloom.so
+          command: make build
       - benchmark-steps
 
 #----------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses the perf automation build issues: https://app.circleci.com/pipelines/github/RedisBloom/RedisBloom/1127/workflows/0f84f6c6-6c4b-47fa-af15-547b03315d51/jobs/4086 by updating readies to the latest to include @chayim 's fix on `--modern` (and non modern) https://github.com/RedisLabsModules/readies/blob/master/bin/getrmpytools