### PR TITLE
[2.2] Print module version on RM_OnLoad (#485)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 username := $(shell sh -c 'id -u')
 usergroup := $(shell sh -c 'id -g')
-CPPFLAGS =  -Wall -Wno-unused-function $(DEBUGFLAGS) -fPIC -std=gnu99 -D_GNU_SOURCE -fcommon
+CPPFLAGS =  -Wall -Wno-unused-function $(DEBUGFLAGS) -fPIC -std=gnu99 -D_GNU_SOURCE -fcommon -D_GNU_SOURCE -DREDISBLOOM_GIT_SHA=\"$(REDISBLOOM_GIT_SHA)\"
 # CC:=$(shell sh -c 'type $(CC) >/dev/null 2>/dev/null && echo $(CC) || echo gcc')
 
 # Compile flags for linux / osx
@@ -39,6 +39,7 @@ CPPFLAGS += -I$(ROOT) -I$(ROOT)/contrib
 SRCDIR := $(ROOT)/src
 MODULE_OBJ = $(SRCDIR)/rebloom.o
 MODULE_SO = $(ROOT)/redisbloom.so
+REDISBLOOM_GIT_SHA := $(shell git rev-parse --short HEAD)
 
 DEPS = $(ROOT)/contrib/MurmurHash2.o \
 	   $(ROOT)/rmutil/util.o \

--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -11,6 +11,10 @@
 #include <string.h>
 #include <ctype.h>
 
+#ifndef REDISBLOOM_GIT_SHA
+#define REDISBLOOM_GIT_SHA "unknown"
+#endif
+
 #define CF_MAX_ITERATIONS 20
 #define CF_DEFAULT_BUCKETSIZE 2
 #define CF_DEFAULT_EXPANSION 1
@@ -1217,6 +1221,10 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
         REDISMODULE_OK) {
         return REDISMODULE_ERR;
     }
+
+    // Print version string!
+    RedisModule_Log(ctx, "notice", "RedisBloom version %d.%d.%d (Git=%s)", REBLOOM_VERSION_MAJOR,
+                    REBLOOM_VERSION_MINOR, REBLOOM_VERSION_PATCH, REDISBLOOM_GIT_SHA);
 
     if (argc == 1) {
         RedisModule_Log(ctx, "notice", "Found empty string. Assuming ramp-packer validation");


### PR DESCRIPTION
* Print module version on RM_OnLoad

* lint fix

* use REDISBLOOM_GIT_SHA

(cherry picked from commit 612c210facfc81fdcf19af70484926a16a32e949)