### PR TITLE
Allow empty string as topk item

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -16,6 +16,7 @@ jobs:
         submodules: true
     - name: Setup
       run: |
+        pip install --upgrade setuptools
         ./sbin/setup
         export GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}"
         ./deps/readies/bin/getredis -v 7 --with-github-token

--- a/src/topk.c
+++ b/src/topk.c
@@ -112,7 +112,6 @@ static HeapBucket *checkExistInHeap(TopK *topk, const char *item, size_t itemlen
 char *TopK_Add(TopK *topk, const char *item, size_t itemlen, uint32_t increment) {
     assert(topk);
     assert(item);
-    assert(itemlen);
 
     Bucket *runner;
     counter_t *countPtr;
@@ -187,7 +186,6 @@ bool TopK_Query(TopK *topk, const char *item, size_t itemlen) {
 size_t TopK_Count(TopK *topk, const char *item, size_t itemlen) {
     assert(topk);
     assert(item);
-    assert(itemlen);
 
     Bucket *runner = NULL;
     uint32_t fp = TOPK_HASH(item, itemlen, GA);

--- a/tests/flow/requirements.txt
+++ b/tests/flow/requirements.txt
@@ -1,2 +1,2 @@
-RLTest ~= 0.7.2
+RLTest == 0.7.5
 numpy

--- a/tests/flow/test_topk.py
+++ b/tests/flow/test_topk.py
@@ -194,3 +194,29 @@ class testTopK():
         self.cmd('topk.add', 'topk', 'Lets\nCrash')
         res = self.cmd('TOPK.LIST', 'topk')
         assert res == ['Lets\nCrash']
+
+    def test_empty_string(self):
+        self.cmd('FLUSHALL')
+        self.cmd('topk.reserve', 'topk', '3')
+        self.cmd('topk.add', 'topk', '')
+
+        self.assertEqual(self.cmd('topk.list', 'topk'), [''])
+        self.assertEqual(self.cmd('topk.list', 'topk', 'withcount'), ['', 1])
+        self.assertEqual(self.cmd('topk.query', 'topk', ''), [1])
+        self.assertEqual(self.cmd('topk.count', 'topk', ''), [1])
+
+        self.cmd('topk.incrby', 'topk', '', 100)
+        self.assertEqual(self.cmd('topk.list', 'topk', 'withcount'), ['', 101])
+
+        self.cmd('topk.add', 'topk', 'foo', 'bar', 'baz')
+        self.cmd('topk.add', 'topk', 'foo', 'bar', 'baz', '')
+        self.cmd('topk.add', 'topk', 'foo', 'bar', '')
+        self.cmd('topk.add', 'topk', 'foo', '')
+        heapList = self.cmd('topk.list', 'topk', 'WITHCOUNT')
+        self.assertEqual(['', 104, 'foo', 4, 'bar', 3], heapList)
+        self.assertEqual(self.cmd('topk.query', 'topk', 'bla', 'foo', ''), [0, 1, 1])
+
+        self.cmd('topk.incrby', 'topk', 'foo', 500, 'bar', 500, 'baz', 500)
+        heapList = self.cmd('topk.list', 'topk', 'WITHCOUNT')
+        self.assertEqual(['foo', 504, 'bar', 503, 'baz', 502], heapList)
+


### PR DESCRIPTION
see RED-114676, allow empty string as topk item

Currently, if topk.add or topk.query has item name as empty string, it will crash Redis due to asserts() in the code.

e.g.
topk.add mykey <empty> 
topk.incrby mykey <empty> 100

Deleting asserts to allow empty string as item name. It will prevent the crash and it will be in line with other commands.