### PR TITLE
[BUG] give error on CMS overflow

### DIFF
--- a/src/cms.c
+++ b/src/cms.c
@@ -6,8 +6,7 @@
 #include "cms.h"
 #include "contrib/murmurhash2.h"
 
-#define min(a,b) (((a)<(b))?(a):(b))
-
+#define min(a, b) (((a) < (b)) ? (a) : (b))
 
 #define BIT64 64
 #define CMS_HASH(item, itemlen, i) MurmurHash2(item, itemlen, i)

--- a/src/cms.c
+++ b/src/cms.c
@@ -6,12 +6,8 @@
 #include "cms.h"
 #include "contrib/murmurhash2.h"
 
-#define min(a, b)                                                                                  \
-    ({                                                                                             \
-        __typeof__(a) _a = (a);                                                                    \
-        __typeof__(b) _b = (b);                                                                    \
-        _a < _b ? _a : _b;                                                                         \
-    })
+#define min(a,b) (((a)<(b))?(a):(b))
+
 
 #define BIT64 64
 #define CMS_HASH(item, itemlen, i) MurmurHash2(item, itemlen, i)
@@ -60,12 +56,11 @@ size_t CMS_IncrBy(CMSketch *cms, const char *item, size_t itemlen, size_t value)
         cms->array[loc] += value;
         if (cms->array[loc] < value) {
             cms->array[loc] = UINT32_MAX;
-            overflow = 1;
         }
         minCount = min(minCount, cms->array[loc]);
     }
     cms->counter += value;
-    return !overflow ? minCount : UINT32_MAX;
+    return minCount;
 }
 
 size_t CMS_Query(CMSketch *cms, const char *item, size_t itemlen) {

--- a/src/cms.c
+++ b/src/cms.c
@@ -47,7 +47,6 @@ size_t CMS_IncrBy(CMSketch *cms, const char *item, size_t itemlen, size_t value)
     assert(item);
 
     size_t minCount = (size_t)-1;
-    int overflow = 0;
 
     for (size_t i = 0; i < cms->depth; ++i) {
         uint32_t hash = CMS_HASH(item, itemlen, i);

--- a/src/rm_cms.c
+++ b/src/rm_cms.c
@@ -133,7 +133,11 @@ int CMSketch_IncrBy(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_ReplyWithArray(ctx, pairCount);
     for (int i = 0; i < pairCount; ++i) {
         size_t count = CMS_IncrBy(cms, pairArray[i].key, pairArray[i].keylen, pairArray[i].value);
-        RedisModule_ReplyWithLongLong(ctx, (long long)count);
+        if (count != UINT32_MAX) {
+            RedisModule_ReplyWithLongLong(ctx, (long long)count);
+        } else {
+            RedisModule_ReplyWithError(ctx, "CMS: INCRBY overflow");
+        }
     }
     RedisModule_ReplicateVerbatim(ctx);
 

--- a/tests/flow/test_cms.py
+++ b/tests/flow/test_cms.py
@@ -181,18 +181,19 @@ class testCMS():
         large_val = 1024*1024*1024*2 - 1
         
         self.cmd('FLUSHALL')
-        self.cmd('cms.initbydim', 'cms', '1000', '5')
-        self.assertEqual([large_val], self.cmd('cms.incrby', 'cms', 'a', large_val))
-        self.assertEqual([large_val], self.cmd('cms.query', 'cms', 'a'))
-        self.assertEqual([large_val * 2], self.cmd('cms.incrby', 'cms', 'a', large_val))
-        self.assertEqual([large_val * 2], self.cmd('cms.query', 'cms', 'a'))
+        self.cmd('cms.initbydim', 'cms', '5', '2')
+        self.assertEqual([large_val, 10, 17, 5], self.cmd('cms.incrby', 'cms', 'a', large_val, 'b', 10, 'c', 7, 'd', 5))
+        self.assertEqual([large_val, 17, 17, 5], self.cmd('cms.query', 'cms', 'a', 'b', 'c', 'd'))
+        self.assertEqual([large_val * 2, 27, 34, 10], self.cmd('cms.incrby', 'cms', 'a', large_val, 'b', 10, 'c', 7, 'd', 5))
+        self.assertEqual([large_val * 2, 34, 34, 10], self.cmd('cms.query', 'cms', 'a', 'b', 'c', 'd'))
         
         # overflow as result > UNIT32_MAX
-        res = self.cmd('cms.incrby', 'cms', 'a', large_val)
+        res = self.cmd('cms.incrby', 'cms', 'a', large_val, 'b', 10, 'c', 7, 'd', 5)
         # result of insert is an error message
         self.env.assertResponseError(res[0], contained='CMS: INCRBY overflow')
-        # result of query in UINT32_MAX
-        self.assertEqual([large_val * 2 + 1], self.cmd('cms.query', 'cms', 'a'))
+        self.assertEqual(res[1:], [44, 51, 15])
+        # result of query in UINT32_MAX (large_val * 2 + 1)
+        self.assertEqual([large_val * 2 + 1, 51, 51, 15], self.cmd('cms.query', 'cms', 'a', 'b', 'c', 'd'))
 
     def test_smallset(self):
         self.cmd('FLUSHALL')


### PR DESCRIPTION
fixes #418 
Return an error message `CMS: INCRBY overflow` if overflow occurs on CMS.INCRBY.
CMS.QUERY will return `UINT32_MAX` or `4294967295`