### PR TITLE
Ensuring proper error message on bad quantile inputs for TDIGEST.QUANTILE

### DIFF
--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -423,6 +423,11 @@ int TDigestSketch_Quantile(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
             __td_free(quantiles);
             return RedisModule_ReplyWithError(ctx, "ERR T-Digest: error parsing quantile");
         }
+        if (quantiles[i] < 0 || quantiles[i] > 1.0) {
+            RedisModule_CloseKey(key);
+            __td_free(quantiles);
+            return RedisModule_ReplyWithError(ctx, "ERR T-Digest: quantile should be in [0,1]");
+        }
     }
     double *values = (double *)__td_calloc(n_quantiles, sizeof(double));
     for (int i = 0; i < n_quantiles; ++i) {

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -447,7 +447,7 @@ class testTDigest:
         )
         # key does not exist
         self.assertRaises(
-            ResponseError, self.cmd, "tdigest.quantile", "dont-exist", 0.9
+            redis.exceptions.ResponseError, self.cmd, "tdigest.quantile", "dont-exist", 0.9
         )
         self.cmd("DEL", "tdigest")
         self.assertOk(self.cmd("tdigest.create", "tdigest"))
@@ -461,6 +461,22 @@ class testTDigest:
             "tdigest",
             1,
             "a",
+        )
+        # parsing quantile needs to be between [0,1]
+        self.assertRaises(
+            redis.exceptions.ResponseError,
+            self.cmd,
+            "tdigest.quantile",
+            "tdigest",
+            -0.5,
+        )
+        # parsing quantile needs to be between [0,1]
+        self.assertRaises(
+            redis.exceptions.ResponseError,
+            self.cmd,
+            "tdigest.quantile",
+            "tdigest",
+            1.1,
         )
         # parsing
         self.assertRaises(


### PR DESCRIPTION
before:
```
127.0.0.1:6379> tdigest.quantile t -1
1) "nan"
127.0.0.1:6379> tdigest.quantile t 10
1) "nan"
127.0.0.1:6379> tdigest.quantile t -INF
1) "nan"
```

after:
```
127.0.0.1:6379> tdigest.quantile t -1
(error) ERR T-Digest: quantile should be in [0,1]
127.0.0.1:6379> tdigest.quantile t 10
(error) ERR T-Digest: quantile should be in [0,1]
127.0.0.1:6379> tdigest.quantile t -INF
(error) ERR T-Digest: quantile should be in [0,1]
```