### PR TITLE
 Ensure allocation check on TDIGEST.CREATE and TDIGEST.MERGE

### DIFF
--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -100,7 +100,10 @@ int TDigestSketch_Create(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
             return REDISMODULE_ERR;
         }
     }
-    tdigest = td_new(compression);
+    if (td_init(compression, &tdigest) != 0) {
+        RedisModule_CloseKey(key);
+        return RedisModule_ReplyWithError(ctx, "ERR T-Digest: allocation failed");
+    }
     if (RedisModule_ModuleTypeSetValue(key, TDigestSketchType, tdigest) != REDISMODULE_OK) {
         RedisModule_CloseKey(key);
         return RedisModule_ReplyWithError(ctx, "ERR T-Digest: error setting value");

--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -309,7 +309,10 @@ int TDigestSketch_Merge(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
             compression = td_compression > compression ? td_compression : compression;
         }
     }
-    tdigestTo = td_new(compression);
+    if (td_init(compression, &tdigestTo) != 0) {
+        RedisModule_ReplyWithError(ctx, "ERR T-Digest: allocation of destination digest failed");
+        goto cleanup;
+    }
     if (tdigestToStart != NULL && override == false) {
         td_merge(tdigestTo, tdigestToStart);
     }

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -58,10 +58,6 @@ class testTDigest:
             redis.exceptions.ResponseError, self.cmd, "tdigest.create", "tdigest", "compression", 100
         )
         self.cmd("DEL", "tdigest")
-        # failed allocation
-        self.assertRaises(
-            redis.exceptions.ResponseError, self.cmd, "tdigest.create", "tdigest", "compression", 10000000000000000
-        )
 
         # arity upper
         self.assertRaises(
@@ -86,6 +82,11 @@ class testTDigest:
         # wrong keyword
         self.assertRaises(
             redis.exceptions.ResponseError, self.cmd, "tdigest.create", "tdigest", "string", 100
+        )
+        self.cmd('FLUSHALL')
+        # failed allocation
+        self.assertRaises(
+           redis.exceptions.ResponseError, self.cmd, "tdigest.create", "tdigest", "compression", '100000000000000000000'
         )
 
     def test_tdigest_reset(self):
@@ -410,6 +411,11 @@ class testTDigest:
         self.assertRaises(
             redis.exceptions.ResponseError, self.cmd, "tdigest.merge", "to-tdigest-500", "1","from-1",
                                                       "bad_keyword", "500"
+        )
+        # allocation of destination digest failed
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.merge", "to-tdigest", "1","from-1",
+                                                      "COMPRESSION", "10000000000000000000"
         )
 
     def test_tdigest_min_max(self):

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -58,6 +58,11 @@ class testTDigest:
             redis.exceptions.ResponseError, self.cmd, "tdigest.create", "tdigest", "compression", 100
         )
         self.cmd("DEL", "tdigest")
+        # failed allocation
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.create", "tdigest", "compression", 10000000000000000
+        )
+
         # arity upper
         self.assertRaises(
             redis.exceptions.ResponseError, self.cmd, "tdigest.create", "tdigest", 100, 5,


### PR DESCRIPTION
Before we did not check that the allocation was indeed successful of the underlying data structure. This PR fixes it and adds tests to confirm we're indeed replying with an error in the case of failed allocations.  