### PR TITLE
MOD-6962 Return error if cms.merge causes overflow

### DIFF
--- a/src/cms.c
+++ b/src/cms.c
@@ -81,8 +81,7 @@ size_t CMS_Query(CMSketch *cms, const char *item, size_t itemlen) {
 }
 
 static int checkOverflow(CMSketch *dest, size_t quantity, const CMSketch **src,
-                         const long long *weights)
-{
+                         const long long *weights) {
     int64_t itemCount = 0;
     int64_t cmsCount = 0;
     size_t width = dest->width;
@@ -146,7 +145,7 @@ int CMS_Merge(CMSketch *dest, size_t quantity, const CMSketch **src, const long 
         for (size_t j = 0; j < width; ++j) {
             itemCount = 0;
             for (size_t k = 0; k < quantity; ++k) {
-                itemCount += (int64_t) src[k]->array[(i * width) + j] * weights[k];
+                itemCount += (int64_t)src[k]->array[(i * width) + j] * weights[k];
             }
             dest->array[(i * width) + j] = itemCount;
         }
@@ -161,8 +160,7 @@ int CMS_Merge(CMSketch *dest, size_t quantity, const CMSketch **src, const long 
 }
 
 int CMS_MergeParams(mergeParams params) {
-    return CMS_Merge(params.dest, params.numKeys,
-                     (const CMSketch **)params.cmsArray,
+    return CMS_Merge(params.dest, params.numKeys, (const CMSketch **)params.cmsArray,
                      (const long long *)params.weights);
 }
 

--- a/src/cms.h
+++ b/src/cms.h
@@ -51,9 +51,12 @@ size_t CMS_Query(CMSketch *cms, const char *item, size_t strlen);
 /*  Merges multiple CMSketches into a single one.
     All sketches must have identical width and depth.
     dest must be already initialized.
+
+    Returns non-zero if overflow validation fails. In this case,
+    merge operation will be aborted with no side effects.
 */
-void CMS_Merge(CMSketch *dest, size_t quantity, const CMSketch **src, const long long *weights);
-void CMS_MergeParams(mergeParams params);
+int CMS_Merge(CMSketch *dest, size_t quantity, const CMSketch **src, const long long *weights);
+int CMS_MergeParams(mergeParams params);
 
 /* Help function */
 void CMS_Print(const CMSketch *cms);

--- a/src/rm_cms.c
+++ b/src/rm_cms.c
@@ -242,7 +242,12 @@ int CMSketch_Merge(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return REDISMODULE_OK;
     }
 
-    CMS_MergeParams(params);
+    if (CMS_MergeParams(params) != 0) {
+        RedisModule_ReplyWithError(ctx, "CMS: MERGE overflow");
+        CMS_FREE(params.cmsArray);
+        CMS_FREE(params.weights);
+        return REDISMODULE_OK;
+    }
 
     CMS_FREE(params.cmsArray);
     CMS_FREE(params.weights);


### PR DESCRIPTION
Currently, `cms.merge` does not check overflows. Merging keys can cause overflow in some cells. 

This PR adds a validation check. If there is an overflow on any cell, 
`cms.merge` will return an error and it will have no side effects (dest key will stay untouched)

Additional changes:
- Some tests for cms.merge scenarios.