### PR TITLE
MOD-6268 Fix crash when error rate is very high

### DIFF
--- a/deps/bloom/bloom.c
+++ b/deps/bloom/bloom.c
@@ -147,7 +147,13 @@ int bloom_init(struct bloom *bloom, uint64_t entries, double error, unsigned opt
 
     } else if (options & BLOOM_OPT_NOROUND) {
         // Don't perform any rounding. Conserve memory instead
-        bits = bloom->bits = (uint64_t)(entries * bloom->bpe);
+        bits = (uint64_t)(entries * bloom->bpe);
+
+        // Guard against very small 'bpe'. Have at least one bit in the filter.
+        if (bits == 0) {
+            bits = 1;
+        }
+        bloom->bits = bits;
         bloom->n2 = 0;
 
     } else {

--- a/tests/flow/test_overall.py
+++ b/tests/flow/test_overall.py
@@ -425,6 +425,20 @@ class testRedisBloom():
         env.assertEqual(info["Capacity"], 300000000)
         env.assertEqual(info["Size"], 1132420232)
 
+    def test_very_high_error_rate(self):
+        env = self.env
+        env.cmd('FLUSHALL')
+
+        env.cmd('bf.reserve', 'bf1', 0.99, 3, "NONSCALING")
+        env.cmd('bf.add', 'bf1', 1)
+
+        env.cmd('bf.reserve', 'bf2', 0.95, 8, "NONSCALING")
+        env.cmd('bf.add', 'bf2', 1)
+
+        env.cmd('bf.reserve', 'bf3', 0.9999999999999999, 100, "NONSCALING")
+        env.cmd('bf.add', 'bf3', 1)
+
+
 class testRedisBloomNoCodec():
     def __init__(self):
         self.env = Env(decodeResponses=False)


### PR DESCRIPTION
Crash scenario:

```
BF.RESERVE b 0.99 3 NONSCALING
BF.ADD b 1
```

It seems like crash is only possible with NONSCALING filters with a very high error rate and relatively small capacity. 
Creating filter with these parameters does not make much sense but it can happen if wrong arguments are passed. 

With the above parameters, we calculate number of required bits in the filter as zero and it leads to crash later. 
To fix the issue, we can limit minimum number of bits to 1.
