### PR TITLE
Ensuring we yeld some seconds on test_add_query_count after debug and reload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,7 +529,7 @@ workflows:
             - lint
       - build:
           name: build-with-redis-<<matrix.redis_version>>
-          <<: *on-any-branch
+          <<: *on-integ-and-version-tags
           matrix:
             alias: build-with-redis-ver
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,7 +529,7 @@ workflows:
             - lint
       - build:
           name: build-with-redis-<<matrix.redis_version>>
-          <<: *on-integ-and-version-tags
+          <<: *on-any-branch
           matrix:
             alias: build-with-redis-ver
             parameters:

--- a/tests/flow/test_topk.py
+++ b/tests/flow/test_topk.py
@@ -58,7 +58,9 @@ class testTopK():
     def test_add_query_count(self):
         self.cmd('FLUSHALL')
         self.assertTrue(self.cmd('topk.reserve', 'topk', '20', '50', '5', '0.9'))
+        yield 1
         self.env.dumpAndReload(restart=True) # prevent error `Background save already in progress`
+        yield 2
 
         self.cmd('topk.add', 'topk', 'bar', 'baz', '42')
         self.assertEqual([1], self.cmd('topk.query', 'topk', 'bar'))


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/RedisBloom/RedisBloom/2122/workflows/e411fd60-005f-46e9-bb00-62fc60c3d99d/jobs/8773

Confirmation that the fix works as expected: https://app.circleci.com/pipelines/github/RedisBloom/RedisBloom/2125/workflows/2ae30d75-88d0-4a98-8022-95e2124cf4ec/jobs/8797