### PR TITLE
Fixed test_no_init_params() float comparison

### DIFF
--- a/tests/flow/test_topk.py
+++ b/tests/flow/test_topk.py
@@ -167,8 +167,10 @@ class testTopK():
         self.assertEqual(['foo', 'baz', 'bar'], heapList)
 
         info = self.cmd('topk.info', 'topk')
-        expected_info = ['k', 3, 'width', 8, 'depth', 7, 'decay', '0.90000000000000002']
-        self.assertEqual(expected_info, info)
+        expected_info = ['k', 3, 'width', 8, 'depth', 7, 'decay']
+        expected_decay = float('0.90000000000000002')
+        self.assertEqual(expected_info, info[:-1])
+        self.assertEqual(expected_decay, float(info[-1:][0]))
 
     def test_list_with_count(self):
         self.cmd('FLUSHALL')


### PR DESCRIPTION
Fixes:

Context:
After https://github.com/redis/redis/pull/10587 we now reply with the least possible number of digits that will be IEEE DP compliant. This PR fixes the comparison to use the float value instead of the string representation. In that manner, the test will work on all redis versions.  