### PR TITLE
Introduce TDIGEST.BYRANK and TDIGEST.BYREVRANK commands

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -912,6 +912,40 @@
     "since": "2.4.0",
     "group": "tdigest"
   },
+  "TDIGEST.BYRANK": {
+    "summary": "Retrieve an estimation of the value with the given the rank. Multiple estimations can be returned with one call.",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "rank",
+        "type": "double",
+        "multiple": true
+      }
+    ],
+    "since": "2.4.0",
+    "group": "tdigest"
+  },
+  "TDIGEST.BYREVRANK": {
+    "summary": "Retrieve an estimation of the value with the given the reverse rank. Multiple estimations can be returned with one call.",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key"
+      },
+      {
+        "name": "reverse_rank",
+        "type": "double",
+        "multiple": true
+      }
+    ],
+    "since": "2.4.0",
+    "group": "tdigest"
+  },
   "TDIGEST.INFO": {
     "summary": "Returns information about a sketch",
     "complexity": "O(1)",

--- a/docs/commands/tdigest.byrank.md
+++ b/docs/commands/tdigest.byrank.md
@@ -1,0 +1,20 @@
+Retrieve an estimation of the value with the given the rank.
+
+Multiple estimations can be returned with one call.
+
+#### Parameters:
+
+* **key**: The name of the sketch (a t-digest data structure)
+* **value**: input rank, for which the value will be determined
+
+@return
+
+@array-reply - the command returns an array of results populated with value_1, value_2, ..., value_N.
+
+@examples
+
+```
+redis> TDIGEST.BYRANK t-digest 100 200
+1) "5"
+2) "10"
+```

--- a/docs/commands/tdigest.byrevrank.md
+++ b/docs/commands/tdigest.byrevrank.md
@@ -1,0 +1,20 @@
+Retrieve an estimation of the value with the given the reverse rank.
+
+Multiple estimations can be returned with one call.
+
+#### Parameters:
+
+* **key**: The name of the sketch (a t-digest data structure)
+* **value**: input reverse rank, for which the value will be determined
+
+@return
+
+@array-reply - the command returns an array of results populated with value_1, value_2, ..., value_N.
+
+@examples
+
+```
+redis> TDIGEST.BYREVRANK t-digest 100 200
+1) "10"
+2) "5"
+```

--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -401,6 +401,102 @@ static int double_cmpfunc(const void *a, const void *b) {
 #endif
 
 /**
+ * Helper method to utilize TDIGEST.BYRANK and TDIGEST.BYREVRANK common logic.
+ */
+static int _TDigest_ByRank(RedisModuleCtx *ctx, RedisModuleString *const *argv, int argc,
+                           int reverse) {
+    if (argc < 3) {
+        return RedisModule_WrongArity(ctx);
+    }
+
+    RedisModuleString *keyName = argv[1];
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, keyName, REDISMODULE_READ);
+
+    if (_TDigest_KeyCheck(ctx, key) != REDISMODULE_OK)
+        return REDISMODULE_ERR;
+
+    const size_t n_values = argc - 2;
+    long long *input_ranks = (long long *)__td_calloc(n_values, sizeof(long long));
+
+    for (int i = 0; i < n_values; ++i) {
+        if (RedisModule_StringToLongLong(argv[2 + i], &input_ranks[i]) != REDISMODULE_OK) {
+            RedisModule_CloseKey(key);
+            __td_free(input_ranks);
+            return RedisModule_ReplyWithError(ctx, "ERR T-Digest: error parsing rank");
+        }
+        if (input_ranks[i] < 0) {
+            RedisModule_CloseKey(key);
+            __td_free(input_ranks);
+            return RedisModule_ReplyWithError(ctx, "ERR T-Digest: rank needs to be non negative");
+        }
+    }
+
+    td_histogram_t *tdigest = RedisModule_ModuleTypeGetValue(key);
+    double *values = (double *)__td_calloc(n_values, sizeof(double));
+
+    const double size = td_size(tdigest);
+    const double min = td_min(tdigest);
+    const double max = td_max(tdigest);
+    for (int i = 0; i < n_values; ++i) {
+        // Nan if the sketch is empty
+        if (size == 0) {
+            values[i] = NAN;
+            // when rank is 0:
+            // the value of the largest observation if reverse
+            // the value of the smallest observation if !reverse
+        } else if (input_ranks[i] == 0) {
+            values[i] = reverse ? max : min;
+            // when rank is larger or equal to the the sum of weights of all observations in the
+            // sketch: -inf if reverse
+            // +inf if !reverse
+        } else if (input_ranks[i] >= size) {
+            values[i] = reverse ? -INFINITY : INFINITY;
+        } else {
+            const double cdf_input =
+                reverse ? ((size - input_ranks[i]) / size) : (input_ranks[i] / size);
+            values[i] = td_quantile(tdigest, cdf_input);
+        }
+    }
+
+    RedisModule_CloseKey(key);
+    RedisModule_ReplyWithArray(ctx, n_values);
+    for (int i = 0; i < n_values; ++i) {
+        RedisModule_ReplyWithDouble(ctx, values[i]);
+    }
+    __td_free(input_ranks);
+    __td_free(values);
+    return REDISMODULE_OK;
+}
+
+/**
+ * Command: TDIGEST.BYRANK {key} {value} [{value}...]
+ *
+ * Retrieve an estimation of the value with the given the rank.
+ *
+ * @param ctx Context in which Redis modules operate
+ * @param argv Redis command arguments, as an array of strings
+ * @param argc Redis command number of arguments
+ * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if the command failed
+ */
+int TDigestSketch_ByRank(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    return _TDigest_ByRank(ctx, argv, argc, false);
+}
+
+/**
+ * Command: TDIGEST.BYREVRANK {key} {value} [{value}...]
+ *
+ * Retrieve an estimation of the value with the given the reverse rank.
+ *
+ * @param ctx Context in which Redis modules operate
+ * @param argv Redis command arguments, as an array of strings
+ * @param argc Redis command number of arguments
+ * @return REDISMODULE_OK on success, or REDISMODULE_ERR  if the command failed
+ */
+int TDigestSketch_ByRevRank(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    return _TDigest_ByRank(ctx, argv, argc, true);
+}
+
+/**
  * Command: TDIGEST.QUANTILE {key} {quantile} [{quantile2}...]
  *
  * Returns an estimate of the cutoff such that a specified fraction of the data
@@ -695,6 +791,8 @@ int TDigestModule_onLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     RMUtil_RegisterReadCmd(ctx, "tdigest.min", TDigestSketch_Min);
     RMUtil_RegisterReadCmd(ctx, "tdigest.max", TDigestSketch_Max);
     RMUtil_RegisterReadCmd(ctx, "tdigest.quantile", TDigestSketch_Quantile);
+    RMUtil_RegisterReadCmd(ctx, "tdigest.byrank", TDigestSketch_ByRank);
+    RMUtil_RegisterReadCmd(ctx, "tdigest.byrevrank", TDigestSketch_ByRevRank);
     RMUtil_RegisterReadCmd(ctx, "tdigest.cdf", TDigestSketch_Cdf);
     RMUtil_RegisterReadCmd(ctx, "tdigest.trimmed_mean", TDigestSketch_TrimmedMean);
     RMUtil_RegisterReadCmd(ctx, "tdigest.info", TDigestSketch_Info);


### PR DESCRIPTION
This PR Introduces 2 new commands: TDIGEST.BYRANK and TDIGEST.BYREVRANK

## TDIGEST.BYRANK key rank [rank...]

Retrieve an estimation of the value with the given rank.

- Accurate when rank is 0 (the value of the smallest observation).

- rank: an integer in [0 .. n-1] where n is the sum of weights of all observations in the sketch.

Return (processed according to this order):

-    Nan if the sketch is empty

 -   Error if rank is negative or not an integer

  -  +INF if rank is larger or equal to the the sum of weights of all observations in the sketch.

  -  A floating-point value


## TDIGEST.BYREVRANK key revrank [revrank...]

Retrieve an estimation of the value with the given reverse rank.

- Accurate when revrank is 0 (the value of the largest observation).

- revrank: an integer in [0 .. n-1] where n is the sum of weights of all observations in the sketch.

Return (processed according to this order): 

  -   NaN if the sketch is empty
 
 -    Error if revrank is negative or not an integer

   -  -INF if revrank is larger or equal to the sum of weights of all observations in the sketch.

   -  A floating-point value