### PR TITLE
Fix 753 (#758)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,10 +361,29 @@ jobs:
       - vm-build-platforms-steps:
           platform: <<parameters.platform>>
 
-  build-macos:
+  build-macos-x64:
     macos:
       xcode: 12.5.1
     resource_class: macos.x86.medium.gen2
+    parameters:
+      upload:
+        type: string
+        default: "yes"
+    steps:
+      - early-returns
+      - build-steps
+      - run:
+          name: Upload artifacts to S3
+          command: |
+            if [[ -n $CIRCLE_BRANCH && "<<parameters.upload>>" == "yes" ]]; then
+                make upload-artifacts SHOW=1 VERBOSE=1
+            fi
+      - persist-artifacts
+
+  build-macos-m1:
+    macos:
+      xcode: 14.2.0
+    resource_class: macos.m1.large.gen1
     parameters:
       upload:
         type: string
@@ -574,7 +593,10 @@ workflows:
           matrix:
             parameters:
               platform: [jammy, focal, bionic]
-      - build-macos:
+      - build-macos-x64:
+          context: common
+          <<: *on-integ-and-version-tags
+      - build-macos-m1:
           context: common
           <<: *on-integ-and-version-tags
       - upload-artifacts:
@@ -585,7 +607,8 @@ workflows:
           requires:
             - build-platforms
             - build-arm-platforms
-            - build-macos
+            - build-macos-x64
+            - build-macos-m1
       - upload-artifacts:
           name: upload-release-artifacts
           context: common
@@ -593,7 +616,8 @@ workflows:
           requires:
             - build-platforms
             - build-arm-platforms
-            - build-macos
+            - build-macos-x64
+            - build-macos-m1
       - release-qa-tests:
           context: common
           <<: *on-version-tags

--- a/sbin/system-setup.py
+++ b/sbin/system-setup.py
@@ -41,7 +41,6 @@ class RedisBloomSetup(paella.Setup):
             self.install("lcov-git", aur=True)
         else:
             self.install("lcov")
-        self.run("{ROOT}/sbin/get-fbinfer".format(ROOT=ROOT))
         self.run("{PYTHON} {READIES}/bin/getrmpytools --reinstall --modern".format(PYTHON=self.python, READIES=READIES))
         self.run("{PYTHON} {READIES}/bin/getcmake --usr".format(PYTHON=self.python, READIES=READIES))
         self.pip_install("-r tests/flow/requirements.txt")

--- a/src/version.h
+++ b/src/version.h
@@ -17,7 +17,7 @@
 #endif
 
 #ifndef REBLOOM_VERSION_PATCH
-#define REBLOOM_VERSION_PATCH 8
+#define REBLOOM_VERSION_PATCH 9
 #endif
 
 #define REBLOOM_MODULE_VERSION                                                                     \

--- a/tests/flow/test_cms.py
+++ b/tests/flow/test_cms.py
@@ -162,6 +162,7 @@ class testCMS():
         self.assertRaises(ResponseError, self.cmd, 'cms.merge', 'foo', 3, 'foo', 'weights', 'B')
         self.assertRaises(ResponseError, self.cmd, 'cms.merge', 'foo', 'A', 'foo', 'weights', 1)
         self.assertRaises(ResponseError, self.cmd, 'cms.merge', 'foo', 3, 'bar', 'baz' 'weights', 1, 'a')
+        self.assertRaises(ResponseError, self.cmd, 'cms.merge', 'foo', 3, 'bar', 'baz' 'weights', 1)
 
     def test_merge_extensive(self):
         self.cmd('FLUSHALL')


### PR DESCRIPTION
Fix crash when cms.merge weights do not match number of keys

- Fixes issue #753.
- In line 193 there was '&&' instead of '||'.
- Some streamline of code.