### PR TITLE
Fixed syntax error in TDIGEST.CREATE example

### DIFF
--- a/docs/commands/tdigest.create.md
+++ b/docs/commands/tdigest.create.md
@@ -19,6 +19,6 @@ is a controllable tradeoff between accuracy and memory consumption. 100 is a com
 ## Examples
 
 {{< highlight bash >}}
-redis> TDIGEST.CREATE t 100
+redis> TDIGEST.CREATE t COMPRESSION 100
 OK
 {{< / highlight >}}


### PR DESCRIPTION
Without the `COMPRESSION` modifier the command doesn't work, this commit fixes that:

```
 > tdigest.create tdig 100
"ERR wrong number of arguments for 'tdigest.create' command"

 > tdigest.create tdig compression 100
"OK"
```