### PR TITLE
[BUG] add break when bucket is cleared

### DIFF
--- a/src/topk.c
+++ b/src/topk.c
@@ -155,6 +155,7 @@ char *TopK_Add(TopK *topk, const char *item, size_t itemlen, uint32_t increment)
                         runner->fp = fp;
                         *countPtr = local_incr;
                         maxCount = max(maxCount, *countPtr);
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
Before the fix, when an element "conquered" a bucket, the loop continues and decreases the count of the element itself.
Thanks to Wang Ruixin