### PR TITLE
Fixed REVRANK and BYREVRANK to be inverse of RANK and BYRANK

### DIFF
--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -442,8 +442,8 @@ static int _TDigest_Rank(RedisModuleCtx *ctx, RedisModuleString *const *argv, in
         } else if (vals[i] > max) {
             ranks[i] = reverse ? -1 : size;
         } else {
-            const double cdf_value = td_cdf(tdigest, vals[i]);
-            ranks[i] = round(reverse ? ((1 - cdf_value) * size) : (cdf_value * size));
+            const double cdf_to_absolute = round(td_cdf(tdigest, vals[i]) * size);
+            ranks[i] = round(reverse ? (size - cdf_to_absolute) : cdf_to_absolute);
         }
     }
 
@@ -541,8 +541,8 @@ static int _TDigest_ByRank(RedisModuleCtx *ctx, RedisModuleString *const *argv, 
         } else if (input_ranks[i] >= size) {
             values[i] = reverse ? -INFINITY : INFINITY;
         } else {
-            const double cdf_input =
-                reverse ? ((size - input_ranks[i]) / size) : (input_ranks[i] / size);
+            const double input_p = (input_ranks[i] / size);
+            const double cdf_input = reverse ? 1 - input_p : input_p;
             values[i] = td_quantile(tdigest, cdf_input);
         }
     }

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -609,17 +609,25 @@ class testTDigest:
         # -1 when value > value of the largest observation
         self.assertEqual(-1, float(self.cmd("tdigest.revrank", "tdigest", 20)[0]))
         # rank from cdf of min
-        self.assertEqual(20, float(self.cmd("tdigest.revrank", "tdigest", 0)[0]))
+        self.assertEqual(19, float(self.cmd("tdigest.revrank", "tdigest", 0)[0]))
         # rank from cdf of max
-        self.assertEqual(1, float(self.cmd("tdigest.revrank", "tdigest", 19)[0]))
+        self.assertEqual(0, float(self.cmd("tdigest.revrank", "tdigest", 19)[0]))
         # rank from cdf above max
         self.assertEqual(-1, float(self.cmd("tdigest.revrank", "tdigest", 50)[0]))
         # rank within [min,max]
         self.assertEqual(1, float(self.cmd("tdigest.revrank", "tdigest", 18)[0]))
-        self.assertEqual(10, float(self.cmd("tdigest.revrank", "tdigest", 10)[0]))
-        self.assertEqual(19, float(self.cmd("tdigest.revrank", "tdigest", 1)[0]))
+        self.assertEqual(9, float(self.cmd("tdigest.revrank", "tdigest", 10)[0]))
+        self.assertEqual(18, float(self.cmd("tdigest.revrank", "tdigest", 1)[0]))
         # multiple inputs test
-        self.assertEqual(["-1","20","10"], self.cmd("tdigest.revrank", "tdigest", 21, 0, 10))
+        self.assertEqual(["-1","19","9"], self.cmd("tdigest.revrank", "tdigest", 21, 0, 10))
+    
+    def test_tdigest_rank_and_revrank(self):
+        self.cmd('FLUSHALL')
+        self.assertOk(self.cmd("tdigest.create", "t", "compression","1000"))
+        self.assertOk(self.cmd('TDIGEST.ADD', 't', '1', '2', '2', '3', '3', '3', '4', '4', '4', '4', '5', '5', '5', '5', '5'))
+        self.assertEqual(['-1', '1', '2', '5', '8', '13', '15'], self.cmd('TDIGEST.RANK', 't', '0', '1', '2', '3', '4', '5', '6'))
+        self.assertEqual(['15', '14', '13', '10', '7', '2', '-1'], self.cmd('TDIGEST.REVRANK', 't', '0', '1', '2', '3', '4', '5', '6'))
+
 
     def test_negative_tdigest_rank(self):
         self.cmd('FLUSHALL')
@@ -665,7 +673,7 @@ class testTDigest:
         
     def test_tdigest_byrevrank(self):
         self.cmd('FLUSHALL')
-        self.assertOk(self.cmd("tdigest.create", "tdigest", "compression", 500))
+        self.assertOk(self.cmd("tdigest.create", "tdigest", "compression", 1000))
         # insert datapoints into sketch
         for x in range(1, 11):
             self.assertOk(self.cmd("tdigest.add", "tdigest", x))
@@ -677,7 +685,7 @@ class testTDigest:
         # inverse rank larger than total count
         self.assertEqual("-inf", self.cmd("tdigest.byrevrank", "tdigest", 100)[0])
         # inverse rank of N-1
-        self.assertEqual(2, float(self.cmd("tdigest.byrevrank", "tdigest", 9)[0]))
+        self.assertEqual(1.0, float(self.cmd("tdigest.byrevrank", "tdigest", 9)[0]))
 
     def test_negative_tdigest_byrank(self):
         self.cmd('FLUSHALL')


### PR DESCRIPTION
Before this PR due to rouding errors the reverse result input could be different than the inverse command. 