### PR TITLE
MOD-6344 Fix potential crash for cf.scandump and cf.loadchunk

### DIFF
--- a/src/cf.c
+++ b/src/cf.c
@@ -84,7 +84,7 @@ const char *CF_GetEncodedChunk(const CuckooFilter *cf, long long *pos, size_t *b
 }
 
 int CF_LoadEncodedChunk(const CuckooFilter *cf, long long pos, const char *data, size_t datalen) {
-    if (datalen == 0) {
+    if (datalen == 0 || pos <= 0 || (size_t)(pos - 1) < datalen) {
         return REDISMODULE_ERR;
     }
 
@@ -100,6 +100,12 @@ int CF_LoadEncodedChunk(const CuckooFilter *cf, long long pos, const char *data,
             break;
         }
         offset -= currentSize;
+    }
+
+    // Boundary check before memcpy()
+    if (!filter || ((size_t)offset > SIZE_MAX - datalen) ||
+        filter->bucketSize * filter->numBuckets < offset + datalen) {
+        return REDISMODULE_ERR;
     }
 
     // copy data to filter

--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -850,7 +850,7 @@ static int CFScanDump_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **argv
     }
 
     long long pos;
-    if (RedisModule_StringToLongLong(argv[2], &pos) != REDISMODULE_OK) {
+    if (RedisModule_StringToLongLong(argv[2], &pos) != REDISMODULE_OK || pos < 0) {
         return RedisModule_ReplyWithError(ctx, "Invalid position");
     }
 

--- a/tests/flow/test_cuckoo.py
+++ b/tests/flow/test_cuckoo.py
@@ -454,3 +454,13 @@ class testCuckooNoCodec():
         # check loaded filter
         for x in range(6):
             self.assertEqual(1, self.cmd('cf.exists', 'cf', 'foo'))
+
+    def test_scandump_invalid(self):
+        self.cmd('FLUSHALL')
+        self.cmd('cf.reserve', 'cf', 4)
+        self.assertRaises(ResponseError, self.cmd, 'cf.loadchunk', 'cf', '-9223372036854775808', '1')
+        self.assertRaises(ResponseError, self.cmd, 'cf.loadchunk', 'cf', '922337203685477588', '1')
+        self.assertRaises(ResponseError, self.cmd, 'cf.loadchunk', 'cf', '4', 'kdoasdksaodsadsadsadsadsadadsadadsdad')
+        self.assertRaises(ResponseError, self.cmd, 'cf.loadchunk', 'cf', '4', 'abcd')
+        self.cmd('cf.add', 'cf', 'x')
+        self.assertRaises(ResponseError, self.cmd, 'cf.scandump', 'cf', '-1')


### PR DESCRIPTION
Add boundary checks for cf.scandump and cf.loadchunk