### PR TITLE
MOD-6343 Fix potential crash for cf.reserve

### DIFF
--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -541,8 +541,8 @@ static int CFReserve_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
         if (RedisModule_StringToLongLong(argv[mi_loc + 1], &maxIterations) != REDISMODULE_OK) {
             return RedisModule_ReplyWithError(ctx, "Couldn't parse MAXITERATIONS");
         } else if (maxIterations <= 0 || maxIterations > CF_MAX_ITERATIONS) {
-            return RedisModule_ReplyWithError(
-                ctx, "MAXITERATIONS parameter must be between 1 and 65535 (both are inclusive).");
+            return RedisModule_ReplyWithError(ctx, "MAXITERATIONS parameter must be an integer "
+                                                   "between 1 and 65535 (both are inclusive).");
         }
     }
 
@@ -553,7 +553,8 @@ static int CFReserve_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
             return RedisModule_ReplyWithError(ctx, "Couldn't parse BUCKETSIZE");
         } else if (bucketSize <= 0 || bucketSize > CF_MAX_BUCKET_SIZE) {
             return RedisModule_ReplyWithError(
-                ctx, "BUCKETSIZE parameter must be between 1 and 255 (both are inclusive).");
+                ctx,
+                "BUCKETSIZE parameter must be an integer between 1 and 255 (both are inclusive).");
         }
     }
 
@@ -564,7 +565,8 @@ static int CFReserve_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
             return RedisModule_ReplyWithError(ctx, "Couldn't parse EXPANSION");
         } else if (expansion < 0 || expansion > CF_MAX_EXPANSION) {
             return RedisModule_ReplyWithError(
-                ctx, "EXPANSION parameter must be between 0 and 32768 (both are inclusive).");
+                ctx,
+                "EXPANSION parameter must be an integer between 0 and 32768 (both are inclusive).");
         }
     }
 

--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -541,8 +541,8 @@ static int CFReserve_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
         if (RedisModule_StringToLongLong(argv[mi_loc + 1], &maxIterations) != REDISMODULE_OK) {
             return RedisModule_ReplyWithError(ctx, "Couldn't parse MAXITERATIONS");
         } else if (maxIterations <= 0 || maxIterations > CF_MAX_ITERATIONS) {
-            return RedisModule_ReplyWithError(ctx, "MAXITERATIONS parameter must be an integer "
-                                                   "between 1 and 65535 (both are inclusive).");
+            return RedisModule_ReplyWithError(
+                ctx, "MAXITERATIONS: value must be an integer between 1 and 65535, inclusive.");
         }
     }
 
@@ -553,8 +553,7 @@ static int CFReserve_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
             return RedisModule_ReplyWithError(ctx, "Couldn't parse BUCKETSIZE");
         } else if (bucketSize <= 0 || bucketSize > CF_MAX_BUCKET_SIZE) {
             return RedisModule_ReplyWithError(
-                ctx,
-                "BUCKETSIZE parameter must be an integer between 1 and 255 (both are inclusive).");
+                ctx, "BUCKETSIZE: value must be an integer between 1 and 255, inclusive.");
         }
     }
 
@@ -565,8 +564,7 @@ static int CFReserve_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
             return RedisModule_ReplyWithError(ctx, "Couldn't parse EXPANSION");
         } else if (expansion < 0 || expansion > CF_MAX_EXPANSION) {
             return RedisModule_ReplyWithError(
-                ctx,
-                "EXPANSION parameter must be an integer between 0 and 32768 (both are inclusive).");
+                ctx, "EXPANSION: value must be an integer between 0 and 32768, inclusive.");
         }
     }
 

--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -25,9 +25,12 @@
 #define REDISBLOOM_GIT_SHA "unknown"
 #endif
 
-#define CF_MAX_ITERATIONS 20
+#define CF_DEFAULT_MAX_ITERATIONS 20
 #define CF_DEFAULT_BUCKETSIZE 2
 #define CF_DEFAULT_EXPANSION 1
+#define CF_MAX_EXPANSION 32768
+#define CF_MAX_BUCKET_SIZE 255
+#define CF_MAX_ITERATIONS 65535
 #define BF_DEFAULT_EXPANSION 2
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -108,8 +111,8 @@ static SBChain *bfCreateChain(RedisModuleKey *key, double error_rate, size_t cap
     return sb;
 }
 
-static CuckooFilter *cfCreate(RedisModuleKey *key, size_t capacity, size_t bucketSize,
-                              size_t maxIterations, size_t expansion) {
+static CuckooFilter *cfCreate(RedisModuleKey *key, size_t capacity, uint16_t bucketSize,
+                              uint16_t maxIterations, uint16_t expansion) {
     if (capacity < bucketSize * 2)
         return NULL;
 
@@ -532,14 +535,14 @@ static int CFReserve_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
         return RedisModule_ReplyWithError(ctx, "Bad capacity");
     }
 
-    long long maxIterations = CF_MAX_ITERATIONS;
+    long long maxIterations = CF_DEFAULT_MAX_ITERATIONS;
     int mi_loc = RMUtil_ArgIndex("MAXITERATIONS", argv, argc);
     if (mi_loc != -1) {
         if (RedisModule_StringToLongLong(argv[mi_loc + 1], &maxIterations) != REDISMODULE_OK) {
             return RedisModule_ReplyWithError(ctx, "Couldn't parse MAXITERATIONS");
-        } else if (maxIterations <= 0) {
+        } else if (maxIterations <= 0 || maxIterations > CF_MAX_ITERATIONS) {
             return RedisModule_ReplyWithError(
-                ctx, "MAXITERATIONS parameter needs to be a positive integer");
+                ctx, "MAXITERATIONS parameter must be between 1 and 65535 (both are inclusive).");
         }
     }
 
@@ -548,9 +551,9 @@ static int CFReserve_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     if (bs_loc != -1) {
         if (RedisModule_StringToLongLong(argv[bs_loc + 1], &bucketSize) != REDISMODULE_OK) {
             return RedisModule_ReplyWithError(ctx, "Couldn't parse BUCKETSIZE");
-        } else if (bucketSize <= 0) {
+        } else if (bucketSize <= 0 || bucketSize > CF_MAX_BUCKET_SIZE) {
             return RedisModule_ReplyWithError(
-                ctx, "BUCKETSIZE parameter needs to be a positive integer");
+                ctx, "BUCKETSIZE parameter must be between 1 and 255 (both are inclusive).");
         }
     }
 
@@ -559,9 +562,9 @@ static int CFReserve_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv,
     if (ex_loc != -1) {
         if (RedisModule_StringToLongLong(argv[ex_loc + 1], &expansion) != REDISMODULE_OK) {
             return RedisModule_ReplyWithError(ctx, "Couldn't parse EXPANSION");
-        } else if (expansion < 0) {
+        } else if (expansion < 0 || expansion > CF_MAX_EXPANSION) {
             return RedisModule_ReplyWithError(
-                ctx, "EXPANSION parameter needs to be a non-negative integer");
+                ctx, "EXPANSION parameter must be between 0 and 32768 (both are inclusive).");
         }
     }
 
@@ -599,7 +602,7 @@ static int cfInsertCommon(RedisModuleCtx *ctx, RedisModuleString *keystr, RedisM
     int status = cfGetFilter(key, &cf);
 
     if (status == SB_EMPTY && options->autocreate) {
-        if ((cf = cfCreate(key, options->capacity, CF_DEFAULT_BUCKETSIZE, CF_MAX_ITERATIONS,
+        if ((cf = cfCreate(key, options->capacity, CF_DEFAULT_BUCKETSIZE, CF_DEFAULT_MAX_ITERATIONS,
                            CF_DEFAULT_EXPANSION)) == NULL) {
             return RedisModule_ReplyWithError(ctx, "Could not create filter"); // LCOV_EXCL_LINE
         }
@@ -1256,7 +1259,7 @@ static void *CFRdbLoad(RedisModuleIO *io, int encver) {
     if (encver < CF_MIN_EXPANSION_VERSION) { // CF_ENCODING_VERSION when added
         cf->numDeletes = 0;                  // Didn't exist earlier. bug fix
         cf->bucketSize = CF_DEFAULT_BUCKETSIZE;
-        cf->maxIterations = CF_MAX_ITERATIONS;
+        cf->maxIterations = CF_DEFAULT_MAX_ITERATIONS;
         cf->expansion = CF_DEFAULT_EXPANSION;
     } else {
         cf->numDeletes = RedisModule_LoadUnsigned(io);

--- a/tests/flow/test_cuckoo.py
+++ b/tests/flow/test_cuckoo.py
@@ -346,6 +346,19 @@ class testCuckoo():
         self.assertRaises(ResponseError, self.cmd, 'CF.LOADCHUNK err iterator') # missing data
         self.assertRaises(ResponseError, self.cmd, 'CF.SCANDUMP err')
 
+    def test_reserve_limits(self):
+        self.cmd('FLUSHALL')
+        self.assertRaises(ResponseError, self.cmd, 'CF.RESERVE cf 100 BUCKETSIZE 33554432')
+        self.assertRaises(ResponseError, self.cmd, 'CF.RESERVE cf 100 MAXITERATIONS 165536')
+        self.assertRaises(ResponseError, self.cmd, 'CF.RESERVE cf 100 EXPANSION 327695')
+        self.assertRaises(ResponseError, self.cmd, 'CF.RESERVE CF 67108864 BUCKETSIZE 33554432 MAXITERATIONS 1337 EXPANSION 1337')
+
+        self.cmd('CF.RESERVE cf 67108864 BUCKETSIZE 255 MAXITERATIONS 65535 EXPANSION 32768')
+        info = self.cmd('CF.INFO cf')
+        self.assertEqual(info[info.index('Bucket size') + 1], 255)
+        self.assertEqual(info[info.index('Expansion rate') + 1], 32768)
+        self.assertEqual(info[info.index('Max iterations') + 1], 65535)
+
 class testCuckooNoCodec():
     def __init__(self):
         self.env = Env(decodeResponses=False)


### PR DESCRIPTION
Currently, there is no upper bound check for cf.reserve arguments BUCKETSIZE, MAXITERATIONS and EXPANSION. 
Accepting a large value for these arguments can cause a crash due to overflow e.g.:

```
CF.RESERVE CF 67108864 BUCKETSIZE 33554432
```

Deciding upper limits for these arguments:

```
typedef struct {
    uint64_t numBuckets : 56;
    uint64_t bucketSize : 8;
    MyCuckooBucket *data;
} SubCF;

typedef struct {
    ....
    uint16_t bucketSize;
    uint16_t maxIterations;
    uint16_t expansion;
    SubCF *filters;
} CuckooFilter;
```

- For BUCKETSIZE, we store it in 8 bits inside struct SubCF. It makes upper limit for BUCKETSIZE: 255
- MAXITERATIONS is stored as uint16_t which makes upper limit: 65535
- EXPANSION is stored as uint16_t as well but it is required to be power of two: 32768

Although it seems algorithm can handle higher upper limits, this PR does not increase
storage for these arguments not to increase memory usage for the most common cases.

**Potentially breaking change**
Currently, if users are passing higher values than these limits, it might still work. 
Though, it is not a well-defined behavior and these usages might have bugs in it. 
After this PR, these cf.reserve calls will get error reply. 



