### PR TITLE
Added TDIGEST.MERGE, TDIGEST.QUANTILE benchmarks

### DIFF
--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -3,10 +3,18 @@ exporter:
   redistimeseries:
     timemetric: "$.StartTime"
     metrics:
+      - "$.Totals.overallQuantiles.all_queries.q0"
+      - "$.Totals.overallQuantiles.all_queries.q50"
+      - "$.Totals.overallQuantiles.all_queries.q95"
+      - "$.Totals.overallQuantiles.all_queries.q99"
+      - "$.Totals.overallQuantiles.all_queries.q100"
+      - "$.Totals.overallQueryRates.all_queries"
+      - "$.Tests.Overall.rps"
       - "$.Tests.Overall.avg_latency_ms"
-      - "$.Tests.Overall.min_latency_ms"
       - "$.Tests.Overall.p50_latency_ms"
       - "$.Tests.Overall.p95_latency_ms"
       - "$.Tests.Overall.p99_latency_ms"
       - "$.Tests.Overall.max_latency_ms"
-      - "$.Tests.Overall.rps"
+      - "$.Tests.Overall.min_latency_ms"
+      - '$."ALL STATS".*."Ops/sec"'
+      - '$."ALL STATS".*."Latency"'

--- a/tests/benchmarks/tdigest_add_comp100.yml
+++ b/tests/benchmarks/tdigest_add_comp100.yml
@@ -1,5 +1,5 @@
 version: 0.2
-name: "tdigest_incrby_cap10M_comp100"
+name: "tdigest_add_comp100"
 description: "Benchmarking adding an item to the t-Digest sketch, 
               with an desired compression of 100"
 remote:

--- a/tests/benchmarks/tdigest_merge_2hist_1M_samples_comp100.yml
+++ b/tests/benchmarks/tdigest_merge_2hist_1M_samples_comp100.yml
@@ -1,0 +1,18 @@
+version: 0.2
+name: "tdigest_merge_2hist_1M_samples_comp100"
+description: "Benchmarking histogram merge of 2 data sketches with 1M elements.
+              The T-Digest sketch has a compression of 100.
+        "
+remote:
+ - type: oss-standalone
+ - setup: redisbloom-m5
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisbloom/datasets/tdigest_1M_samples_comp100_v2.4.0_dump.rdb"
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 2
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TDIGEST.MERGE tdigest-0 tdigest-1'"

--- a/tests/benchmarks/tdigest_quantile_p50_1M_samples_comp100.yml
+++ b/tests/benchmarks/tdigest_quantile_p50_1M_samples_comp100.yml
@@ -1,0 +1,18 @@
+version: 0.2
+name: "tdigest_quantile_p50_1M_samples_comp100"
+description: "Benchmarking p50 calculation of 1 t-digest data sketch with 1M elements.
+              The T-Digest sketch has a compression of 100.
+        "
+remote:
+ - type: oss-standalone
+ - setup: redisbloom-m5
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisbloom/datasets/tdigest_1M_samples_comp100_v2.4.0_dump.rdb"
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 2
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TDIGEST.QUANTILE tdigest-0 0.50'"

--- a/tests/benchmarks/tdigest_quantile_p95_1M_samples_comp100.yml
+++ b/tests/benchmarks/tdigest_quantile_p95_1M_samples_comp100.yml
@@ -1,0 +1,18 @@
+version: 0.2
+name: "tdigest_quantile_p95_1M_samples_comp100"
+description: "Benchmarking p95 calculation of 1 t-digest data sketch with 1M elements.
+              The T-Digest sketch has a compression of 100.
+        "
+remote:
+ - type: oss-standalone
+ - setup: redisbloom-m5
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisbloom/datasets/tdigest_1M_samples_comp100_v2.4.0_dump.rdb"
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 2
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TDIGEST.QUANTILE tdigest-0 0.95'"

--- a/tests/benchmarks/tdigest_quantile_p99_1M_samples_comp100.yml
+++ b/tests/benchmarks/tdigest_quantile_p99_1M_samples_comp100.yml
@@ -1,0 +1,18 @@
+version: 0.2
+name: "tdigest_quantile_p99_1M_samples_comp100"
+description: "Benchmarking p99 calculation of 1 t-digest data sketch with 1M elements.
+              The T-Digest sketch has a compression of 100.
+        "
+remote:
+ - type: oss-standalone
+ - setup: redisbloom-m5
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisbloom/datasets/tdigest_1M_samples_comp100_v2.4.0_dump.rdb"
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 2
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TDIGEST.QUANTILE tdigest-0 0.99'"


### PR DESCRIPTION
This PR simply increases benchmarks coverage for the digest data structure. It adds 4 new benchmarks for quantile and merge operations. 