### PR TITLE
[BUG] SubCF->numBuckets change to uint64

### DIFF
--- a/src/cuckoo.h
+++ b/src/cuckoo.h
@@ -25,8 +25,8 @@ typedef uint8_t CuckooBucket[1];
 typedef uint8_t MyCuckooBucket;
 
 typedef struct {
-    uint32_t numBuckets;
-    uint8_t bucketSize;
+    uint64_t numBuckets : 56;
+    uint64_t bucketSize : 8;
     MyCuckooBucket *data;
 } SubCF;
 


### PR DESCRIPTION
This is a bug fix for issue #609.
unit_32 was used and get replaced with unit_64 as a 56 bit field which is more than enough for any imaginable system.
size 
Note: The decision to not introduce a new independent variable was in order to avoid a breaking change as the size of the filter in CF.INFO would change.

Fixes #609 