### PR TITLE
Added support for trimmed mean calculation: TDIGEST.TRIMMED_MEAN

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -852,6 +852,26 @@
     "since": "2.4.0",
     "group": "tdigest"
   },
+  "TDIGEST.TRIMMED_MEAN": {
+    "summary": "Returns the trimmed mean ignoring values outside given cutoff upper and lower limits",
+    "complexity": "O(n)",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "low_cut_percentile",
+        "type": "double"
+      },
+      {
+        "name": "high_cut_percentile",
+        "type": "double"
+      }
+    ],
+    "since": "2.4.0",
+    "group": "tdigest"
+  },
   "TDIGEST.INFO": {
     "summary": "Returns information about a sketch",
     "complexity": "O(1)",

--- a/docs/docs/_index.md
+++ b/docs/docs/_index.md
@@ -6,6 +6,7 @@ type: docs
 ---
 
 [![Discord](https://img.shields.io/discord/697882427875393627?style=flat-square)](https://discord.gg/wXhwjCQ)
+[![Github](https://img.shields.io/static/v1?label=&message=repository&color=5961FF&logo=github)](https://github.com/RedisBloom/RedisBloom/)
 
 RedisBloom adds four probabilistic data structures to Redis: a scalable **Bloom filter**, a **cuckoo filter**, a **count-min sketch**, and a **top-k**. These data structures trade perfect accuracy for extreme memory efficiency, so they're especially useful for big data and streaming applications.
 

--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -316,7 +316,7 @@ int TDigestSketch_Cdf(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
  *
  * Returns the trimmed mean ignoring values outside given cutoff upper and lower limits.
  *
- * @param ctx Context in which RedisTRIMMED_MEAN modules operate
+ * @param ctx Context in which Redis modules operate
  * @param argv Redis command arguments, as an array of strings
  * @param argc Redis command number of arguments
  * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if the command failed
@@ -348,6 +348,11 @@ int TDigestSketch_TrimmedMean(RedisModuleCtx *ctx, RedisModuleString **argv, int
         RedisModule_CloseKey(key);
         return RedisModule_ReplyWithError(
             ctx, "ERR T-Digest: low_cut_percentile and high_cut_percentile should be in [0,1]");
+    }
+    if (low_cut_percentile > high_cut_percentile) {
+        RedisModule_CloseKey(key);
+        return RedisModule_ReplyWithError(
+            ctx, "ERR T-Digest: low_cut_percentile should be lower than high_cut_percentile");
     }
     const double value = td_trimmed_mean(tdigest, low_cut_percentile, high_cut_percentile);
     RedisModule_CloseKey(key);

--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -3,10 +3,18 @@ exporter:
   redistimeseries:
     timemetric: "$.StartTime"
     metrics:
+      - "$.Totals.overallQuantiles.all_queries.q0"
+      - "$.Totals.overallQuantiles.all_queries.q50"
+      - "$.Totals.overallQuantiles.all_queries.q95"
+      - "$.Totals.overallQuantiles.all_queries.q99"
+      - "$.Totals.overallQuantiles.all_queries.q100"
+      - "$.Totals.overallQueryRates.all_queries"
+      - "$.Tests.Overall.rps"
       - "$.Tests.Overall.avg_latency_ms"
-      - "$.Tests.Overall.min_latency_ms"
       - "$.Tests.Overall.p50_latency_ms"
       - "$.Tests.Overall.p95_latency_ms"
       - "$.Tests.Overall.p99_latency_ms"
       - "$.Tests.Overall.max_latency_ms"
-      - "$.Tests.Overall.rps"
+      - "$.Tests.Overall.min_latency_ms"
+      - '$."ALL STATS".*."Ops/sec"'
+      - '$."ALL STATS".*."Latency"'

--- a/tests/benchmarks/tdigest_trimmed_mean_1M_samples_comp100.yml
+++ b/tests/benchmarks/tdigest_trimmed_mean_1M_samples_comp100.yml
@@ -19,9 +19,9 @@ dbconfig:
   - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisbloom/datasets/tdigest_1M_samples_comp100_v2.4.0_dump.rdb"
   - dataset_load_timeout_secs: 180
   - check:
-      keyspacelen: 1
+      keyspacelen: 2
 
 clientconfig:
   benchmark_type: "read-only"
   tool: memtier_benchmark
-  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TDIGEST.TRIMMED_MEAN tdigest 0.1 0.9'"
+  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TDIGEST.TRIMMED_MEAN tdigest-0 0.1 0.9'"

--- a/tests/benchmarks/tdigest_trimmed_mean_1M_samples_comp100.yml
+++ b/tests/benchmarks/tdigest_trimmed_mean_1M_samples_comp100.yml
@@ -1,0 +1,27 @@
+version: 0.2
+name: "tdigest_trimmed_mean_1M_samples_comp100"
+description: "Benchmarking trimmed mean calculation of a data sketch with 1M elements.
+              The T-Digest sketch has a compression of 100.
+              The RDB was generated using python as follow:
+
+              import numpy as np
+              import redis
+              np.random.seed(12345)
+              conn = redis.StrictRedis()
+              conn.execute_command('TDIGEST.CREATE', 'tdigest', '100')
+              for x in np.random.zipf(1.1, size=1000000):
+                conn.execute_command('TDIGEST.ADD', 'tdigest', '{}'.format(x), '1.0')
+        "
+remote:
+ - type: oss-standalone
+ - setup: redisbloom-m5
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisbloom/datasets/tdigest_1M_samples_comp100_v2.4.0_dump.rdb"
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 1
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TDIGEST.TRIMMED_MEAN tdigest 0.1 0.9'"

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -357,6 +357,55 @@ class testTDigest:
             redis.exceptions.ResponseError, self.cmd, "tdigest.cdf", "tdigest", "a"
         )
 
+    def test_tdigest_trimmed_mean(self):
+        self.assertOk(self.cmd("tdigest.create", "tdigest", 500))
+        # insert datapoints into sketch
+        for x in range(0, 20):
+            self.assertOk(self.cmd("tdigest.add", "tdigest", x, 1.0))
+
+        self.assertAlmostEqual(
+            9.5, float(self.cmd("tdigest.trimmed_mean", "tdigest", 0.1,0.9)), 0.01
+        )
+        self.assertAlmostEqual(
+            9.5, float(self.cmd("tdigest.trimmed_mean", "tdigest", 0.0,1.0)), 0.01
+        )
+        self.assertAlmostEqual(
+            9.5, float(self.cmd("tdigest.trimmed_mean", "tdigest", 0.20,0.8)), 0.01
+        )
+
+    def test_negative_tdigest_trimmed_mean(self):
+        self.cmd("SET", "tdigest", "B")
+        # WRONGTYPE
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.trimmed_mean", "tdigest", 0.9
+        )
+        # key does not exist
+        self.assertRaises(
+            ResponseError, self.cmd, "tdigest.trimmed_mean", "dont-exist", 0.9
+        )
+        self.cmd("DEL", "tdigest", "B")
+        self.assertOk(self.cmd("tdigest.create", "tdigest", 100))
+        # arity lower
+        self.assertRaises(redis.exceptions.ResponseError, self.cmd, "tdigest.trimmed_mean")
+        # arity upper
+        self.assertRaises(
+            redis.exceptions.ResponseError,
+            self.cmd,
+            "tdigest.trimmed_mean",
+            "tdigest",
+            1,
+            1,
+            1,
+        )
+        # parsing
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.trimmed_mean", "tdigest", "a", "a"
+        )
+        # low_cut_percentile and high_cut_percentile should be in [0,1]
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.trimmed_mean", "tdigest", "10.0", "20.0"
+        )
+
     def test_negative_tdigest_info(self):
         self.cmd("SET", "tdigest", "B")
         # WRONGTYPE

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -370,7 +370,7 @@ class testTDigest:
             9.5, float(self.cmd("tdigest.trimmed_mean", "tdigest", 0.0,1.0)), 0.01
         )
         self.assertAlmostEqual(
-            9.5, float(self.cmd("tdigest.trimmed_mean", "tdigest", 0.20,0.8)), 0.01
+            9.5, float(self.cmd("tdigest.trimmed_mean", "tdigest", 0.2,0.8)), 0.01
         )
 
     def test_negative_tdigest_trimmed_mean(self):
@@ -404,6 +404,10 @@ class testTDigest:
         # low_cut_percentile and high_cut_percentile should be in [0,1]
         self.assertRaises(
             redis.exceptions.ResponseError, self.cmd, "tdigest.trimmed_mean", "tdigest", "10.0", "20.0"
+        )
+        # low_cut_percentile should be lower than high_cut_percentile
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.trimmed_mean", "tdigest", "0.9", "0.1"
         )
 
     def test_negative_tdigest_info(self):


### PR DESCRIPTION
The following PR adds support for trimmed mean calculation via the new command:
```
TDIGEST.TRIMMED_MEAN {key} {low_cut_percentile} {high_cut_percentile}
```
i.e. return the mean of the data set without the values below and above the low-cut and high-cut percentiles respectively.

Fixes #386 

Note: It implies the review of https://github.com/RedisBloom/t-digest-c/pull/22