### PR TITLE
Added support for TD.QUANTILE multiple quantiles in a single command

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -821,7 +821,7 @@
     "group": "tdigest"
   },
   "TDIGEST.QUANTILE": {
-    "summary": "Returns an estimate of the cutoff",
+    "summary": "Returns an estimate of the cutoff such that a specified fraction of the data added to this TDigest would be less than or equal to the specified cutoffs. Multiple quantiles can be returned with one call.",
     "complexity": "O(1)",
     "arguments": [
       {
@@ -830,7 +830,8 @@
       },
       {
         "name": "quantile",
-        "type": "double"
+        "type": "double",
+        "multiple": true
       }
     ],
     "since": "2.4.0",

--- a/docs/commands/tdigest.quantile.md
+++ b/docs/commands/tdigest.quantile.md
@@ -1,5 +1,8 @@
 Returns an estimate of the cutoff such that a specified fraction of the data
-added to this TDigest would be less than or equal to the cutoff.
+added to this TDigest would be less than or equal to the specified cutoffs.
+
+Multiple quantiles can be returned with one call.
+
 
 #### Parameters:
 
@@ -8,16 +11,19 @@ added to this TDigest would be less than or equal to the cutoff.
 
 @return
 
-@double-reply - value estimate of the cutoff such that a specified fraction of the data
-added to this TDigest would be less than or equal to the cutoff.
+@array-reply - the command returns an array of results populated with quantile_1, cutoff_1, quantile_2, cutoff_2, ..., quantile_N, cutoff_N.
 
 @examples
 
 ```
-redis> TDIGEST.QUANTILE t-digest 0.5
-"100.42"
+redis> TDIGEST.QUANTILE tdigest-0 0.5
+1) "0.5"
+2) "18200.224436313329"
 ```
 ```
-redis> TDIGEST.QUANTILE nonexist 0.5
-"nan"
+redis> TDIGEST.QUANTILE tdigest-0 0.5 0.999
+1) "0.5"
+2) "18200.224436313329"
+3) "0.999"
+4) "5.3830741444744448e+18"
 ```

--- a/docs/commands/tdigest.quantile.md
+++ b/docs/commands/tdigest.quantile.md
@@ -16,14 +16,14 @@ Multiple quantiles can be returned with one call.
 @examples
 
 ```
-redis> TDIGEST.QUANTILE tdigest-0 0.5
+redis> TDIGEST.QUANTILE t-digest 0.5
 1) "0.5"
-2) "18200.224436313329"
+2) "100.42"
 ```
 ```
-redis> TDIGEST.QUANTILE tdigest-0 0.5 0.999
+redis> TDIGEST.QUANTILE t-digest 0.5 0.999
 1) "0.5"
-2) "18200.224436313329"
+2) "100.42"
 3) "0.999"
-4) "5.3830741444744448e+18"
+4) "190.01"
 ```

--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -1,7 +1,6 @@
 #include <math.h>    // ceil, log10f
 #include <stdlib.h>  // malloc
 #include <strings.h> // strncasecmp
-#include <stdbool.h>
 
 #include "rm_tdigest.h"
 #include "rmutil/util.h"
@@ -280,7 +279,6 @@ int TDigestSketch_Quantile(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
 
     const size_t n_quantiles = argc - 2;
     double *quantiles = (double *)__td_calloc(n_quantiles, sizeof(double));
-    int sorted = 1;
 
     for (int i = 0; i < n_quantiles; ++i) {
         if (RedisModule_StringToDouble(argv[2 + i], &quantiles[i]) != REDISMODULE_OK) {

--- a/tests/benchmarks/tdigest_quantile_p50_p95_p99_p999_1M_samples_comp100.yml
+++ b/tests/benchmarks/tdigest_quantile_p50_p95_p99_p999_1M_samples_comp100.yml
@@ -1,0 +1,18 @@
+version: 0.2
+name: "tdigest_quantile_p50_p95_p99_p999_1M_samples_comp100"
+description: "Benchmarking p50, p95, p99 and p999 calculation of 1 t-digest data sketch with 1M elements.
+              The T-Digest sketch has a compression of 100.
+        "
+remote:
+ - type: oss-standalone
+ - setup: redisbloom-m5
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisbloom/datasets/tdigest_1M_samples_comp100_v2.4.0_dump.rdb"
+  - dataset_load_timeout_secs: 180
+  - check:
+      keyspacelen: 2
+
+clientconfig:
+  benchmark_type: "read-only"
+  tool: memtier_benchmark
+  arguments: "--test-time 180 -c 32 -t 1 --hide-histogram --command 'TDIGEST.QUANTILE tdigest-0 0.50 0.95 0.99 0.999'"


### PR DESCRIPTION
Addresses #387 

This PR changes the reply format of TD.QUANTILE from a single double reply value:

```
redis> TDIGEST.QUANTILE t-digest 0.5
"18200.224436313329"
```

to an array reply with results populated with quantile_1, cutoff_1, quantile_2, cutoff_2, ..., quantile_N, cutoff_N:

```
redis> TDIGEST.QUANTILE tdigest 0.5
1) "0.5"
2) "18200.224436313329"
redis> TDIGEST.QUANTILE tdigest 0.5 0.999
1) "0.5"
2) "18200.224436313329"
3) "0.999"
4) "5.3830741444744448e+18"
```

As part of the benchmarks CI process we're introducing a new benchmark named `tdigest_quantile_p50_p95_p99_p999_1M_samples_comp100` that, as the name states, computes multiple quantiles in a single command. 