### PR TITLE
TDIGEST.ADD value and weight checks (As in the reference implementation)

### DIFF
--- a/docs/commands/tdigest.add.md
+++ b/docs/commands/tdigest.add.md
@@ -3,7 +3,7 @@ Adds one or more observations to a t-digest sketch.
 #### Parameters:
 
 * **key**: The name of the sketch (a t-digest data structure)
-* **val**: The value of the observation (floating-point)
+* **val**: The value of the observation (floating-point). The value should be a finite number
 * **weight**: The weight of this observation (positive integer). **weight** can indicate the number of observations with such value
 
 @return

--- a/docs/commands/tdigest.add.md
+++ b/docs/commands/tdigest.add.md
@@ -4,7 +4,7 @@ Adds one or more observations to a t-digest sketch.
 
 * **key**: The name of the sketch (a t-digest data structure)
 * **val**: The value of the observation (floating-point)
-* **weight**: The weight of this observation (floating-point, >0). **weight** can indicate the number of observations with such value
+* **weight**: The weight of this observation (positive integer). **weight** can indicate the number of observations with such value
 
 @return
 
@@ -13,11 +13,11 @@ Adds one or more observations to a t-digest sketch.
 @examples
 
 ```
-redis> TDIGEST.ADD t-digest 42 1 194 0.3
+redis> TDIGEST.ADD t-digest 42 1 194 1
 OK
 ```
 ```
-redis> TDIGEST.ADD t-digest string 1.0
+redis> TDIGEST.ADD t-digest string 1
 (error) ERR T-Digest: error parsing val parameter
 ```
 ```

--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -167,6 +167,11 @@ int TDigestSketch_Add(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             RedisModule_CloseKey(key);
             return RedisModule_ReplyWithError(ctx, "ERR T-Digest: error parsing val parameter");
         }
+        if (val < -__DBL_MAX__ || val > __DBL_MAX__) {
+            RedisModule_CloseKey(key);
+            return RedisModule_ReplyWithError(
+                ctx, "ERR T-Digest: val parameter needs to be a finite number");
+        }
         if (RedisModule_StringToLongLong(argv[i + 1], &weight) != REDISMODULE_OK) {
             RedisModule_CloseKey(key);
             return RedisModule_ReplyWithError(ctx, "ERR T-Digest: error parsing weight parameter");

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -169,7 +169,20 @@ class testTDigest:
         self.assertRaises(
             redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", 5.0, "a"
         )
+        # val parameter needs to be a finite number
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", 5.0, "-inf"
+        )
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", 5.0, "+inf"
+        )
         # weight parameter needs to be a positive integer
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", 5.0, 0
+        )
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", 5.0, -10
+        )
         self.assertRaises(
             redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", 5.0, 5.95
         )

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -89,7 +89,7 @@ class testTDigest:
         self.assertOk(self.cmd("tdigest.reset", "tdigest"))
         # insert datapoints into sketch
         for x in range(100):
-            self.assertOk(self.cmd("tdigest.add", "tdigest", random.random(), 1.0))
+            self.assertOk(self.cmd("tdigest.add", "tdigest", random.random(), 1))
 
         # assert we have 100 unmerged nodes
         self.assertEqual(
@@ -137,7 +137,7 @@ class testTDigest:
                     "tdigest.add",
                     "tdigest",
                     random.random() * 10000,
-                    random.random() * 500 + 1.0,
+                    int(random.random() * 500 + 1.0),
                 )
             )
 
@@ -169,6 +169,13 @@ class testTDigest:
         self.assertRaises(
             redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", 5.0, "a"
         )
+        # weight parameter needs to be a positive integer
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", 5.0, 5.95
+        )
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", 5.0, -10.0
+        )
 
     def test_tdigest_merge(self):
         self.cmd("FLUSHALL")
@@ -176,9 +183,9 @@ class testTDigest:
         self.assertOk(self.cmd("tdigest.create", "from-tdigest", "compression", 100))
         # insert datapoints into sketch
         for _ in range(100):
-            self.assertOk(self.cmd("tdigest.add", "from-tdigest", 1.0, 1.0))
+            self.assertOk(self.cmd("tdigest.add", "from-tdigest", 1.0, 1))
         for _ in range(100):
-            self.assertOk(self.cmd("tdigest.add", "to-tdigest", 1.0, 10.0))
+            self.assertOk(self.cmd("tdigest.add", "to-tdigest", 1.0, 10))
         # merge from-tdigest into to-tdigest
         self.assertOk(self.cmd("tdigest.merge", "to-tdigest", "from-tdigest"))
         # we should now have 1100 weight on to-histogram
@@ -194,7 +201,7 @@ class testTDigest:
         self.assertOk(self.cmd("tdigest.create", "from-tdigest", "compression", 100))
         # insert datapoints into sketch
         for _ in range(100):
-            self.assertOk(self.cmd("tdigest.add", "from-tdigest", 1.0, 1.0))
+            self.assertOk(self.cmd("tdigest.add", "from-tdigest", 1.0, 1))
         # merge from-tdigest into to-tdigest
         self.assertOk(self.cmd("tdigest.merge", "to-tdigest", "from-tdigest"))
         # assert we have same merged weight on both histograms ( given the to-histogram was empty )
@@ -213,8 +220,8 @@ class testTDigest:
         self.assertOk(self.cmd("tdigest.create", "from-1", "compression", 100))
         self.assertOk(self.cmd("tdigest.create", "from-2", "compression", 200))
         # insert datapoints into sketch
-        self.assertOk(self.cmd("tdigest.add", "from-1", 1.0, 1.0))
-        self.assertOk(self.cmd("tdigest.add", "from-2", 1.0, 10.0))
+        self.assertOk(self.cmd("tdigest.add", "from-1", 1.0, 1))
+        self.assertOk(self.cmd("tdigest.add", "from-2", 1.0, 10))
         # merge to a t-digest with default compression
         self.assertOk(self.cmd("tdigest.mergestore", "to-tdigest-100", "2","from-1", "from-2"))
         # assert we have same merged weight on both histograms ( given the to-histogram was empty )
@@ -240,7 +247,7 @@ class testTDigest:
         self.assertOk(self.cmd("tdigest.create", "from-1", "compression", 500))
         # insert datapoints into sketch
         for x in range(1, 10000):
-            self.assertOk(self.cmd("tdigest.add", "from-1", x * 0.01, 1.0))
+            self.assertOk(self.cmd("tdigest.add", "from-1", x * 0.01, 1))
         # merge to a t-digest with default compression
         self.assertOk(self.cmd("tdigest.mergestore", "to-tdigest-500", "1","from-1", "COMPRESSION", "500"))
         # assert min min/max have same result as quantile 0 and 1
@@ -364,7 +371,7 @@ class testTDigest:
         self.assertEqual(-sys.float_info.max, float(self.cmd("tdigest.max", "tdigest")))
         # insert datapoints into sketch
         for x in range(1, 101):
-            self.assertOk(self.cmd("tdigest.add", "tdigest", x, 1.0))
+            self.assertOk(self.cmd("tdigest.add", "tdigest", x, 1))
         # min/max
         self.assertEqual(100, float(self.cmd("tdigest.max", "tdigest")))
         self.assertEqual(1, float(self.cmd("tdigest.min", "tdigest")))
@@ -405,7 +412,7 @@ class testTDigest:
         self.assertOk(self.cmd("tdigest.create", "tdigest", "compression", 500))
         # insert datapoints into sketch
         for x in range(1, 10000):
-            self.assertOk(self.cmd("tdigest.add", "tdigest", x * 0.01, 1.0))
+            self.assertOk(self.cmd("tdigest.add", "tdigest", x * 0.01, 1))
         # assert min min/max have same result as quantile 0 and 1
         self.assertEqual(
             float(self.cmd("tdigest.max", "tdigest")),
@@ -472,7 +479,7 @@ class testTDigest:
         self.assertOk(self.cmd("tdigest.create", "tdigest", "compression", 500))
         # insert datapoints into sketch
         for x in range(1, 100):
-            self.assertOk(self.cmd("tdigest.add", "tdigest", x, 1.0))
+            self.assertOk(self.cmd("tdigest.add", "tdigest", x, 1))
 
         self.assertAlmostEqual(
             0.01, float(self.cmd("tdigest.cdf", "tdigest", 1.0)), 0.01
@@ -510,7 +517,7 @@ class testTDigest:
         self.assertOk(self.cmd("tdigest.create", "tdigest", "compression", 500))
         # insert datapoints into sketch
         for x in range(0, 20):
-            self.assertOk(self.cmd("tdigest.add", "tdigest", x, 1.0))
+            self.assertOk(self.cmd("tdigest.add", "tdigest", x, 1))
 
         self.assertAlmostEqual(
             9.5, float(self.cmd("tdigest.trimmed_mean", "tdigest", 0.1,0.9)), 0.01
@@ -585,7 +592,7 @@ class testTDigest:
         self.assertOk(self.cmd("tdigest.create", "tdigest"))
         # insert datapoints into sketch
         for _ in range(1, 101):
-            self.assertOk(self.cmd("tdigest.add", "tdigest", 1.0, 1.0))
+            self.assertOk(self.cmd("tdigest.add", "tdigest", 1.0, 1))
         self.assertEqual(True, self.cmd("SAVE"))
         mem_usage_prior_restart = self.cmd("MEMORY", "USAGE", "tdigest")
         self.restart_and_reload()

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -171,10 +171,10 @@ class testTDigest:
         )
         # val parameter needs to be a finite number
         self.assertRaises(
-            redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", 5.0, "-inf"
+            redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", "-inf", 5, 
         )
         self.assertRaises(
-            redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", 5.0, "+inf"
+            redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", "+inf", 5,
         )
         # weight parameter needs to be a positive integer
         self.assertRaises(
@@ -188,6 +188,12 @@ class testTDigest:
         )
         self.assertRaises(
             redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", 5.0, -10.0
+        )
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", 5.0, "-inf"
+        )
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", 5.0, "+inf"
         )
 
     def test_tdigest_merge(self):


### PR DESCRIPTION

- Allow only positive integer weights on TDIGEST.ADD (As in the reference implementation)
- Disallow INF and -INF in TDIGEST.ADD