### PR TITLE
Upload artifacts from ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,42 +159,42 @@ commands:
             make test <<parameters.test_params>> SHOW=1
       - save-tests-logs
 
-  build-platforms-steps:
-    parameters:
-      platform:
-        type: string
-    steps:
-      - early-returns
-      - setup-executor
-      - checkout-all
-      - install-prerequisites
-      - run:
-          name: Build for platform
-          command: |
-            ROOT=$PWD
-            cd build/docker
-            make build OSNICK=<<parameters.platform>> VERSION="$CIRCLE_TAG" BRANCH="$CIRCLE_BRANCH" TEST=1 OFFICIAL=1 SHOW=1
-            cd $ROOT
-            mkdir -p tests/flow/logs
-            tar -C tests/flow/logs -xzf bin/artifacts/tests-flow-logs*.tgz
-          no_output_timeout: 30m
-      - save-tests-logs
-      - early-return-for-forked-pull-requests
-      - run:
-          name: Upload artifacts to S3
-          shell: /bin/bash -l -eo pipefail
-          command: |
-            if [[ -n $CIRCLE_BRANCH ]]; then
-                make upload-artifacts OSNICK=<<parameters.platform>> SHOW=1 VERBOSE=1
-            fi
-      - run:
-          name: Publish container
-          shell: /bin/bash -l -eo pipefail
-          command: |
-            docker login -u redisfab -p $DOCKER_REDISFAB_PWD
-            cd build/docker
-            make publish OSNICK=<<parameters.platform>> VERSION="$CIRCLE_TAG" BRANCH="$CIRCLE_BRANCH" OFFICIAL=1 SHOW=1
-      - persist-artifacts
+  # build-platforms-steps:
+  #   parameters:
+  #     platform:
+  #       type: string
+  #   steps:
+  #     - early-returns
+  #     - setup-executor
+  #     - checkout-all
+  #     - install-prerequisites
+  #     - run:
+  #         name: Build for platform
+  #         command: |
+  #           ROOT=$PWD
+  #           cd build/docker
+  #           make build OSNICK=<<parameters.platform>> VERSION="$CIRCLE_TAG" BRANCH="$CIRCLE_BRANCH" TEST=1 OFFICIAL=1 SHOW=1
+  #           cd $ROOT
+  #           mkdir -p tests/flow/logs
+  #           tar -C tests/flow/logs -xzf bin/artifacts/tests-flow-logs*.tgz
+  #         no_output_timeout: 30m
+  #     - save-tests-logs
+  #     - early-return-for-forked-pull-requests
+  #     - run:
+  #         name: Upload artifacts to S3
+  #         shell: /bin/bash -l -eo pipefail
+  #         command: |
+  #           if [[ -n $CIRCLE_BRANCH ]]; then
+  #               make upload-artifacts OSNICK=<<parameters.platform>> SHOW=1 VERBOSE=1
+  #           fi
+  #     - run:
+  #         name: Publish container
+  #         shell: /bin/bash -l -eo pipefail
+  #         command: |
+  #           docker login -u redisfab -p $DOCKER_REDISFAB_PWD
+  #           cd build/docker
+  #           make publish OSNICK=<<parameters.platform>> VERSION="$CIRCLE_TAG" BRANCH="$CIRCLE_BRANCH" OFFICIAL=1 SHOW=1
+  #     - persist-artifacts
 
   vm-build-platforms-steps:
     parameters:

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -1,0 +1,133 @@
+name: CI Basic
+# This is a basic workflow for the non-production branches and tags.
+# It will run the tests on the two latest Ubuntu LTS releases and run
+# the tests with a few supported Redis versions. It will not publish
+# the artifacts of the builds and will not test against all the
+# supported platforms.
+
+on:
+  push:
+      paths-ignore:
+          - '.circleci/**'
+          - 'docs/**'
+          - '*.md'
+      branches-ignore:
+          - main
+          - master
+          - '[0-9]+.[0-9]+.[0-9]+'
+          - '[0-9]+.[0-9]+'
+          - 'feature-*'
+      tags-ignore:
+          - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
+          - 'v[0-9]+.[0-9]+.[0-9]+-m[0-9]+'
+          - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  recent-ubuntu:
+    runs-on: ${{ matrix.builder-os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        redis-version: ["6.0.20", "7.2.4", "unstable"]
+        builder-os: ['ubuntu-22.04', 'ubuntu-20.04']
+    defaults:
+      run:
+        shell: bash -l -eo pipefail {0}
+    steps:
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential autoconf automake libtool cmake lcov valgrind
+      - name: Setup Python for testing
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install Python dependencies
+        run:
+          python3 -m pip install -r tests/flow/requirements.txt
+      - name: Checkout Redis
+        uses: actions/checkout@v3
+        with:
+          repository: 'redis/redis'
+          ref: ${{ matrix.redis-version }}
+          path: 'redis'
+      - name: Build Redis
+        run: cd redis && make -j 4
+      - name: Build
+        run: make -j 4
+      - name: Run tests
+        run: make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+
+  test-valgrind:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        redis-version: ["6.0.20", "7.2.4", "unstable"]
+    defaults:
+      run:
+        shell: bash -l -eo pipefail {0}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential autoconf automake libtool cmake lcov valgrind
+      - name: Setup Python for testing
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
+      - name: Install Python dependencies
+        run:
+          python -m pip install -r tests/flow/requirements.txt
+      - name: Checkout Redis
+        uses: actions/checkout@v3
+        with:
+          repository: 'redis/redis'
+          ref: ${{ matrix.redis-version }}
+          path: 'redis'
+      - name: Build Redis
+        run: cd redis && make valgrind -j 4
+      - name: Build
+        run: make -j 4
+      - name: Run tests
+        run: make test VG=1 REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+
+  test-address-sanitizer:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        redis-version: ["7.2.4", "unstable"]
+    defaults:
+      run:
+        shell: bash -l -eo pipefail {0}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential autoconf automake libtool cmake lcov valgrind
+      - name: Setup Python for testing
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
+      - name: Install Python dependencies
+        run:
+          python -m pip install -r tests/flow/requirements.txt
+      - name: Checkout Redis
+        uses: actions/checkout@v3
+        with:
+          repository: 'redis/redis'
+          ref: ${{ matrix.redis-version }}
+          path: 'redis'
+      - name: Build Redis
+        run: cd redis && make SANITIZER=address -j 4
+      - name: Build
+        run: make -j 4
+      - name: Run tests
+        run: make test SAN=addr REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -3,6 +3,21 @@ name: CI Full suite
 # includes building and testing on all supported platforms, and
 # uploading the artifacts to S3.
 
+# TODO:
+#
+# 1. Remove the use of "readies" completely.
+# 2. Remove the use of all the scripts for anything and do everything
+#    right here in the workflow.
+# 3. Use the corresponding actions for the end goal: aws s3 upload
+#    action, docker publish action, etc. This also will remove the need
+#    for the installation of aws-cli and docker steps.
+#
+# More info: jobs.steps.uses: docker://alpine:3.8 for docker images,
+# To use the AWS CLI: https://hub.docker.com/r/amazon/aws-cli
+#
+# To build and push docker images, instead of the Makefile/scripts, use
+# https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+
 on:
   push:
       paths-ignore:
@@ -24,10 +39,26 @@ jobs:
   setup-environment:
     runs-on: ubuntu-latest
     outputs:
-      STAGING: ${{ steps.set-environment.outputs.STAGING }}
+      STAGING: ${{ steps.set-staging.outputs.STAGING }}
+      TAG: ${{ steps.set-git-info.outputs.TAG }}
+      BRANCH: ${{ steps.set-git-info.outputs.BRANCH }}
     steps:
-      - name: Set environment
-        id: set-environment
+      - name: Set the branch and tag outputs
+        id: set-git-info
+        run: |
+          export REF="${{ github.ref }}"
+          export BRANCH_PATTERN="^refs/heads/(.*)$"
+          export TAG_PATTERN="^refs/tags/(.*)$"
+
+          if [[ $REF =~ $BRANCH_PATTERN ]]; then
+            echo "BRANCH=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ $REF =~ $TAG_PATTERN ]]; then
+            echo "TAG=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+          fi
+      - name: Set the staging flag
+        id: set-staging
         run: |
           # If this is a version tag, then set to false, meaning this
           # is not a production build.
@@ -43,6 +74,10 @@ jobs:
 
   recent-ubuntu:
     runs-on: ${{ matrix.builder.os }}
+    env:
+      STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+      VERSION: ${{ needs.setup-environment.outputs.TAG }}
+      BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
     strategy:
       fail-fast: false
       matrix:
@@ -84,19 +119,35 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
+          unset-current-credentials: true
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: "us-east-1"
+          # aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+          aws-region: "us-east-2"
       - name: Upload artifacts to S3
-        env:
-          STAGING: ${{ needs.setup-environment.outputs.STAGING }}
         run: |
+          # TODO: Get rid of this in favour of GitHub actions or a docker image:
+          # https://hub.docker.com/r/amazon/aws-cli
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          ./deps/readies/bin/getaws
           mkdir -p bin
           ln -s ~/workspace/artifacts bin/artifacts
           if [[ $STAGING -eq 1 ]]; then
             make upload-artifacts SHOW=1 VERBOSE=1
           fi
           make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
+      - name: Publish docker image
+        run: |
+          # TODO: GET RID OF THIS in favour of GitHub actions or a docker image.
+          # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+          ./deps/readies/bin/getdocker
+          docker login -u redisfab -p ${{ secrets.DOCKER_REDISFAB_PASSWORD }}
+          cd build/docker
+          make publish OSNICK=${{ matrix.builder.nick }} VERSION="$VERSION" BRANCH="$BRANCH" OFFICIAL=1 SHOW=1
+      - name: List artifacts
+        run: |
+          cd bin/artifacts
+          du -ah --apparent-size *
 
   test-valgrind:
     runs-on: ubuntu-latest
@@ -173,6 +224,10 @@ jobs:
   old-ubuntu:
     runs-on: ubuntu-latest
     container: ${{ matrix.builder.image }}
+    env:
+      STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+      VERSION: ${{ needs.setup-environment.outputs.TAG }}
+      BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
     strategy:
       fail-fast: false
       matrix:
@@ -245,19 +300,37 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: "us-east-1"
       - name: Upload artifacts to S3
-        env:
-          STAGING: ${{ needs.setup-environment.outputs.STAGING }}
         run: |
+          # TODO: Get rid of this in favour of GitHub actions or a docker image:
+          # https://hub.docker.com/r/amazon/aws-cli
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          ./deps/readies/bin/getaws
           mkdir -p bin
           ln -s ~/workspace/artifacts bin/artifacts
           if [[ $STAGING -eq 1 ]]; then
             make upload-artifacts SHOW=1 VERBOSE=1
           fi
           make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
+      - name: Publish docker image
+        run: |
+          # TODO: GET RID OF THIS in favour of GitHub actions or a docker image.
+          # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+          ./deps/readies/bin/getdocker
+          docker login -u redisfab -p ${{ secrets.DOCKER_REDISFAB_PASSWORD }}
+          cd build/docker
+          make publish OSNICK=${{ matrix.builder.nick }} VERSION="$VERSION" BRANCH="$BRANCH" OFFICIAL=1 SHOW=1
+      - name: List artifacts
+        run: |
+          cd bin/artifacts
+          du -ah --apparent-size *
 
   debian:
     runs-on: ubuntu-latest
     container: ${{ matrix.builder.image }}
+    env:
+      STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+      VERSION: ${{ needs.setup-environment.outputs.TAG }}
+      BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
     strategy:
       fail-fast: false
       matrix:
@@ -307,19 +380,37 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: "us-east-1"
       - name: Upload artifacts to S3
-        env:
-          STAGING: ${{ needs.setup-environment.outputs.STAGING }}
         run: |
+          # TODO: Get rid of this in favour of GitHub actions or a docker image:
+          # https://hub.docker.com/r/amazon/aws-cli
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          ./deps/readies/bin/getaws
           mkdir -p bin
           ln -s ~/workspace/artifacts bin/artifacts
           if [[ $STAGING -eq 1 ]]; then
             make upload-artifacts SHOW=1 VERBOSE=1
           fi
           make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
+      - name: Publish docker image
+        run: |
+          # TODO: GET RID OF THIS in favour of GitHub actions or a docker image.
+          # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+          ./deps/readies/bin/getdocker
+          docker login -u redisfab -p ${{ secrets.DOCKER_REDISFAB_PASSWORD }}
+          cd build/docker
+          make publish OSNICK=${{ matrix.builder.nick }} VERSION="$VERSION" BRANCH="$BRANCH" OFFICIAL=1 SHOW=1
+      - name: List artifacts
+        run: |
+          cd bin/artifacts
+          du -ah --apparent-size *
 
   centos:
     runs-on: ubuntu-latest
     container: ${{ matrix.builder.image }}
+    env:
+      STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+      VERSION: ${{ needs.setup-environment.outputs.TAG }}
+      BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
     strategy:
       fail-fast: false
       matrix:
@@ -388,19 +479,37 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: "us-east-1"
       - name: Upload artifacts to S3
-        env:
-          STAGING: ${{ needs.setup-environment.outputs.STAGING }}
         run: |
+          # TODO: Get rid of this in favour of GitHub actions or a docker image:
+          # https://hub.docker.com/r/amazon/aws-cli
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          ./deps/readies/bin/getaws
           mkdir -p bin
           ln -s ~/workspace/artifacts bin/artifacts
           if [[ $STAGING -eq 1 ]]; then
             make upload-artifacts SHOW=1 VERBOSE=1
           fi
           make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
+      - name: Publish docker image
+        run: |
+          # TODO: GET RID OF THIS in favour of GitHub actions or a docker image.
+          # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+          ./deps/readies/bin/getdocker
+          docker login -u redisfab -p ${{ secrets.DOCKER_REDISFAB_PASSWORD }}
+          cd build/docker
+          make publish OSNICK=${{ matrix.builder.nick }} VERSION="$VERSION" BRANCH="$BRANCH" OFFICIAL=1 SHOW=1
+      - name: List artifacts
+        run: |
+          cd bin/artifacts
+          du -ah --apparent-size *
 
   amazon-linux:
     runs-on: ubuntu-latest
     container: ${{ matrix.builder.image }}
+    env:
+      STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+      VERSION: ${{ needs.setup-environment.outputs.TAG }}
+      BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
     strategy:
       fail-fast: false
       matrix:
@@ -468,15 +577,29 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: "us-east-1"
       - name: Upload artifacts to S3
-        env:
-          STAGING: ${{ needs.setup-environment.outputs.STAGING }}
         run: |
+          # TODO: Get rid of this in favour of GitHub actions or a docker image:
+          # https://hub.docker.com/r/amazon/aws-cli
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          ./deps/readies/bin/getaws
           mkdir -p bin
           ln -s ~/workspace/artifacts bin/artifacts
           if [[ $STAGING -eq 1 ]]; then
             make upload-artifacts SHOW=1 VERBOSE=1
           fi
           make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
+      - name: Publish docker image
+        run: |
+          # TODO: GET RID OF THIS in favour of GitHub actions or a docker image.
+          # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+          ./deps/readies/bin/getdocker
+          docker login -u redisfab -p ${{ secrets.DOCKER_REDISFAB_PASSWORD }}
+          cd build/docker
+          make publish OSNICK=${{ matrix.builder.nick }} VERSION="$VERSION" BRANCH="$BRANCH" OFFICIAL=1 SHOW=1
+      - name: List artifacts
+        run: |
+          cd bin/artifacts
+          du -ah --apparent-size *
 
   rocky-linux:
     runs-on: ubuntu-latest
@@ -551,15 +674,29 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: "us-east-1"
       - name: Upload artifacts to S3
-        env:
-          STAGING: ${{ needs.setup-environment.outputs.STAGING }}
         run: |
+          # TODO: Get rid of this in favour of GitHub actions or a docker image:
+          # https://hub.docker.com/r/amazon/aws-cli
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          ./deps/readies/bin/getaws
           mkdir -p bin
           ln -s ~/workspace/artifacts bin/artifacts
           if [[ $STAGING -eq 1 ]]; then
             make upload-artifacts SHOW=1 VERBOSE=1
           fi
           make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
+      - name: Publish docker image
+        run: |
+          # TODO: GET RID OF THIS in favour of GitHub actions or a docker image.
+          # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+          ./deps/readies/bin/getdocker
+          docker login -u redisfab -p ${{ secrets.DOCKER_REDISFAB_PASSWORD }}
+          cd build/docker
+          make publish OSNICK=${{ matrix.builder.nick }} VERSION="$VERSION" BRANCH="$BRANCH" OFFICIAL=1 SHOW=1
+      - name: List artifacts
+        run: |
+          cd bin/artifacts
+          du -ah --apparent-size *
 
   macos-x86_64:
     runs-on: macos-13
@@ -605,12 +742,26 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: "us-east-1"
       - name: Upload artifacts to S3
-        env:
-          STAGING: ${{ needs.setup-environment.outputs.STAGING }}
         run: |
+          # TODO: Get rid of this in favour of GitHub actions or a docker image:
+          # https://hub.docker.com/r/amazon/aws-cli
+          export HOMEBREW_NO_AUTO_UPDATE=1
+          ./deps/readies/bin/getaws
           mkdir -p bin
           ln -s ~/workspace/artifacts bin/artifacts
           if [[ $STAGING -eq 1 ]]; then
             make upload-artifacts SHOW=1 VERBOSE=1
           fi
           make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
+      - name: Publish docker image
+        run: |
+          # TODO: GET RID OF THIS in favour of GitHub actions or a docker image.
+          # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+          ./deps/readies/bin/getdocker
+          docker login -u redisfab -p ${{ secrets.DOCKER_REDISFAB_PASSWORD }}
+          cd build/docker
+          make publish OSNICK=${{ matrix.builder.nick }} VERSION="$VERSION" BRANCH="$BRANCH" OFFICIAL=1 SHOW=1
+      - name: List artifacts
+        run: |
+          cd bin/artifacts
+          du -ah --apparent-size *

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -9,14 +9,10 @@ name: CI Full suite
 # 2. Remove the use of all the scripts for anything and do everything
 #    right here in the workflow.
 # 3. Use the corresponding actions for the end goal: aws s3 upload
-#    action, docker publish action, etc. This also will remove the need
-#    for the installation of aws-cli and docker steps.
+#    action. This also will remove the need for the installation of aws-cli.
 #
 # More info: jobs.steps.uses: docker://alpine:3.8 for docker images,
 # To use the AWS CLI: https://hub.docker.com/r/amazon/aws-cli
-#
-# To build and push docker images, instead of the Makefile/scripts, use
-# https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
 
 on:
   push:
@@ -146,14 +142,6 @@ jobs:
             make upload-artifacts SHOW=1 VERBOSE=1
           fi
           make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
-      - name: Publish docker image
-        run: |
-          # TODO: GET RID OF THIS in favour of GitHub actions or a docker image.
-          # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
-          ./deps/readies/bin/getdocker
-          docker login -u redisfab -p ${{ secrets.DOCKER_REDISFAB_PASSWORD }}
-          cd build/docker
-          make publish OSNICK=${{ matrix.builder.nick }} VERSION="$VERSION" BRANCH="$BRANCH" OFFICIAL=1 SHOW=1
       - name: List artifacts
         run: |
           cd bin/artifacts
@@ -340,14 +328,6 @@ jobs:
             make upload-artifacts SHOW=1 VERBOSE=1
           fi
           make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
-      - name: Publish docker image
-        run: |
-          # TODO: GET RID OF THIS in favour of GitHub actions or a docker image.
-          # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
-          ./deps/readies/bin/getdocker
-          docker login -u redisfab -p ${{ secrets.DOCKER_REDISFAB_PASSWORD }}
-          cd build/docker
-          make publish OSNICK=${{ matrix.builder.nick }} VERSION="$VERSION" BRANCH="$BRANCH" OFFICIAL=1 SHOW=1
       - name: List artifacts
         run: |
           cd bin/artifacts
@@ -431,14 +411,6 @@ jobs:
             make upload-artifacts SHOW=1 VERBOSE=1
           fi
           make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
-      - name: Publish docker image
-        run: |
-          # TODO: GET RID OF THIS in favour of GitHub actions or a docker image.
-          # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
-          ./deps/readies/bin/getdocker
-          docker login -u redisfab -p ${{ secrets.DOCKER_REDISFAB_PASSWORD }}
-          cd build/docker
-          make publish OSNICK=${{ matrix.builder.nick }} VERSION="$VERSION" BRANCH="$BRANCH" OFFICIAL=1 SHOW=1
       - name: List artifacts
         run: |
           cd bin/artifacts
@@ -541,14 +513,6 @@ jobs:
             make upload-artifacts SHOW=1 VERBOSE=1
           fi
           make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
-      - name: Publish docker image
-        run: |
-          # TODO: GET RID OF THIS in favour of GitHub actions or a docker image.
-          # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
-          ./deps/readies/bin/getdocker
-          docker login -u redisfab -p ${{ secrets.DOCKER_REDISFAB_PASSWORD }}
-          cd build/docker
-          make publish OSNICK=${{ matrix.builder.nick }} VERSION="$VERSION" BRANCH="$BRANCH" OFFICIAL=1 SHOW=1
       - name: List artifacts
         run: |
           cd bin/artifacts
@@ -650,14 +614,6 @@ jobs:
             make upload-artifacts SHOW=1 VERBOSE=1
           fi
           make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
-      - name: Publish docker image
-        run: |
-          # TODO: GET RID OF THIS in favour of GitHub actions or a docker image.
-          # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
-          ./deps/readies/bin/getdocker
-          docker login -u redisfab -p ${{ secrets.DOCKER_REDISFAB_PASSWORD }}
-          cd build/docker
-          make publish OSNICK=${{ matrix.builder.nick }} VERSION="$VERSION" BRANCH="$BRANCH" OFFICIAL=1 SHOW=1
       - name: List artifacts
         run: |
           cd bin/artifacts
@@ -759,14 +715,6 @@ jobs:
             make upload-artifacts SHOW=1 VERBOSE=1
           fi
           make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
-      - name: Publish docker image
-        run: |
-          # TODO: GET RID OF THIS in favour of GitHub actions or a docker image.
-          # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
-          ./deps/readies/bin/getdocker
-          docker login -u redisfab -p ${{ secrets.DOCKER_REDISFAB_PASSWORD }}
-          cd build/docker
-          make publish OSNICK=${{ matrix.builder.nick }} VERSION="$VERSION" BRANCH="$BRANCH" OFFICIAL=1 SHOW=1
       - name: List artifacts
         run: |
           cd bin/artifacts
@@ -843,14 +791,6 @@ jobs:
             make upload-artifacts SHOW=1 VERBOSE=1
           fi
           make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
-      - name: Publish docker image
-        run: |
-          # TODO: GET RID OF THIS in favour of GitHub actions or a docker image.
-          # https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
-          ./deps/readies/bin/getdocker
-          docker login -u redisfab -p ${{ secrets.DOCKER_REDISFAB_PASSWORD }}
-          cd build/docker
-          make publish VERSION="$VERSION" BRANCH="$BRANCH" OFFICIAL=1 SHOW=1
       - name: List artifacts
         run: |
           cd bin/artifacts

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -42,6 +42,7 @@ jobs:
       STAGING: ${{ steps.set-staging.outputs.STAGING }}
       TAG: ${{ steps.set-git-info.outputs.TAG }}
       BRANCH: ${{ steps.set-git-info.outputs.BRANCH }}
+      TAG_OR_BRANCH: ${{ steps.set-git-info.outputs.TAG }}${{ steps.set-git-info.outputs.BRANCH }}
     steps:
       - name: Set the branch and tag outputs
         id: set-git-info
@@ -78,6 +79,7 @@ jobs:
       STAGING: ${{ needs.setup-environment.outputs.STAGING }}
       VERSION: ${{ needs.setup-environment.outputs.TAG }}
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
+      TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
     strategy:
       fail-fast: false
       matrix:
@@ -102,8 +104,9 @@ jobs:
         with:
           submodules: true
       - name: Install Python dependencies
-        run:
+        run: |
           python3 -m pip install -r tests/flow/requirements.txt
+          python3 -m pip install jinja2 ramp-packer
       - name: Checkout Redis
         uses: actions/checkout@v3
         with:
@@ -111,11 +114,18 @@ jobs:
           ref: ${{ matrix.redis-version }}
           path: 'redis'
       - name: Build Redis
-        run: cd redis && make -j 4
+        run: |
+          cd redis && make -j `nproc`
+          echo "REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/redis/src" >> $GITHUB_PATH
+          export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
+          redis-server --version
       - name: Build
         run: make -j 4
       - name: Run tests
         run: make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+      - name: Pack module
+        run: make pack BRANCH=$TAG_OR_BRANCH SHOW=1
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -179,9 +189,14 @@ jobs:
           ref: ${{ matrix.redis-version }}
           path: 'redis'
       - name: Build Redis
-        run: cd redis && make valgrind -j 4
+        run: |
+          cd redis && make valgrind -j `nproc`
+          echo "REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/redis/src" >> $GITHUB_PATH
+          export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
+          redis-server --version
       - name: Build
-        run: make -j 4
+        run: make -j `nproc`
       - name: Run tests
         run: make test VG=1 REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
 
@@ -215,9 +230,14 @@ jobs:
           ref: ${{ matrix.redis-version }}
           path: 'redis'
       - name: Build Redis
-        run: cd redis && make SANITIZER=address -j 4
+        run: |
+          cd redis && make SANITIZER=address -j `nproc`
+          echo "REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/redis/src" >> $GITHUB_PATH
+          export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
+          redis-server --version
       - name: Build
-        run: make -j 4
+        run: make -j `nproc`
       - name: Run tests
         run: make test SAN=addr REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
 
@@ -228,6 +248,7 @@ jobs:
       STAGING: ${{ needs.setup-environment.outputs.STAGING }}
       VERSION: ${{ needs.setup-environment.outputs.TAG }}
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
+      TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
     strategy:
       fail-fast: false
       matrix:
@@ -279,8 +300,9 @@ jobs:
         with:
           submodules: true
       - name: Install Python dependencies
-        run:
+        run: |
           python3 -m pip install -r tests/flow/requirements.txt
+          python3 -m pip install jinja2 ramp-packer
       - name: Checkout Redis
         uses: actions/checkout@v3
         with:
@@ -288,11 +310,18 @@ jobs:
           ref: ${{ matrix.redis-version }}
           path: 'redis'
       - name: Build Redis
-        run: cd redis && make -j `nproc`
+        run: |
+          cd redis && make -j `nproc`
+          echo "REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/redis/src" >> $GITHUB_PATH
+          export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
+          redis-server --version
       - name: Build RedisBloom
         run: make -j `nproc`
       - name: Run tests
         run: make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+      - name: Pack module
+        run: make pack BRANCH=$TAG_OR_BRANCH SHOW=1
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -331,6 +360,7 @@ jobs:
       STAGING: ${{ needs.setup-environment.outputs.STAGING }}
       VERSION: ${{ needs.setup-environment.outputs.TAG }}
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
+      TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
     strategy:
       fail-fast: false
       matrix:
@@ -359,8 +389,9 @@ jobs:
         with:
           submodules: true
       - name: Install Python dependencies
-        run:
+        run: |
           python3 -m pip install -r tests/flow/requirements.txt
+          python3 -m pip install jinja2 ramp-packer
       - name: Checkout Redis
         uses: actions/checkout@v3
         with:
@@ -368,11 +399,20 @@ jobs:
           ref: ${{ matrix.redis-version }}
           path: 'redis'
       - name: Build Redis
-        run: cd redis && make -j `nproc`
+        run: |
+          cd redis && make -j `nproc`
+          echo "REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/redis/src" >> $GITHUB_PATH
+          export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
+          redis-server --version
       - name: Build RedisBloom
         run: make -j `nproc`
       - name: Run tests
         run: make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+      - name: Pack module
+        run: |
+          export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
+          make pack BRANCH=$TAG_OR_BRANCH SHOW=1
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -411,6 +451,7 @@ jobs:
       STAGING: ${{ needs.setup-environment.outputs.STAGING }}
       VERSION: ${{ needs.setup-environment.outputs.TAG }}
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
+      TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
     strategy:
       fail-fast: false
       matrix:
@@ -455,6 +496,7 @@ jobs:
         run: |
           scl enable devtoolset-11 bash
           python3 -m pip install -r tests/flow/requirements.txt
+          python3 -m pip install jinja2 ramp-packer
       - name: Checkout Redis
         uses: actions/checkout@v3
         with:
@@ -463,7 +505,12 @@ jobs:
           path: 'redis'
       - name: Build Redis
         run: |
+          . scl_source enable devtoolset-11 || true
           cd redis && make -j `nproc`
+          echo "REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/redis/src" >> $GITHUB_PATH
+          export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
+          redis-server --version
       - name: Build RedisBloom
         run: |
           . scl_source enable devtoolset-11 || true
@@ -472,6 +519,10 @@ jobs:
         run: |
           . scl_source enable devtoolset-11 || true
           make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+      - name: Pack module
+        run: |
+          . scl_source enable devtoolset-11 || true
+          make pack BRANCH=$TAG_OR_BRANCH SHOW=1
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -510,6 +561,7 @@ jobs:
       STAGING: ${{ needs.setup-environment.outputs.STAGING }}
       VERSION: ${{ needs.setup-environment.outputs.TAG }}
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
+      TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
     strategy:
       fail-fast: false
       matrix:
@@ -553,6 +605,7 @@ jobs:
         run: |
           scl enable devtoolset-11 bash
           python3 -m pip install -r tests/flow/requirements.txt
+          python3 -m pip install jinja2 ramp-packer
       - name: Checkout Redis
         uses: actions/checkout@v3
         with:
@@ -561,7 +614,12 @@ jobs:
           path: 'redis'
       - name: Build Redis
         run: |
+          . scl_source enable devtoolset-11 || true
           cd redis && make -j `nproc`
+          echo "REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/redis/src" >> $GITHUB_PATH
+          export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
+          redis-server --version
       - name: Build RedisBloom
         run: |
           . scl_source enable devtoolset-11 || true
@@ -570,6 +628,10 @@ jobs:
         run: |
           . scl_source enable devtoolset-11 || true
           make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+      - name: Pack module
+        run: |
+          . scl_source enable devtoolset-11 || true
+          make pack BRANCH=$TAG_OR_BRANCH SHOW=1
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -604,6 +666,11 @@ jobs:
   rocky-linux:
     runs-on: ubuntu-latest
     container: ${{ matrix.builder.image }}
+    env:
+      STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+      VERSION: ${{ needs.setup-environment.outputs.TAG }}
+      BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
+      TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
     strategy:
       fail-fast: false
       matrix:
@@ -650,6 +717,7 @@ jobs:
         run: |
           . scl_source enable gcc-toolset-13 || true
           python3 -m pip install -r tests/flow/requirements.txt
+          python3 -m pip install jinja2 ramp-packer
       - name: Checkout Redis
         uses: actions/checkout@v3
         with:
@@ -659,6 +727,10 @@ jobs:
       - name: Build Redis
         run: |
           cd redis && make -j `nproc`
+          echo "REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/redis/src" >> $GITHUB_PATH
+          export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
+          redis-server --version
       - name: Build RedisBloom
         run: |
           . scl_source enable gcc-toolset-13 || true
@@ -667,6 +739,8 @@ jobs:
         run: |
           . scl_source enable gcc-toolset-13 || true
           make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+      - name: Pack module
+        run: make pack BRANCH=$TAG_OR_BRANCH SHOW=1
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -698,12 +772,20 @@ jobs:
           cd bin/artifacts
           du -ah --apparent-size *
 
-  macos-x86_64:
-    runs-on: macos-13
+  macos:
+    runs-on: ${{ matrix.os }}
+    env:
+      STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+      VERSION: ${{ needs.setup-environment.outputs.TAG }}
+      BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
+      TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
     strategy:
       fail-fast: false
       matrix:
-        redis-version: ["6.0.20", "7.2.4", "unstable"]
+        # 6.0.20 can't be built due to Redis bug.
+        redis-version: ["6.2.14", "7.2.4", "unstable"]
+        # MacOS 13 - x86-64, MacOS 14 - ARM (Apple Chips).
+        os: ["macos-13", "macos-14"]
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
@@ -712,6 +794,7 @@ jobs:
       - name: Install prerequisites
         run: |
           brew install make
+
       - name: Checkout sources
         uses: actions/checkout@v3
         with:
@@ -720,6 +803,7 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip setuptools wheel
           python3 -m pip install -r tests/flow/requirements.txt
+          python3 -m pip install jinja2 ramp-packer
       - name: Checkout Redis
         uses: actions/checkout@v3
         with:
@@ -728,13 +812,19 @@ jobs:
           path: 'redis'
       - name: Build Redis
         run: |
-          cd redis && make -j `sysctl -n hw.logicalcpu`
+          cd redis && gmake -j `sysctl -n hw.logicalcpu`
+          echo "REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server" >> $GITHUB_ENV
+          echo "$GITHUB_WORKSPACE/redis/src" >> $GITHUB_PATH
+          export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
+          redis-server --version
       - name: Build RedisBloom
         run: |
           gmake -j `sysctl -n hw.logicalcpu`
       - name: Run tests
         run: |
-          gmake test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+          gmake test
+      - name: Pack module
+        run: gmake pack BRANCH=$TAG_OR_BRANCH SHOW=1
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -760,7 +850,7 @@ jobs:
           ./deps/readies/bin/getdocker
           docker login -u redisfab -p ${{ secrets.DOCKER_REDISFAB_PASSWORD }}
           cd build/docker
-          make publish OSNICK=${{ matrix.builder.nick }} VERSION="$VERSION" BRANCH="$BRANCH" OFFICIAL=1 SHOW=1
+          make publish VERSION="$VERSION" BRANCH="$BRANCH" OFFICIAL=1 SHOW=1
       - name: List artifacts
         run: |
           cd bin/artifacts

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,9 +1,47 @@
-name: CI
+name: CI Full suite
+# This is a full workflow for the production branches and tags, which
+# includes building and testing on all supported platforms, and
+# uploading the artifacts to S3.
 
-on: [push, pull_request]
+on:
+  push:
+      paths-ignore:
+          - '.circleci/**'
+          - 'docs/**'
+          - '*.md'
+      branches:
+          - main
+          - master
+          - '[0-9]+.[0-9]+.[0-9]+'
+          - '[0-9]+.[0-9]+'
+          - 'feature-*'
+      tags:
+          - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
+          - 'v[0-9]+.[0-9]+.[0-9]+-m[0-9]+'
+          - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  test-recent-ubuntu:
+  setup-environment:
+    runs-on: ubuntu-latest
+    outputs:
+      STAGING: ${{ steps.set-environment.outputs.STAGING }}
+    steps:
+      - name: Set environment
+        id: set-environment
+        run: |
+          # If this is a version tag, then set to false, meaning this
+          # is not a production build.
+          export REF="${{ github.ref }}"
+          export PATTERN="refs/tags/v[0-9]+.*"
+          if [[ $REF =~ $PATTERN ]]; then
+            echo "This is a production build"
+            echo "STAGING=0" >> $GITHUB_OUTPUT
+          else
+            echo "This is a staging build"
+            echo "STAGING=1" >> $GITHUB_OUTPUT
+          fi
+
+  recent-ubuntu:
     runs-on: ${{ matrix.builder.os }}
     strategy:
       fail-fast: false
@@ -16,6 +54,7 @@ jobs:
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
+    needs: setup-environment
     steps:
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential autoconf automake libtool cmake lcov valgrind
@@ -49,136 +88,15 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: "us-east-1"
       - name: Upload artifacts to S3
-        run: make upload-artifacts OSNICK=${{ matrix.builder.nick }} SHOW=1 VERBOSE=1
-
-  test-old-ubuntu:
-    runs-on: ubuntu-latest
-    container: ${{ matrix.builder.image }}
-    strategy:
-      fail-fast: false
-      matrix:
-        redis-version: ["6.0.20", "7.2.4", "unstable"]
-        builder: [
-          {
-            image: 'ubuntu:xenial',
-            nick: 'xenial'
-          },
-          {
-            image: 'ubuntu:focal',
-            nick: 'focal'
-          }
-        ]
-    defaults:
-      run:
-        shell: bash -l -eo pipefail {0}
-    steps:
-      - name: Install build dependencies
+        env:
+          STAGING: ${{ needs.setup-environment.outputs.STAGING }}
         run: |
-          apt-get update && apt-get install -y software-properties-common
-          add-apt-repository ppa:git-core/ppa -y
-          apt-get update
-          apt-get install -y build-essential make autoconf automake libtool lcov git wget zlib1g-dev lsb-release libssl-dev openssl ca-certificates
-          wget https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
-          tar -xzvf cmake-3.28.0.tar.gz
-          cd cmake-3.28.0
-          ./configure
-          make -j `nproc`
-          make install
-          cd ..
-          ln -s /usr/local/bin/cmake /usr/bin/cmake
-          wget https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz
-          tar -xvf Python-3.9.6.tgz
-          cd Python-3.9.6
-          ./configure
-          make -j `nproc`
-          make altinstall
-          cd ..
-          rm /usr/bin/python3 && ln -s `which python3.9` /usr/bin/python3
-          rm /usr/bin/lsb_release
-          python3 --version
-          make --version
-          cmake --version
-          python3 -m pip install --upgrade pip
-      - name: Checkout RedisBloom
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Install Python dependencies
-        run:
-          python3 -m pip install -r tests/flow/requirements.txt
-      - name: Checkout Redis
-        uses: actions/checkout@v3
-        with:
-          repository: 'redis/redis'
-          ref: ${{ matrix.redis-version }}
-          path: 'redis'
-      - name: Build Redis
-        run: cd redis && make -j `nproc`
-      - name: Build RedisBloom
-        run: make -j `nproc`
-      - name: Run tests
-        run: make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: "us-east-1"
-      - name: Upload artifacts to S3
-        run: make upload-artifacts OSNICK=${{ matrix.builder.nick }} SHOW=1 VERBOSE=1
-
-  debian:
-    runs-on: ubuntu-latest
-    container: ${{ matrix.builder.image }}
-    strategy:
-      fail-fast: false
-      matrix:
-        redis-version: ["6.0.20", "7.2.4", "unstable"]
-        builder: [
-          {
-            image: 'debian:bullseye',
-            nick: 'bullseye'
-          }
-        ]
-    defaults:
-      run:
-        shell: bash -l -eo pipefail {0}
-    steps:
-      - name: Install build dependencies
-        run: |
-          apt-get update
-          apt-get install -y build-essential make cmake autoconf automake libtool lcov git wget zlib1g-dev lsb-release libssl-dev openssl ca-certificates python3 python3-pip
-          python3 --version
-          make --version
-          cmake --version
-          python3 -m pip install --upgrade pip
-      - name: Checkout RedisBloom
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Install Python dependencies
-        run:
-          python3 -m pip install -r tests/flow/requirements.txt
-      - name: Checkout Redis
-        uses: actions/checkout@v3
-        with:
-          repository: 'redis/redis'
-          ref: ${{ matrix.redis-version }}
-          path: 'redis'
-      - name: Build Redis
-        run: cd redis && make -j `nproc`
-      - name: Build RedisBloom
-        run: make -j `nproc`
-      - name: Run tests
-        run: make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: "us-east-1"
-      - name: Upload artifacts to S3
-        run: make upload-artifacts OSNICK=${{ matrix.builder.nick }} SHOW=1 VERBOSE=1
+          mkdir -p bin
+          ln -s ~/workspace/artifacts bin/artifacts
+          if [[ $STAGING -eq 1 ]]; then
+            make upload-artifacts SHOW=1 VERBOSE=1
+          fi
+          make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
 
   test-valgrind:
     runs-on: ubuntu-latest
@@ -252,6 +170,153 @@ jobs:
       - name: Run tests
         run: make test SAN=addr REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
 
+  old-ubuntu:
+    runs-on: ubuntu-latest
+    container: ${{ matrix.builder.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        redis-version: ["6.0.20", "7.2.4", "unstable"]
+        builder: [
+          {
+            image: 'ubuntu:xenial',
+            nick: 'xenial'
+          },
+          {
+            image: 'ubuntu:focal',
+            nick: 'focal'
+          }
+        ]
+    defaults:
+      run:
+        shell: bash -l -eo pipefail {0}
+    needs: setup-environment
+    steps:
+      - name: Install build dependencies
+        run: |
+          apt-get update && apt-get install -y software-properties-common
+          add-apt-repository ppa:git-core/ppa -y
+          apt-get update
+          apt-get install -y build-essential make autoconf automake libtool lcov git wget zlib1g-dev lsb-release libssl-dev openssl ca-certificates
+          wget https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
+          tar -xzvf cmake-3.28.0.tar.gz
+          cd cmake-3.28.0
+          ./configure
+          make -j `nproc`
+          make install
+          cd ..
+          ln -s /usr/local/bin/cmake /usr/bin/cmake
+          wget https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz
+          tar -xvf Python-3.9.6.tgz
+          cd Python-3.9.6
+          ./configure
+          make -j `nproc`
+          make altinstall
+          cd ..
+          rm /usr/bin/python3 && ln -s `which python3.9` /usr/bin/python3
+          rm /usr/bin/lsb_release
+          python3 --version
+          make --version
+          cmake --version
+          python3 -m pip install --upgrade pip
+      - name: Checkout RedisBloom
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install Python dependencies
+        run:
+          python3 -m pip install -r tests/flow/requirements.txt
+      - name: Checkout Redis
+        uses: actions/checkout@v3
+        with:
+          repository: 'redis/redis'
+          ref: ${{ matrix.redis-version }}
+          path: 'redis'
+      - name: Build Redis
+        run: cd redis && make -j `nproc`
+      - name: Build RedisBloom
+        run: make -j `nproc`
+      - name: Run tests
+        run: make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-east-1"
+      - name: Upload artifacts to S3
+        env:
+          STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+        run: |
+          mkdir -p bin
+          ln -s ~/workspace/artifacts bin/artifacts
+          if [[ $STAGING -eq 1 ]]; then
+            make upload-artifacts SHOW=1 VERBOSE=1
+          fi
+          make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
+
+  debian:
+    runs-on: ubuntu-latest
+    container: ${{ matrix.builder.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        redis-version: ["6.0.20", "7.2.4", "unstable"]
+        builder: [
+          {
+            image: 'debian:bullseye',
+            nick: 'bullseye'
+          }
+        ]
+    defaults:
+      run:
+        shell: bash -l -eo pipefail {0}
+    needs: setup-environment
+    steps:
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y build-essential make cmake autoconf automake libtool lcov git wget zlib1g-dev lsb-release libssl-dev openssl ca-certificates python3 python3-pip
+          python3 --version
+          make --version
+          cmake --version
+          python3 -m pip install --upgrade pip
+      - name: Checkout RedisBloom
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install Python dependencies
+        run:
+          python3 -m pip install -r tests/flow/requirements.txt
+      - name: Checkout Redis
+        uses: actions/checkout@v3
+        with:
+          repository: 'redis/redis'
+          ref: ${{ matrix.redis-version }}
+          path: 'redis'
+      - name: Build Redis
+        run: cd redis && make -j `nproc`
+      - name: Build RedisBloom
+        run: make -j `nproc`
+      - name: Run tests
+        run: make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-east-1"
+      - name: Upload artifacts to S3
+        env:
+          STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+        run: |
+          mkdir -p bin
+          ln -s ~/workspace/artifacts bin/artifacts
+          if [[ $STAGING -eq 1 ]]; then
+            make upload-artifacts SHOW=1 VERBOSE=1
+          fi
+          make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
+
   centos:
     runs-on: ubuntu-latest
     container: ${{ matrix.builder.image }}
@@ -268,6 +333,7 @@ jobs:
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
+    needs: setup-environment
     steps:
       - name: Install build dependencies
         run: |
@@ -322,7 +388,15 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: "us-east-1"
       - name: Upload artifacts to S3
-        run: make upload-artifacts OSNICK=${{ matrix.builder.nick }} SHOW=1 VERBOSE=1
+        env:
+          STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+        run: |
+          mkdir -p bin
+          ln -s ~/workspace/artifacts bin/artifacts
+          if [[ $STAGING -eq 1 ]]; then
+            make upload-artifacts SHOW=1 VERBOSE=1
+          fi
+          make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
 
   amazon-linux:
     runs-on: ubuntu-latest
@@ -340,6 +414,7 @@ jobs:
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
+    needs: setup-environment
     steps:
       - name: Install build dependencies
         run: |
@@ -393,7 +468,15 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: "us-east-1"
       - name: Upload artifacts to S3
-        run: make upload-artifacts OSNICK=${{ matrix.builder.nick }} SHOW=1 VERBOSE=1
+        env:
+          STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+        run: |
+          mkdir -p bin
+          ln -s ~/workspace/artifacts bin/artifacts
+          if [[ $STAGING -eq 1 ]]; then
+            make upload-artifacts SHOW=1 VERBOSE=1
+          fi
+          make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
 
   rocky-linux:
     runs-on: ubuntu-latest
@@ -414,6 +497,7 @@ jobs:
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
+    needs: setup-environment
     steps:
       - name: Install build dependencies
         run: |
@@ -467,7 +551,15 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: "us-east-1"
       - name: Upload artifacts to S3
-        run: make upload-artifacts OSNICK=${{ matrix.builder.nick }} SHOW=1 VERBOSE=1
+        env:
+          STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+        run: |
+          mkdir -p bin
+          ln -s ~/workspace/artifacts bin/artifacts
+          if [[ $STAGING -eq 1 ]]; then
+            make upload-artifacts SHOW=1 VERBOSE=1
+          fi
+          make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
 
   macos-x86_64:
     runs-on: macos-13
@@ -478,6 +570,7 @@ jobs:
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
+    needs: setup-environment
     steps:
       - name: Install prerequisites
         run: |
@@ -512,4 +605,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: "us-east-1"
       - name: Upload artifacts to S3
-        run: make upload-artifacts SHOW=1 VERBOSE=1
+        env:
+          STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+        run: |
+          mkdir -p bin
+          ln -s ~/workspace/artifacts bin/artifacts
+          if [[ $STAGING -eq 1 ]]; then
+            make upload-artifacts SHOW=1 VERBOSE=1
+          fi
+          make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,15 @@ on: [push, pull_request]
 
 jobs:
   test-recent-ubuntu:
-    runs-on: ${{ matrix.builder-os }}
+    runs-on: ${{ matrix.builder.os }}
     strategy:
       fail-fast: false
       matrix:
         redis-version: ["6.0.20", "7.2.4", "unstable"]
-        # jammy and bionic
-        builder-os: ['ubuntu-22.04', 'ubuntu-20.04']
+        builder: [
+          { os: 'ubuntu-22.04', nick: 'jammy' },
+          { os: 'ubuntu-20.04', nick: 'focal' }
+        ]
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
@@ -40,15 +42,32 @@ jobs:
         run: make -j 4
       - name: Run tests
         run: make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-east-1"
+      - name: Upload artifacts to S3
+        run: make upload-artifacts OSNICK=${{ matrix.builder.nick }} SHOW=1 VERBOSE=1
 
   test-old-ubuntu:
     runs-on: ubuntu-latest
-    container: ${{ matrix.builder-container }}
+    container: ${{ matrix.builder.image }}
     strategy:
       fail-fast: false
       matrix:
         redis-version: ["6.0.20", "7.2.4", "unstable"]
-        builder-container: ['ubuntu:xenial', 'ubuntu:bionic']
+        builder: [
+          {
+            image: 'ubuntu:xenial',
+            nick: 'xenial'
+          },
+          {
+            image: 'ubuntu:focal',
+            nick: 'focal'
+          }
+        ]
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
@@ -99,15 +118,28 @@ jobs:
         run: make -j `nproc`
       - name: Run tests
         run: make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-east-1"
+      - name: Upload artifacts to S3
+        run: make upload-artifacts OSNICK=${{ matrix.builder.nick }} SHOW=1 VERBOSE=1
 
   debian:
     runs-on: ubuntu-latest
-    container: ${{ matrix.builder-container }}
+    container: ${{ matrix.builder.image }}
     strategy:
       fail-fast: false
       matrix:
         redis-version: ["6.0.20", "7.2.4", "unstable"]
-        builder-container: ['debian:bullseye']
+        builder: [
+          {
+            image: 'debian:bullseye',
+            nick: 'bullseye'
+          }
+        ]
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
@@ -139,6 +171,14 @@ jobs:
         run: make -j `nproc`
       - name: Run tests
         run: make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-east-1"
+      - name: Upload artifacts to S3
+        run: make upload-artifacts OSNICK=${{ matrix.builder.nick }} SHOW=1 VERBOSE=1
 
   test-valgrind:
     runs-on: ubuntu-latest
@@ -214,12 +254,17 @@ jobs:
 
   centos:
     runs-on: ubuntu-latest
-    container: ${{ matrix.builder-container }}
+    container: ${{ matrix.builder.image }}
     strategy:
       fail-fast: false
       matrix:
         redis-version: ["6.2.14", "7.2.4", "unstable"]
-        builder-container: ['centos:7']
+        builder: [
+          {
+            image: 'centos:7',
+            nick: 'centos7'
+          }
+        ]
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
@@ -270,15 +315,28 @@ jobs:
         run: |
           . scl_source enable devtoolset-11 || true
           make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-east-1"
+      - name: Upload artifacts to S3
+        run: make upload-artifacts OSNICK=${{ matrix.builder.nick }} SHOW=1 VERBOSE=1
 
   amazon-linux:
     runs-on: ubuntu-latest
-    container: ${{ matrix.builder-container }}
+    container: ${{ matrix.builder.image }}
     strategy:
       fail-fast: false
       matrix:
         redis-version: ["6.0.20", "7.2.4", "unstable"]
-        builder-container: ['amazonlinux:2']
+        builder: [
+          {
+            image: 'amazonlinux:2',
+            nick: 'amzn2'
+          }
+        ]
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
@@ -328,15 +386,31 @@ jobs:
         run: |
           . scl_source enable devtoolset-11 || true
           make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-east-1"
+      - name: Upload artifacts to S3
+        run: make upload-artifacts OSNICK=${{ matrix.builder.nick }} SHOW=1 VERBOSE=1
 
   rocky-linux:
     runs-on: ubuntu-latest
-    container: ${{ matrix.builder-container }}
+    container: ${{ matrix.builder.image }}
     strategy:
       fail-fast: false
       matrix:
         redis-version: ["6.0.20", "7.2.4", "unstable"]
-        builder-container: ['rockylinux:8', 'rockylinux:9']
+        builder: [{
+            image: 'rockylinux:8',
+            nick: 'rocky8'
+          },
+          {
+            image: 'rockylinux:9',
+            nick: 'rocky9'
+          }
+        ]
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
@@ -386,12 +460,19 @@ jobs:
         run: |
           . scl_source enable gcc-toolset-13 || true
           make test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-east-1"
+      - name: Upload artifacts to S3
+        run: make upload-artifacts OSNICK=${{ matrix.builder.nick }} SHOW=1 VERBOSE=1
 
   macos-x86_64:
     runs-on: macos-13
     strategy:
       fail-fast: false
-      # TODO: figure out the version we need to test on.
       matrix:
         redis-version: ["6.0.20", "7.2.4", "unstable"]
     defaults:
@@ -424,3 +505,11 @@ jobs:
       - name: Run tests
         run: |
           gmake test REDIS_SERVER=$GITHUB_WORKSPACE/redis/src/redis-server
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-east-1"
+      - name: Upload artifacts to S3
+        run: make upload-artifacts SHOW=1 VERBOSE=1


### PR DESCRIPTION
Adds the uploading of artefacts to the S3 storage and pushing of the docker image. The workflow has become too complex and long, and for this and to better reflect what CircleCI had, it is split into two different workflows.

To publish the artefacts and push the docker image, the "full" workflow requires valid AWS S3 credentials and a valid Docker user token.

Additionally, it adds a "ramp packer" step and a Mac arm job (which fails due to Redis not being able to build). 