### PR TITLE
TDIGEST.TRIMMED_MEAN: enforce low_cut_percentile to be lower than high_cut_percentile (as in reference implementations)

### DIFF
--- a/docs/commands/tdigest.trimmed_mean.md
+++ b/docs/commands/tdigest.trimmed_mean.md
@@ -9,7 +9,7 @@ Estimate the mean value from the sketch, excluding observation values outside th
 @return
 
 @simple-string-reply estimation of the mean value.
-Will return __DBL_MAX__ if the sketch is empty.
+Will return "nan" if the sketch is empty.
 
 @examples
 

--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -514,7 +514,7 @@ int TDigestSketch_TrimmedMean(RedisModuleCtx *ctx, RedisModuleString **argv, int
         return RedisModule_ReplyWithError(
             ctx, "ERR T-Digest: low_cut_percentile and high_cut_percentile should be in [0,1]");
     }
-    if (low_cut_percentile > high_cut_percentile) {
+    if (low_cut_percentile >= high_cut_percentile) {
         RedisModule_CloseKey(key);
         return RedisModule_ReplyWithError(
             ctx, "ERR T-Digest: low_cut_percentile should be lower than high_cut_percentile");

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -507,7 +507,7 @@ class testTDigest:
 
     def test_tdigest_trimmed_mean(self):
         self.cmd('FLUSHALL')
-        self.assertOk(self.cmd("tdigest.create", "tdigest", "compression", 500))
+        self.assertOk(self.cmd("tdigest.create", "tdigest", "compression", 1000))
         # insert datapoints into sketch
         for x in range(0, 20):
             self.assertOk(self.cmd("tdigest.add", "tdigest", x, 1.0))
@@ -521,6 +521,45 @@ class testTDigest:
         self.assertAlmostEqual(
             9.5, float(self.cmd("tdigest.trimmed_mean", "tdigest", 0.2,0.8)), 0.01
         )
+        self.assertOk(self.cmd("tdigest.reset", "tdigest"))
+        self.assertEqual(
+            "nan", self.cmd("tdigest.trimmed_mean", "tdigest", 0.2,0.8)
+        )
+        # insert datapoints into sketch
+        # given a high number of datapoints, the trimmed mean between a range on those datapoints
+        # is approximate to the precise mean of the interval range
+        for x in range(1, 10001):
+            self.assertOk(self.cmd("tdigest.add", "tdigest", float(x)/1000.0, 1.0))
+        for x in range(1, 10):
+            low_cut = float(x)/10.0
+            high_cut = low_cut + 0.1
+            self.assertAlmostEqual(
+                x+0.5, float(self.cmd("tdigest.trimmed_mean", "tdigest", low_cut, high_cut)), 0.01
+            )
+        # simple confirmation that the when having:
+        #   9 observations of value 1
+        #   1 observation of value 5
+        # and comparing vs sheets
+        #      TRIMMEAN(G2:G11,0.2) we get 1.0
+        #      TRIMMEAN(G2:G11,0.19) we get 1.4
+        #      TRIMMEAN(G2:G11,0.10) we get 1.4
+        #      TRIMMEAN(G2:G11,0.02) we get 1.4
+        # if we replicate this on our trimmed_mean implementation we get the same results
+        self.assertOk(self.cmd("tdigest.reset", "tdigest"))
+        self.assertOk(self.cmd("tdigest.add", "tdigest", 1.0, 9))
+        self.assertOk(self.cmd("tdigest.add", "tdigest", 5.0, 1))
+        self.assertAlmostEqual(
+                1.0, float(self.cmd("tdigest.trimmed_mean", "tdigest", 0.10, 0.90)), 0.01
+            )
+        self.assertAlmostEqual(
+                1.4, float(self.cmd("tdigest.trimmed_mean", "tdigest", 0.095, 0.905)), 0.01
+            )
+        self.assertAlmostEqual(
+                1.4, float(self.cmd("tdigest.trimmed_mean", "tdigest", 0.05, 0.95)), 0.01
+            )
+        self.assertAlmostEqual(
+                1.4, float(self.cmd("tdigest.trimmed_mean", "tdigest", 0.01, 0.99)), 0.01
+            )
 
     def test_negative_tdigest_trimmed_mean(self):
         self.cmd('FLUSHALL')
@@ -558,6 +597,9 @@ class testTDigest:
         # low_cut_percentile should be lower than high_cut_percentile
         self.assertRaises(
             redis.exceptions.ResponseError, self.cmd, "tdigest.trimmed_mean", "tdigest", "0.9", "0.1"
+        )
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.trimmed_mean", "tdigest", "0.1", "0.1"
         )
 
     def test_negative_tdigest_info(self):

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -555,7 +555,7 @@ class testTDigest:
 
     def test_tdigest_trimmed_mean(self):
         self.cmd('FLUSHALL')
-        self.assertOk(self.cmd("tdigest.create", "tdigest", "compression", 1000))
+        self.assertOk(self.cmd("tdigest.create", "tdigest", "compression", 500))
         # insert datapoints into sketch
         for x in range(0, 20):
             self.assertOk(self.cmd("tdigest.add", "tdigest", x, 1))
@@ -577,7 +577,7 @@ class testTDigest:
         # given a high number of datapoints, the trimmed mean between a range on those datapoints
         # is approximate to the precise mean of the interval range
         for x in range(1, 10001):
-            self.assertOk(self.cmd("tdigest.add", "tdigest", float(x)/1000.0, 1.0))
+            self.assertOk(self.cmd("tdigest.add", "tdigest", float(x)/1000.0, 1))
         for x in range(1, 10):
             low_cut = float(x)/10.0
             high_cut = low_cut + 0.1


### PR DESCRIPTION
Given the original tdigest does not have a reference implementation:

- Compared implementation vs postgresql tdigest trimmed mean implementation: https://github.com/tvondra/tdigest/blob/master/tdigest.c
- Confirmed also that using google sheets the result of TRIMMEAN function results in the same output of our implementation. 
