### PR TITLE
Use RM_String in TDIGEST.QUANTILE  reply

### DIFF
--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -413,7 +413,7 @@ int TDigestSketch_Quantile(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     double *values = (double *)__td_calloc(n_quantiles, sizeof(double));
     for (int i = 0; i < n_quantiles; ++i) {
         int start = i;
-        while (quantiles[i] < quantiles[i + 1] && i < n_quantiles) {
+        while (i < n_quantiles - 1 && quantiles[i] < quantiles[i + 1]) {
             ++i;
         }
         td_quantiles(tdigest, quantiles + start, values + start, i - start + 1);

--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -413,7 +413,7 @@ int TDigestSketch_Quantile(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     double *values = (double *)__td_calloc(n_quantiles, sizeof(double));
     for (int i = 0; i < n_quantiles; ++i) {
         int start = i;
-        while (i < n_quantiles - 1 && quantiles[i] < quantiles[i + 1]) {
+        while (i < n_quantiles - 1 && quantiles[i] <= quantiles[i + 1]) {
             ++i;
         }
         td_quantiles(tdigest, quantiles + start, values + start, i - start + 1);

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -429,6 +429,7 @@ class testTDigest:
                 expected[pos], float(v), 0.01
             )
         # the reply provides the output percentiles in ordered manner
+        expected = [0.95,95.0,0.99,99.0,0.01,1.0,0.50,50.0]
         res = self.cmd("tdigest.quantile", "tdigest", 0.95, 0.99, 0.01, 0.5)
         for pos, v in enumerate(res):
             self.assertAlmostEqual(


### PR DESCRIPTION
remove optimization of `qsort` which allowed for a faster query of quantiles but `double` reply might be different than the user's input. Instead, use the original RM_String as a return value.
