### PR TITLE
Fix CI for centos/amazon/ubuntu-xenial builds

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -242,6 +242,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.builder.image }}
     env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       STAGING: ${{ needs.setup-environment.outputs.STAGING }}
       VERSION: ${{ needs.setup-environment.outputs.TAG }}
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
@@ -427,6 +428,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.builder.image }}
     env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       STAGING: ${{ needs.setup-environment.outputs.STAGING }}
       VERSION: ${{ needs.setup-environment.outputs.TAG }}
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
@@ -449,8 +451,20 @@ jobs:
       - name: Install build dependencies
         run: |
           yum -y install epel-release
-          yum -y install http://opensource.wandisco.com/centos/7/git/x86_64/wandisco-git-release-7-2.noarch.rpm
-          yum -y install gcc make cmake3 git python-pip openssl-devel bzip2-devel libffi-devel zlib-devel wget centos-release-scl scl-utils
+          yum-config-manager --add-repo http://vault.centos.org/centos/7/sclo/x86_64/rh/
+          rpm --import https://vault.centos.org/RPM-GPG-KEY-CentOS-7
+          # http://mirror.centos.org/centos/7/ is deprecated, so we have to disable mirrorlists
+          # and change the baseurl in the repo file to the working mirror (from mirror.centos.org to vault.centos.org)
+          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+          sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+          sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+          yum -y install epel-release
+          yum -y install http://opensource.wandisco.com/centos/7/git/x86_64/wandisco-git-release-7-2.noarch.rpm 
+          yum -y install make cmake3 git python-pip openssl-devel bzip2-devel libffi-devel zlib-devel wget centos-release-scl scl-utils
+          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+          sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+          sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+          yum groups mark convert
           yum groupinstall "Development Tools" -y
           yum install -y devtoolset-11
           . scl_source enable devtoolset-11 || true
@@ -529,6 +543,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.builder.image }}
     env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       STAGING: ${{ needs.setup-environment.outputs.STAGING }}
       VERSION: ${{ needs.setup-environment.outputs.TAG }}
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
@@ -552,7 +567,7 @@ jobs:
         run: |
           amazon-linux-extras install epel -y
           yum -y install epel-release yum-utils
-          yum-config-manager --add-repo http://mirror.centos.org/centos/7/sclo/x86_64/rh/
+          yum-config-manager --add-repo http://vault.centos.org/centos/7/sclo/x86_64/rh/
           yum -y install gcc make cmake3 git python-pip openssl-devel bzip2-devel libffi-devel zlib-devel wget centos-release-scl scl-utils which tar unzip
           yum -y install devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make --nogpgcheck
           . scl_source enable devtoolset-11 || true


### PR DESCRIPTION
- Force using node16 for centos7/amazon2/old-ubuntu builds. This is temporary fix. For details: 
  https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
  
- Centos7 went EOL. Use vault repo to support it. 