### PR TITLE
Enabled CI profilers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,18 @@ commands:
       module_path:
         type: string
         default: ../../redisbloom.so
+      profile_env:
+        type: string
+        default: "0"
+      benchmark_glob:
+        type: string
+        default: "*.yml"
+      triggering_env:
+        type: string
+        default: "circleci"
+      allowed_envs:
+        type: string
+        default: "oss-standalone"
     steps:
       - run:
           name: Install remote benchmark tool dependencies
@@ -113,7 +125,9 @@ commands:
             export AWS_SECRET_ACCESS_KEY=$PERFORMANCE_EC2_SECRET_KEY
             export AWS_DEFAULT_REGION=$PERFORMANCE_EC2_REGION
             export EC2_PRIVATE_PEM=$PERFORMANCE_EC2_PRIVATE_PEM
-
+            export PROFILE=<< parameters.profile_env >>
+            export BENCHMARK_GLOB=<< parameters.benchmark_glob >>
+            export PERF_CALLGRAPH_MODE="dwarf"
             redisbench-admin run-remote \
               --required-module bf \
               --module_path << parameters.module_path >> \
@@ -123,8 +137,10 @@ commands:
               --github_sha $CIRCLE_SHA1 \
               --github_branch $CIRCLE_BRANCH \
               --upload_results_s3 \
-              --triggering_env circleci \
-              --push_results_redistimeseries
+              --triggering_env << parameters.triggering_env >> \
+              --fail_fast \
+              --push_results_redistimeseries \
+              --allowed-envs << parameters.allowed_envs >>
 
   platform-build-steps:
     parameters:
@@ -317,16 +333,29 @@ jobs:
           name: Run QA Automation
           command: MODULE_VERSION=$CIRCLE_BRANCH VERBOSE=1 TEST=nightly QUICK=1 ./tests/qa/run
 
-  performance-automation:
+  benchmark-bloom-oss-standalone:
     docker:
-      - image: redisfab/rmbuilder:6.2.3-x64-bionic
+      - image: redisfab/rmbuilder:6.2.5-x64-bionic
     steps:
       - checkout-all
       - setup-automation
       - run:
           name: build artifact
-          command: make build
+          command: make all
       - benchmark-steps
+  
+  benchmark-bloom-oss-standalone-profiler:
+    docker:
+      - image: redisfab/rmbuilder:6.2.5-x64-bionic
+    steps:
+      - checkout-all
+      - setup-automation
+      - run:
+          name: build artifact
+          command: make all
+      - benchmark-steps:
+          profile_env: "1"
+          triggering_env: "circleci.profilers" # results generated with profilers attached are not mixed with the ones without it 
 
 #----------------------------------------------------------------------------------------------------------------------------------
 
@@ -407,7 +436,12 @@ workflows:
           <<: *on-any-branch
           requires:
             - lint
-      - performance-automation:
+      - benchmark-bloom-oss-standalone:
+          <<: *on-integ-and-version-tags
+          requires:
+            - lint
+          context: common
+      - benchmark-bloom-oss-standalone-profiler:
           <<: *on-integ-and-version-tags
           requires:
             - lint
@@ -448,5 +482,7 @@ workflows:
                 - master
                 - /^feature-.*$/
     jobs:
-      - performance-automation:
+      - benchmark-bloom-oss-standalone:
+          context: common
+      - benchmark-bloom-oss-standalone-profiler:
           context: common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,6 +414,15 @@ on-integ-and-version-tags: &on-integ-and-version-tags
         - master
         - /^\d+\.\d+.*$/
         - /^feature-.*$/
+    tags:
+      only: /^v[0-9].*/
+
+on-perf-tags: &on-perf-tags
+  filters:
+    branches:
+      only:
+        - master
+        - /^\d+\.\d+.*$/
         - /^perf.*$/
     tags:
       only: /^v[0-9].*/
@@ -437,12 +446,12 @@ workflows:
           requires:
             - lint
       - benchmark-bloom-oss-standalone:
-          <<: *on-integ-and-version-tags
+          <<: *on-perf-tags
           requires:
             - lint
           context: common
       - benchmark-bloom-oss-standalone-profiler:
-          <<: *on-integ-and-version-tags
+          <<: *on-perf-tags
           requires:
             - lint
           context: common


### PR DESCRIPTION
This PR enables a CI profiler setup with the same specs as the default benchmark setups. 
It attaches a profiler for 60 seconds to each benchmark run and produces a set of outputs by default that can be consulted at 
[CI profiler viewer Grafana dashboard](https://benchmarksrediscom.grafana.net/d/uRPZar57k/ci-profiler-viewer?orgId=1):


- Flame Graph
- Main THREAD Flame Graph
- perf report per dso
- perf report per dso,sym
- perf report per dso,sym with callgraph
- perf report per dso,sym,srcline
- perf report per dso,sym,srcline with callgraph
- perf report top self-cpu
- perf report top self-cpu (dso=)
- Identical stacks collapsed

Note: the results produced with a profiler attached are not used on the visualizations/regression analysis due to the profiler overhead impact.