### PR TITLE
double-precision overflow detection on TDIGEST.ADD

### DIFF
--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -170,7 +170,11 @@ int TDigestSketch_Add(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
             RedisModule_CloseKey(key);
             return RedisModule_ReplyWithError(ctx, "ERR T-Digest: error parsing weight parameter");
         }
-        td_add(tdigest, val, weight);
+        if (td_add(tdigest, val, weight) != 0) {
+            RedisModule_CloseKey(key);
+            return RedisModule_ReplyWithError(ctx,
+                                              "ERR T-Digest: double-precision overflow detected");
+        }
     }
     RedisModule_CloseKey(key);
     RedisModule_ReplicateVerbatim(ctx);

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -169,6 +169,11 @@ class testTDigest:
         self.assertRaises(
             redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", 5.0, "a"
         )
+        # double-precision overflow detected
+        self.assertOk(self.cmd("tdigest.add", "tdigest", 5.0, 1e308))
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.add", "tdigest", 5.0, 1e308
+        )
 
     def test_tdigest_merge(self):
         self.cmd("FLUSHALL")


### PR DESCRIPTION
Requires https://github.com/RedisBloom/t-digest-c/pull/26/files to be reviewed prior to reviewing this PR.