### PR TITLE
Add new command BF.CARD

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -229,6 +229,18 @@
     "since": "1.0.0",
     "group": "bf"
   },
+  "BF.CARD": {
+    "summary": "Returns the cardinality (number of items inserted) of the bloom filter stored at key.",
+    "complexity": "O(1)",
+    "arguments": [
+      {
+        "name": "key",
+        "type": "key"
+      }
+    ],
+    "since": "1.0.0",
+    "group": "bf"
+  },
   "CF.RESERVE": {
     "summary": "Creates a new Cuckoo Filter",
     "complexity": "O(1)",

--- a/docs/commands/bf.card.md
+++ b/docs/commands/bf.card.md
@@ -1,0 +1,20 @@
+Returns the cardinality (number of items inserted) of the bloom filter stored at key.
+
+### Parameters
+
+* **key**: The name of the filter
+
+@return
+
+@integer-reply - the cardinality (number of items inserted) of the bloom filter, or 0 if key does not exist.
+
+@examples
+
+```
+redis> BF.ADD item1 item_foo
+(integer) 1
+redis> BF.CARD item1
+(integer) 1
+redis> BF.CARD item_new
+(integer) 0
+```

--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -954,6 +954,28 @@ static int BFInfo_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, in
     return REDISMODULE_OK;
 }
 
+static int BFCard_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    RedisModule_AutoMemory(ctx);
+    if (argc != 2) {
+        return RedisModule_WrongArity(ctx);
+    }
+
+    SBChain *bf;
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ);
+    if (key == NULL) {
+        RedisModule_ReplyWithLongLong(ctx, 0);
+        return REDISMODULE_OK;
+    }
+    int status = bfGetChain(key, &bf);
+    if (status != REDISMODULE_OK) {
+        return RedisModule_ReplyWithError(ctx, statusStrerror(status));
+    }
+
+    RedisModule_ReplyWithLongLong(ctx, bf->size);
+
+    return REDISMODULE_OK;
+}
+
 uint64_t CFSize(CuckooFilter *cf) {
     uint64_t numBuckets = 0;
     for (uint16_t ii = 0; ii < cf->numFilters; ++ii) {
@@ -1324,6 +1346,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     CREATE_ROCMD("bf.exists", BFCheck_RedisCommand);
     CREATE_ROCMD("bf.mexists", BFCheck_RedisCommand);
     CREATE_ROCMD("bf.info", BFInfo_RedisCommand);
+    CREATE_ROCMD("bf.card", BFCard_RedisCommand);
 
     // Bloom - Debug
     CREATE_ROCMD("bf.debug", BFDebug_RedisCommand);

--- a/tests/flow/test_overall.py
+++ b/tests/flow/test_overall.py
@@ -341,6 +341,16 @@ class testRedisBloom():
         with env.assertResponseError():
             env.cmd('bf.info', 'bf', 'wrong_value')
 
+    def test_card(self):
+        self.cmd('FLUSHALL')
+        self.assertEqual(self.cmd('bf.card not_exist'), 0)
+        self.assertOk(self.cmd('bf.reserve', 'bf', '0.001', '100'))
+        self.assertEqual(self.cmd('bf.card bf'), 0)
+        self.assertOk(self.cmd('bf.add', 'bf', 'foo'))
+        self.assertEqual(self.cmd('bf.card bf'), 1)
+        with self.assertResponseError():
+            self.cmd('bf.card')
+
     def test_no_1_error_rate(self):
         env = self.env
         env.cmd('FLUSHALL')

--- a/tests/flow/test_overall.py
+++ b/tests/flow/test_overall.py
@@ -342,14 +342,18 @@ class testRedisBloom():
             env.cmd('bf.info', 'bf', 'wrong_value')
 
     def test_card(self):
-        self.cmd('FLUSHALL')
-        self.assertEqual(self.cmd('bf.card not_exist'), 0)
-        self.assertOk(self.cmd('bf.reserve', 'bf', '0.001', '100'))
-        self.assertEqual(self.cmd('bf.card bf'), 0)
-        self.assertOk(self.cmd('bf.add', 'bf', 'foo'))
-        self.assertEqual(self.cmd('bf.card bf'), 1)
-        with self.assertResponseError():
-            self.cmd('bf.card')
+        env = self.env
+        env.cmd('FLUSHALL')
+        env.assertEqual(env.cmd('bf.card not_exist'), 0)
+        env.assertOk(env.cmd('bf.reserve', 'bf', '0.001', '100'))
+        env.assertEqual(env.cmd('bf.card bf'), 0)
+        env.assertEqual(env.cmd('bf.add', 'bf', 'foo'), 1)
+        env.assertEqual(env.cmd('bf.card bf'), 1)
+        with env.assertResponseError():
+            env.cmd('bf.card')
+        with env.assertResponseError():
+            env.cmd('set', 'key:string', 'foo')
+            env.cmd('bf.card', 'key:string')
 
     def test_no_1_error_rate(self):
         env = self.env


### PR DESCRIPTION
As discussion in #389 ,  we introduce a new command `BF.CARD`, which returns the cardinality (number of items inserted) of the bloom filter stored at key.
As mentioned in #389 , `BF.CARD`:
> Return 0 when key does not exist.
> Error when key is of a type other than Bloom filter.
> Note: when key exists - return the same value as BF.INFO key ITEMS.