### PR TITLE
Ensure CF.COUNT does not use bool response for resp3

### DIFF
--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -770,7 +770,7 @@ static int CFCheck_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, i
 
     for (size_t ii = 2; ii < argc; ++ii) {
         if (is_empty == 1) {
-            if (_is_resp3(ctx)) {
+            if (_is_resp3(ctx) && !is_count) {
                 RedisModule_ReplyWithBool(ctx, 0);
             } else {
                 RedisModule_ReplyWithLongLong(ctx, 0);

--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -785,7 +785,7 @@ static int CFCheck_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv, i
             } else {
                 rv = CuckooFilter_Check(cf, hash);
             }
-            if (_is_resp3(ctx)) {
+            if (_is_resp3(ctx) && !is_count) {
                 RedisModule_ReplyWithBool(ctx, !!rv);
             } else {
                 RedisModule_ReplyWithLongLong(ctx, rv);

--- a/tests/flow/test_resp3.py
+++ b/tests/flow/test_resp3.py
@@ -86,6 +86,12 @@ class testResp3():
         res = env.cmd('CF.MEXISTS a 4 3')
         assert type(res[0]) == bool
         env.assertEqual(res, [True, False])
+        res = env.cmd('CF.COUNT a 3')
+        assert type(res) == int
+        env.assertEqual(res, 0)
+        res = env.cmd('CF.COUNT a 4')
+        assert type(res) == int
+        env.assertEqual(res, 2)
 
         res = env.cmd('cf.info a')
         assert res == {b'Size': 64, b'Number of buckets': 4,


### PR DESCRIPTION
# Description
As of the change in #638 `CFCheck_RedisCommand` now returns boolean for all cases when used with RESP3. The fix is to ensure that if `CFCheck_RedisCommand` is used with `CF.COUNT` it always returns a `longlong`


This was noticed in a CI run for [coredis](https://github.com/alisaifee/coredis/actions/runs/4832143187/jobs/8615175533) which tests against the redis-stack@edge docker image with resp3.