### PR TITLE
Fix upload of artifacts

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -35,7 +35,7 @@ jobs:
   setup-environment:
     runs-on: ubuntu-latest
     outputs:
-      STAGING: ${{ steps.set-staging.outputs.STAGING }}
+      TAGGED: ${{ steps.set-tagged.outputs.TAGGED }}
       TAG: ${{ steps.set-git-info.outputs.TAG }}
       BRANCH: ${{ steps.set-git-info.outputs.BRANCH }}
       TAG_OR_BRANCH: ${{ steps.set-git-info.outputs.TAG }}${{ steps.set-git-info.outputs.BRANCH }}
@@ -54,19 +54,19 @@ jobs:
           if [[ $REF =~ $TAG_PATTERN ]]; then
             echo "TAG=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
           fi
-      - name: Set the staging flag
-        id: set-staging
+      - name: Set the tagged flag
+        id: set-tagged
         run: |
           # If this is a version tag, then set to false, meaning this
           # is not a production build.
           export REF="${{ github.ref }}"
           export PATTERN="refs/tags/v[0-9]+.*"
           if [[ $REF =~ $PATTERN ]]; then
-            echo "This is a production build"
-            echo "STAGING=0" >> $GITHUB_OUTPUT
+            echo "This is a tagged build"
+            echo "TAGGED=1" >> $GITHUB_OUTPUT
           else
-            echo "This is a staging build"
-            echo "STAGING=1" >> $GITHUB_OUTPUT
+            echo "This is not a tagged build"
+            echo "TAGGED=0" >> $GITHUB_OUTPUT
           fi
 
   linter:
@@ -86,7 +86,7 @@ jobs:
   recent-ubuntu:
     runs-on: ${{ matrix.builder.os }}
     env:
-      STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+      TAGGED: ${{ needs.setup-environment.outputs.TAGGED }}
       VERSION: ${{ needs.setup-environment.outputs.TAG }}
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
       TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
@@ -147,10 +147,11 @@ jobs:
         run: |
           mkdir -p bin
           ln -s ~/workspace/artifacts bin/artifacts
-          if [[ $STAGING -eq 1 ]]; then
+          if [[ $TAGGED -eq 0 ]]; then
             make upload-artifacts SHOW=1 VERBOSE=1
+          else
+            make upload-release SHOW=1 VERBOSE=1
           fi
-          make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
       - name: List artifacts
         run: |
           cd bin/artifacts
@@ -243,7 +244,7 @@ jobs:
     container: ${{ matrix.builder.image }}
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-      STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+      TAGGED: ${{ needs.setup-environment.outputs.TAGGED }}
       VERSION: ${{ needs.setup-environment.outputs.TAG }}
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
       TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
@@ -253,12 +254,16 @@ jobs:
         redis-version: ["6.0.20", "7.2.4", "unstable"]
         builder: [
           {
-            image: 'ubuntu:xenial',
-            nick: 'xenial'
-          },
-          {
             image: 'ubuntu:focal',
             nick: 'focal'
+          },
+          {
+            image: 'ubuntu:bionic',
+            nick: 'bionic'
+          },
+          {
+            image: 'ubuntu:xenial',
+            nick: 'xenial'
           }
         ]
     defaults:
@@ -333,10 +338,11 @@ jobs:
         run: |
           mkdir -p bin
           ln -s ~/workspace/artifacts bin/artifacts
-          if [[ $STAGING -eq 1 ]]; then
+          if [[ $TAGGED -eq 0 ]]; then
             make upload-artifacts SHOW=1 VERBOSE=1
+          else
+            make upload-release SHOW=1 VERBOSE=1
           fi
-          make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
       - name: List artifacts
         run: |
           cd bin/artifacts
@@ -346,7 +352,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.builder.image }}
     env:
-      STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+      TAGGED: ${{ needs.setup-environment.outputs.TAGGED }}
       VERSION: ${{ needs.setup-environment.outputs.TAG }}
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
       TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
@@ -415,10 +421,11 @@ jobs:
         run: |
           mkdir -p bin
           ln -s ~/workspace/artifacts bin/artifacts
-          if [[ $STAGING -eq 1 ]]; then
+          if [[ $TAGGED -eq 0 ]]; then
             make upload-artifacts SHOW=1 VERBOSE=1
+          else
+            make upload-release SHOW=1 VERBOSE=1
           fi
-          make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
       - name: List artifacts
         run: |
           cd bin/artifacts
@@ -429,7 +436,7 @@ jobs:
     container: ${{ matrix.builder.image }}
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-      STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+      TAGGED: ${{ needs.setup-environment.outputs.TAGGED }}
       VERSION: ${{ needs.setup-environment.outputs.TAG }}
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
       TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
@@ -529,10 +536,12 @@ jobs:
           . scl_source enable devtoolset-11 || true
           mkdir -p bin
           ln -s ~/workspace/artifacts bin/artifacts
-          if [[ $STAGING -eq 1 ]]; then
+          if [[ $TAGGED -eq 0 ]]; then
             make upload-artifacts SHOW=1 VERBOSE=1
+          else
+            make upload-release SHOW=1 VERBOSE=1
           fi
-          make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
+
       - name: List artifacts
         run: |
           cd bin/artifacts
@@ -543,7 +552,7 @@ jobs:
     container: ${{ matrix.builder.image }}
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-      STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+      TAGGED: ${{ needs.setup-environment.outputs.TAGGED }}
       VERSION: ${{ needs.setup-environment.outputs.TAG }}
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
       TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
@@ -631,10 +640,11 @@ jobs:
           . scl_source enable devtoolset-11 || true
           mkdir -p bin
           ln -s ~/workspace/artifacts bin/artifacts
-          if [[ $STAGING -eq 1 ]]; then
+          if [[ $TAGGED -eq 0 ]]; then
             make upload-artifacts SHOW=1 VERBOSE=1
+          else
+            make upload-release SHOW=1 VERBOSE=1
           fi
-          make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
       - name: List artifacts
         run: |
           cd bin/artifacts
@@ -644,7 +654,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.builder.image }}
     env:
-      STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+      TAGGED: ${{ needs.setup-environment.outputs.TAGGED }}
       VERSION: ${{ needs.setup-environment.outputs.TAG }}
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
       TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
@@ -732,10 +742,11 @@ jobs:
           . scl_source enable gcc-toolset-13 || true
           mkdir -p bin
           ln -s ~/workspace/artifacts bin/artifacts
-          if [[ $STAGING -eq 1 ]]; then
+          if [[ $TAGGED -eq 0 ]]; then
             make upload-artifacts SHOW=1 VERBOSE=1
+          else
+            make upload-release SHOW=1 VERBOSE=1
           fi
-          make upload-release STAGING=$STAGING SHOW=1 VERBOSE=1
       - name: List artifacts
         run: |
           cd bin/artifacts
@@ -744,7 +755,7 @@ jobs:
   macos:
     runs-on: ${{ matrix.os }}
     env:
-      STAGING: ${{ needs.setup-environment.outputs.STAGING }}
+      TAGGED: ${{ needs.setup-environment.outputs.TAGGED }}
       VERSION: ${{ needs.setup-environment.outputs.TAG }}
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
       TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH}}
@@ -754,7 +765,7 @@ jobs:
         # 6.0.20 can't be built due to Redis bug.
         redis-version: ["6.2.14", "7.2.4", "unstable"]
         # MacOS 13 - x86-64, MacOS 14 - ARM (Apple Chips).
-        os: ["macos-13", "macos-14"]
+        os: ["macos-13", "macos-13-xlarge", "macos-14"]
     defaults:
       run:
         shell: bash -l -eo pipefail {0}
@@ -813,7 +824,8 @@ jobs:
 
           mkdir -p bin
           ln -s ~/workspace/artifacts bin/artifacts
-          if [[ $STAGING -eq 1 ]]; then
+          if [[ $TAGGED -eq 0 ]]; then
             gmake upload-artifacts SHOW=1 VERBOSE=1
+          else
+            gmake upload-release SHOW=1 VERBOSE=1
           fi
-          gmake upload-release STAGING=$STAGING SHOW=1 VERBOSE=1


### PR DESCRIPTION
- Fix upload of artifacts
   Call either `make upload-release` or `make upload-artifacts`

- Add missing ubuntu and macos builds (Exist on CircleCI but not on gh actions).