### PR TITLE
Add setuptools package to python dependencies to fix MacOS build

### DIFF
--- a/tests/flow/requirements.txt
+++ b/tests/flow/requirements.txt
@@ -1,2 +1,5 @@
+# MacOS setup on github actions needs setuptools (required by RLTest).
+# Normally, it would be better RLTest have this package as dependency.
+setuptools
 RLTest == 0.7.5
 numpy


### PR DESCRIPTION
```
    File "/Users/runner/Library/Python/3.12/lib/python/site-packages/RLTest/__init__.py", line 3, in <module>
      from ._version import __version__
    File "/Users/runner/Library/Python/3.12/lib/python/site-packages/RLTest/_version.py", line 4, in <module>
      import pkg_resources
  ModuleNotFoundError: No module named 'pkg_resources'
```
MacOS build on github actions fails with above error: [link](https://github.com/RedisBloom/RedisBloom/actions/runs/7284882607/job/19850896589)

Looks like RLTest needs `setuptools` package and it does not come by default on this macOS build. 

