### PR TITLE
Added TDIGEST.MERGESTORE command and made TDIGEST.CREATE compression optional

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -730,7 +730,8 @@
       },
       {
         "name": "compression",
-        "type": "integer"
+        "type": "integer",
+        "optional": true
       }
     ],
     "since": "2.4.0",
@@ -776,7 +777,7 @@
     "group": "tdigest"
   },
   "TDIGEST.MERGE": {
-    "summary": "Merges all of the values from 'from' to 'this' sketch",
+    "summary": "Merges all of the values from 'from' keys to 'this' sketch",
     "complexity": "O(N), where N is the number of centroids",
     "arguments": [
       {
@@ -785,7 +786,46 @@
       },
       {
         "name": "from-key",
+        "type": "key",
+        "multiple": true
+      }
+    ],
+    "since": "2.4.0",
+    "group": "tdigest"
+  },
+  "TDIGEST.MERGESTORE": {
+    "summary": "Merges all of the values from 'from' keys to 'destination-key' sketch",
+    "complexity": "O(N*K), where N is the number of centroids and K being the number of input sketches",
+    "arguments": [
+      {
+        "name": "destination-key",
         "type": "key"
+      }
+      ,
+      {
+        "name": "numkeys",
+        "type": "integer"
+      },
+      {
+        "name": "from-key",
+        "type": "key",
+        "multiple": true
+      },
+      {
+        "name": "config",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "compression",
+            "token": "COMPRESSION",
+            "type": "pure-token"
+          },
+          {
+            "name": "compression",
+            "type": "integer"
+          }
+        ]
       }
     ],
     "since": "2.4.0",

--- a/commands.json
+++ b/commands.json
@@ -777,15 +777,15 @@
     "group": "tdigest"
   },
   "TDIGEST.MERGE": {
-    "summary": "Merges all of the values from 'from' keys to 'this' sketch",
+    "summary": "Merges all of the values from 'source-key' keys to 'destination-key' sketch",
     "complexity": "O(N), where N is the number of centroids",
     "arguments": [
       {
-        "name": "to-key",
+        "name": "destination-key",
         "type": "key"
       },
       {
-        "name": "from-key",
+        "name": "source-key",
         "type": "key",
         "multiple": true
       }
@@ -794,7 +794,7 @@
     "group": "tdigest"
   },
   "TDIGEST.MERGESTORE": {
-    "summary": "Merges all of the values from 'from' keys to 'destination-key' sketch",
+    "summary": "Merges all of the values from 'source-key' keys to 'destination-key' sketch",
     "complexity": "O(N*K), where N is the number of centroids and K being the number of input sketches",
     "arguments": [
       {
@@ -807,7 +807,7 @@
         "type": "integer"
       },
       {
-        "name": "from-key",
+        "name": "source-key",
         "type": "key",
         "multiple": true
       },

--- a/docs/commands/tdigest.create.md
+++ b/docs/commands/tdigest.create.md
@@ -3,7 +3,12 @@ Allocate memory and initialize a t-digest sketch.
 #### Parameters:
 
 * **key**: The name of the sketch (a t-digest data structure)
-* **compression**: The compression parameter. 100 is a common value for normal uses. 1000 is extremely large. See the further notes bellow
+
+
+Optional parameters:
+
+* **COMPRESSION**: The compression parameter. 100 is a common value for normal uses. 1000 is extremely large. If no value value is passed by default the compression will be 100. See the further notes bellow.
+
 
 
 **Further notes on compression vs accuracy:**

--- a/docs/commands/tdigest.create.md
+++ b/docs/commands/tdigest.create.md
@@ -7,7 +7,8 @@ Allocate memory and initialize a t-digest sketch.
 
 Optional parameters:
 
-* **COMPRESSION**: The compression parameter. 100 is a common value for normal uses. 1000 is extremely large. If no value value is passed by default the compression will be 100. See the further notes bellow.
+* **COMPRESSION**: The compression parameter. 100 is a common value for normal uses. 1000 is extremely large.
+If no value is passed by default the compression will be 100. See the further notes bellow.
 
 
 

--- a/docs/commands/tdigest.create.md
+++ b/docs/commands/tdigest.create.md
@@ -8,8 +8,7 @@ Allocate memory and initialize a t-digest sketch.
 Optional parameters:
 
 * **COMPRESSION**: The compression parameter. 100 is a common value for normal uses. 1000 is extremely large.
-If no value is passed by default the compression will be 100. See the further notes bellow.
-
+If no value is passed by default the compression will be 100. Further notes bellow.
 
 
 **Further notes on compression vs accuracy:**

--- a/docs/commands/tdigest.merge.md
+++ b/docs/commands/tdigest.merge.md
@@ -2,8 +2,8 @@ Merges all the observation values from the 'from' sketch to the 'to' sketch.
 
 #### Parameters:
 
-* **to-key**: Sketch to copy observation values to (a t-digest data structure)
-* **from-key**: Sketch to copy observation values from (a t-digest data structure)
+* **destination-key**: Sketch to copy observation values to (a t-digest data structure)
+* **source-key**: Sketch to copy observation values from (a t-digest data structure)
 
 @return
 

--- a/docs/commands/tdigest.mergestore.md
+++ b/docs/commands/tdigest.mergestore.md
@@ -13,7 +13,8 @@ If destination already exists, it is overwritten.
 
 Optional parameters:
 
-* **COMPRESSION**: The compression parameter. 100 is a common value for normal uses. 1000 is extremely large. If no value value is passed by default the compression will be 100. For more information on scaling of accuracy versus the compression parameter see [_The t-digest: Efficient estimates of distributions_](https://www.sciencedirect.com/science/article/pii/S2665963820300403).
+* **COMPRESSION**: The compression parameter. 100 is a common value for normal uses. 1000 is extremely large. If no value is passed by default the compression will be 100.
+For more information on scaling of accuracy versus the compression parameter see [_The t-digest: Efficient estimates of distributions_](https://www.sciencedirect.com/science/article/pii/S2665963820300403).
 
 @return
 

--- a/docs/commands/tdigest.mergestore.md
+++ b/docs/commands/tdigest.mergestore.md
@@ -14,7 +14,7 @@ If destination already exists, it is overwritten.
 Optional parameters:
 
 * **COMPRESSION**: The compression parameter. 100 is a common value for normal uses. 1000 is extremely large.
-If no value is passed, the used compression will the maximal value amongst all inputs.
+If no value is passed, the used compression will the maximal value among all inputs.
 For more information on scaling of accuracy versus the compression parameter see [_The t-digest: Efficient estimates of distributions_](https://www.sciencedirect.com/science/article/pii/S2665963820300403).
 
 @return

--- a/docs/commands/tdigest.mergestore.md
+++ b/docs/commands/tdigest.mergestore.md
@@ -7,8 +7,8 @@ If destination already exists, it is overwritten.
 #### Parameters:
 
 * **destination-key**: Sketch to copy observation values to (a t-digest data structure)
-* **numkeys**: Sketch(es) to copy observation values from (a t-digest data structure)
-* **from**: Sketch(es) to copy observation values from (a t-digest data structure)
+* **numkeys**: Number of sketch(es) to copy observation values from
+* **source-key**: Sketch(es) to copy observation values from (a t-digest data structure)
 
 
 Optional parameters:

--- a/docs/commands/tdigest.mergestore.md
+++ b/docs/commands/tdigest.mergestore.md
@@ -13,7 +13,8 @@ If destination already exists, it is overwritten.
 
 Optional parameters:
 
-* **COMPRESSION**: The compression parameter. 100 is a common value for normal uses. 1000 is extremely large. If no value is passed by default the compression will be 100.
+* **COMPRESSION**: The compression parameter. 100 is a common value for normal uses. 1000 is extremely large.
+If no value is passed, the used compression will the maximal value amongst all inputs.
 For more information on scaling of accuracy versus the compression parameter see [_The t-digest: Efficient estimates of distributions_](https://www.sciencedirect.com/science/article/pii/S2665963820300403).
 
 @return

--- a/docs/commands/tdigest.mergestore.md
+++ b/docs/commands/tdigest.mergestore.md
@@ -1,0 +1,35 @@
+Merges all of the values from 'from' keys to 'destination-key' sketch.
+
+It is mandatory to provide the number of input keys (numkeys) before passing the input keys and the other (optional) arguments.
+
+If destination already exists, it is overwritten.
+
+#### Parameters:
+
+* **destination-key**: Sketch to copy observation values to (a t-digest data structure)
+* **numkeys**: Sketch(es) to copy observation values from (a t-digest data structure)
+* **from**: Sketch(es) to copy observation values from (a t-digest data structure)
+
+
+Optional parameters:
+
+* **COMPRESSION**: The compression parameter. 100 is a common value for normal uses. 1000 is extremely large. If no value value is passed by default the compression will be 100. For more information on scaling of accuracy versus the compression parameter see [_The t-digest: Efficient estimates of distributions_](https://www.sciencedirect.com/science/article/pii/S2665963820300403).
+
+@return
+
+OK on success, error otherwise
+
+@examples
+
+```
+redis> TDIGEST.CREATE from-sketch-1
+OK
+redis> TDIGEST.CREATE from-sketch-2
+OK
+redis> TDIGEST.ADD from-sketch-1 10.0 1.0
+OK
+redis> TDIGEST.ADD from-sketch-2 50.0 1.0
+OK
+redis> TDIGEST.MERGESTORE destination-key 2 from-sketch-1 from-sketch-2
+OK
+```

--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -251,7 +251,8 @@ int TDigestSketch_MergeStore(RedisModuleCtx *ctx, RedisModuleString **argv, int 
         goto cleanup;
     }
     long long compression = 0;
-    // If no compression value is passed, the used compression will the maximal value amongst all inputs.
+    // If no compression value is passed, the used compression will the maximal value amongst all
+    // inputs.
     bool use_max_compression = true;
     const int start_remaining_args = numkeys + 3;
     if (start_remaining_args + 2 == argc) {

--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -251,6 +251,7 @@ int TDigestSketch_MergeStore(RedisModuleCtx *ctx, RedisModuleString **argv, int 
         goto cleanup;
     }
     long long compression = 0;
+    // If no compression value is passed, the used compression will the maximal value amongst all inputs.
     bool use_max_compression = true;
     const int start_remaining_args = numkeys + 3;
     if (start_remaining_args + 2 == argc) {

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -207,15 +207,22 @@ class testTDigest:
         # merge to a t-digest with default compression
         self.assertOk(self.cmd("tdigest.mergestore", "to-tdigest-100", "2","from-1", "from-2"))
         # assert we have same merged weight on both histograms ( given the to-histogram was empty )
-        from_info = parse_tdigest_info(self.cmd("tdigest.info", "to-tdigest-100"))
-        total_weight_to = float(from_info["Merged weight"]) + float(
-            from_info["Unmerged weight"]
+        to_info = parse_tdigest_info(self.cmd("tdigest.info", "to-tdigest-100"))
+        # ensure tha the destination t-digest has the largest compression of all input t-digests
+        compression = int(to_info["Compression"])
+        self.assertEqual(200, compression)
+        total_weight_to = float(to_info["Merged weight"]) + float(
+            to_info["Unmerged weight"]
         )
         total_weight_from = 10.0 + 1.0
         self.assertEqual(total_weight_from, total_weight_to)
 
-        # merge to a t-digest with default compression
-        self.assertOk(self.cmd("tdigest.mergestore", "to-tdigest-100", "2","from-1", "from-2", "COMPRESSION", "200"))
+        # merge to a t-digest with non-default compression
+        self.assertOk(self.cmd("tdigest.mergestore", "to-tdigest-50", "2","from-1", "from-2", "COMPRESSION", "50"))
+        # ensure tha the destination t-digest has the passed compression
+        to_info = parse_tdigest_info(self.cmd("tdigest.info", "to-tdigest-50"))
+        compression = int(to_info["Compression"])
+        self.assertEqual(50, compression)
 
     def test_tdigest_mergestore_percentile(self):
         self.cmd("FLUSHALL")

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -296,10 +296,18 @@ class testTDigest:
     def test_negative_tdigest_mergestore(self):
         self.cmd("SET", "to-tdigest", "B")
         self.cmd("SET", "from-tdigest", "B")
+        self.assertOk(self.cmd("tdigest.create", "from-1", 100))
 
         # WRONGTYPE
         self.assertRaises(
             ResponseError, self.cmd, "tdigest.mergestore", "to-tdigest", "1", "from-tdigest"
+        )
+        # WRONGTYPE in the one of the inputs
+        self.assertRaises(
+            ResponseError, self.cmd, "tdigest.mergestore", "to-tdigest", "2", "from-1", "from-tdigest"
+        )
+        self.assertRaises(
+            ResponseError, self.cmd, "tdigest.mergestore", "to-tdigest", "2", "from-tdigest", "from-1"
         )
         self.cmd("DEL", "to-tdigest")
         # arity lower

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -322,6 +322,14 @@ class testTDigest:
             "from-tdigest",
             "extra-arg",
         )
+        # numkeys needs to be a positive integer
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.mergestore", "to-tdigest", "-1", "from-tdigest"
+        )
+        # numkeys needs to be a positive integer
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.mergestore", "to-tdigest", "0", "from-tdigest"
+        )
 
     def test_tdigest_min_max(self):
         self.assertOk(self.cmd("tdigest.create", "tdigest", 100))

--- a/wordlist
+++ b/wordlist
@@ -43,3 +43,4 @@ scalable
 subcommand
 unmerged
 yadazula
+CLI


### PR DESCRIPTION
This PR adds a new command for the T-Digest datastructure, which allows to merge multiple t-digests into a new key. 
It has a similar look and feel like https://redis.io/commands/zinterstore/ . 
If destination already exists, it is overwritten. 

```
TDIGEST.MERGESTORE {destination} numkeys from-key [from-key ...] [COMPRESSION compression]
```

Apart from it, after discussing with @gkorland about the default compression, we've made COMPRESSION on `TDIGEST.CREATE` optional. 