### PR TITLE
Adding links to learning resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ Answering each of these questions accurately can require a huge amount of memory
 
 RedisBloom is part of [Redis Stack](https://github.com/redis-stack).
 
+### How do I Redis?
+
+[Learn for free at Redis University](https://university.redis.com/)
+
+[Build faster with the Redis Launchpad](https://launchpad.redis.com/)
+
+[Try the Redis Cloud](https://redis.com/try-free/)
+
+[Dive in developer tutorials](https://developer.redis.com/)
+
+[Join the Redis community](https://redis.com/community/)
+
+[Work at Redis](https://redis.com/company/careers/jobs/)
+
 ## Setup
 
 You can either get RedisBloom setup in a Docker container or on your own machine.


### PR DESCRIPTION
This pull request adds links to the README for various, general Redis learning resources. The aim is to bring them in line with the clients, that already do this. 

We're trying to help people, generally, better learn how to Redis.
