### PR TITLE
Update commands.json: TDIGEST.ADD: remove redundant values block

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -805,15 +805,9 @@
         "type": "key"
       },
       {
-        "name": "values",
+        "name": "value",
         "type": "block",
-        "multiple": true,
-        "arguments": [
-          {
-            "name": "value",
-            "type": "double"
-          }
-        ]
+        "multiple": true
       }
     ],
     "since": "2.4.0",


### PR DESCRIPTION
Hey, I'm working on an awesome Redis client library in Go called [redis/rueidis](https://github.com/redis/rueidis),
and I found that the command.json for `TDIGEST.ADD` is a little bit redundant.

The values block can be replaced by a `value` argument with `multiple=true`.