### PR TITLE
Enabled Pull Request CI Performance info generation and publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,6 +278,16 @@ commands:
               --fail_fast \
               --push_results_redistimeseries \
               --allowed-envs << parameters.allowed_envs >>
+      - run:
+          name: Generate Pull Request Performance info
+          command: |
+            if [[ -n ${CIRCLE_PULL_REQUEST##*/} ]]; then
+                redisbench-admin compare  \
+                  --defaults_filename ./tests/benchmarks/defaults.yml \
+                  --comparison-branch $CIRCLE_BRANCH \
+                  --auto-approve \
+                  --pull-request ${CIRCLE_PULL_REQUEST##*/}
+            fi
 
 jobs:
   lint:

--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -18,3 +18,8 @@ exporter:
       - "$.Tests.Overall.min_latency_ms"
       - '$."ALL STATS".*."Ops/sec"'
       - '$."ALL STATS".*."Latency"'
+  comparison:
+    metrics:
+      - "Ops/sec"
+    mode: higher-better
+    baseline-branch: master

--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -21,5 +21,6 @@ exporter:
   comparison:
     metrics:
       - "Ops/sec"
+      - "Tests.Overall.rps"
     mode: higher-better
     baseline-branch: master


### PR DESCRIPTION
This PR enables Automated performance analysis summaries to be generated and published to PRs that are labeled with `action:run-benchmark` label.
- Here's a sample output of a PR comment: https://github.com/RedisGraph/RedisGraph/pull/2789#issuecomment-1371139517
- Notice that multiples pushes to the PR will always update the previous comment to avoid bloating the PR. 