### PR TITLE
Update bf.reserve.md

### DIFF
--- a/docs/commands/bf.reserve.md
+++ b/docs/commands/bf.reserve.md
@@ -60,11 +60,11 @@ redis> BF.RESERVE bf 0.01 1000
 ```
 
 ```
-redis> BF.RESERVE bf_exp 1000 EXPANSION 2
+redis> BF.RESERVE bf_exp 0.01 1000 EXPANSION 2
 OK
 ```
 
 ```
-redis> BF.RESERVE bf_exp 1000 NONSCALING
+redis> BF.RESERVE bf_non 0.01 1000 NONSCALING
 OK
 ```


### PR DESCRIPTION
BF.RESERVE requires the error rate and without it you get 

BF.RESERVE bf_exp 1000 EXPANSION 2
(error) ERR (0 < error rate range < 1)

Proposed change from bf_exp to bf_non because bf_exp would already exist in this order.