### PR TITLE
[BUG] fix init params for CF.RESERVE

### DIFF
--- a/docs/docs/Configuration.md
+++ b/docs/docs/Configuration.md
@@ -30,7 +30,7 @@ $ redis-server --loadmodule ./redisbloom.so [OPT VAL]...
 
 ## RedisBloom configuration parameters
 
-The following table summerizes which configuration parameters can be set at module load-time and which can be set on run-time:
+The following table summarizes which configuration parameters can be set at module load-time and which can be set on run-time:
 
 | Configuration Parameter                 | Load-time          | Run-time             |
 | :-------                                | :-----             | :-----------         |

--- a/src/cuckoo.c
+++ b/src/cuckoo.c
@@ -235,6 +235,10 @@ static CuckooInsertStatus CuckooFilter_InsertFP(CuckooFilter *filter, const Look
         return CuckooInsert_Inserted;
     }
 
+    if (filter->expansion == 0) {
+        return CuckooInsert_NoSpace;
+    }
+
     if (CuckooFilter_Grow(filter) != 0) {
         return CuckooInsert_MemAllocFailed;
     }

--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -508,6 +508,9 @@ static int CFReserve_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     if (mi_loc != -1) {
         if (RedisModule_StringToLongLong(argv[mi_loc + 1], &maxIterations) != REDISMODULE_OK) {
             return RedisModule_ReplyWithError(ctx, "Couldn't parse MAXITERATIONS");
+        } else if (maxIterations <= 0) {
+            return RedisModule_ReplyWithError(
+                ctx, "MAXITERATIONS parameter needs to be a positive integer");
         }
     }
 
@@ -516,6 +519,9 @@ static int CFReserve_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     if (bs_loc != -1) {
         if (RedisModule_StringToLongLong(argv[bs_loc + 1], &bucketSize) != REDISMODULE_OK) {
             return RedisModule_ReplyWithError(ctx, "Couldn't parse BUCKETSIZE");
+        } else if (bucketSize <= 0) {
+            return RedisModule_ReplyWithError(
+                ctx, "BUCKETSIZE parameter needs to be a positive integer");
         }
     }
 
@@ -524,6 +530,9 @@ static int CFReserve_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     if (ex_loc != -1) {
         if (RedisModule_StringToLongLong(argv[ex_loc + 1], &expansion) != REDISMODULE_OK) {
             return RedisModule_ReplyWithError(ctx, "Couldn't parse EXPANSION");
+        } else if (expansion < 0) {
+            return RedisModule_ReplyWithError(
+                ctx, "EXPANSION parameter needs to be a non-negative integer");
         }
     }
 
@@ -604,6 +613,7 @@ static int cfInsertCommon(RedisModuleCtx *ctx, RedisModuleString *keystr, RedisM
             } else {
                 RedisModule_ReplyWithLongLong(ctx, -1);
             }
+            break;
         case CuckooInsert_MemAllocFailed:
             RedisModule_ReplyWithError(ctx, "Memory allocation failure"); // LCOV_EXCL_LINE
             break;

--- a/tests/flow/test_cuckoo.py
+++ b/tests/flow/test_cuckoo.py
@@ -287,6 +287,16 @@ class testCuckoo():
         self.assertRaises(ResponseError, self.cmd, 'CF.RESERVE err 10 EXPANSION')
         self.assertRaises(ResponseError, self.cmd, 'CF.RESERVE err 10 EXPANSION string')
 
+    def test_expansion_0(self):
+        self.cmd('FLUSHALL')
+        self.cmd('CF.RESERVE a 4 EXPANSION 0')
+        self.assertEqual(self.cmd('CF.ADD a 1'), 1)
+        self.assertEqual(self.cmd('CF.ADD a 2'), 1)
+        self.assertEqual(self.cmd('CF.ADD a 3'), 1)
+        self.assertEqual(self.cmd('CF.ADD a 4'), 1)
+        self.assertEqual(self.cmd('CF.INSERT a ITEMS 5 6'), [-1, -1])
+        self.assertRaises(ResponseError, self.cmd, 'Filter is full')
+
     def test_info(self):
         self.cmd('FLUSHALL')
         self.cmd('CF.RESERVE a 1000')
@@ -308,6 +318,11 @@ class testCuckoo():
         self.cmd('FLUSHALL')
         self.assertRaises(ResponseError, self.cmd, 'CF.RESERVE')
         self.assertRaises(ResponseError, self.cmd, 'CF.RESERVE err')
+        self.assertRaises(ResponseError, self.cmd, 'CF.RESERVE err 10 EXPANSION -1')
+        self.assertRaises(ResponseError, self.cmd, 'CF.RESERVE err 10 BUCKETSIZE 0')
+        self.assertRaises(ResponseError, self.cmd, 'CF.RESERVE err 10 BUCKETSIZE -1')
+        self.assertRaises(ResponseError, self.cmd, 'CF.RESERVE err 10 MAXITERATIONS 0')
+        self.assertRaises(ResponseError, self.cmd, 'CF.RESERVE err 10 MAXITERATIONS -1')        
         self.cmd('CF.RESERVE err 1000')
 
         self.assertRaises(ResponseError, self.cmd, 'CF.ADD')


### PR DESCRIPTION
This PR:
- checks for `CF.RESERVE` initialization parameters EXPANSION, BUCKETSIZE and MAXITERATIONS.
- prevent a crash when the filter attempts to grow, but expansion is 0. 

Fixes #481 