### PR TITLE
Use RLTest 0.7.5

### DIFF
--- a/tests/flow/requirements.txt
+++ b/tests/flow/requirements.txt
@@ -1,2 +1,2 @@
-RLTest ~= 0.7.2
+RLTest == 0.7.5
 numpy


### PR DESCRIPTION
Latest RLTest version 0.7.7 throws some errors. 
We can stick to version 0.7.5 for now until those issues are resolved. 