### PR TITLE
Revert "CircleCI: removed Redis 6.0 tests (#559)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -533,7 +533,7 @@ workflows:
           matrix:
             alias: build-with-redis-ver
             parameters:
-              redis_version: ["7", "unstable"]
+              redis_version: ["6.0", "7", "unstable"]
       - build-platforms:
           <<: *on-integ-and-version-tags
           context: common


### PR DESCRIPTION
This reverts commit 1040b2f638aa0bf3391e150f5b4370ee2381df70.