### PR TITLE
Fixed tdigest max value on RDB load

### DIFF
--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -640,7 +640,7 @@ void *TDigestRdbLoad(RedisModuleIO *rdb, int encver) {
     const double compression = RedisModule_LoadDouble(rdb);
     td_histogram_t *tdigest = td_new(compression);
     tdigest->min = RedisModule_LoadDouble(rdb);
-    tdigest->min = RedisModule_LoadDouble(rdb);
+    tdigest->max = RedisModule_LoadDouble(rdb);
 
     // cap is the total size of nodes
     tdigest->cap = RedisModule_LoadSigned(rdb);

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -678,6 +678,8 @@ class testTDigest:
             self.assertOk(self.cmd("tdigest.add", "tdigest", 1.0, 1))
         self.assertEqual(True, self.cmd("SAVE"))
         mem_usage_prior_restart = self.cmd("MEMORY", "USAGE", "tdigest")
+        tdigest_min = self.cmd("tdigest.min", "tdigest")
+        tdigest_max = self.cmd("tdigest.max", "tdigest")
         self.restart_and_reload()
         # assert we have 100 unmerged nodes
         self.assertEqual(1, self.cmd("EXISTS", "tdigest"))
@@ -689,3 +691,5 @@ class testTDigest:
         )
         mem_usage_after_restart = self.cmd("MEMORY", "USAGE", "tdigest")
         self.assertEqual(mem_usage_prior_restart, mem_usage_after_restart)
+        self.assertEqual(tdigest_min, self.cmd("tdigest.min", "tdigest"))
+        self.assertEqual(tdigest_max, self.cmd("tdigest.max", "tdigest"))


### PR DESCRIPTION
The test `test_save_load` was extended to cover the min max values. As expected prior the fix the test failed. 

```
Test Took: 7 sec
Total Tests Run: 23, Total Tests Failed: 2, Total Tests Passed: 21
Failed Tests Summary:
	test_tdigest:testTDigest.test_save_load
		❌  (FAIL):	'1' == '-1.7976931348623157e+308'	test_tdigest.py:695
	test_tdigest:testTDigest.test_save_load
		❌  (FAIL):	'1' == '-1.7976931348623157e+308'	test_tdigest.py:695
```