### PR TITLE
Fix naming of macos arm64 artifacts

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -765,7 +765,7 @@ jobs:
         # 6.0.20 can't be built due to Redis bug.
         redis-version: ["6.2.14", "7.2.4", "unstable"]
         # MacOS 13 - x86-64, MacOS 14 - ARM (Apple Chips).
-        os: ["macos-13", "macos-13-xlarge", "macos-14"]
+        os: ["macos-13", "macos-14"]
     defaults:
       run:
         shell: bash -l -eo pipefail {0}

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -79,6 +79,7 @@ if [[ $OS == macos ]]; then
 		OSNICK=catalina  # to be aligned with the rest of the modules in redis stack
 	else
 		[[ $OSNICK == ventura ]] && OSNICK=monterey
+		[[ $OSNICK == sonoma ]] && OSNICK=monterey
 	fi
 fi
 

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -61,6 +61,7 @@ if [[ $OS == macos ]]; then
 		OSNICK=catalina  # to be aligned with the rest of the modules in redis stack
 	else
 		[[ $OSNICK == ventura ]] && OSNICK=monterey
+		[[ $OSNICK == sonoma ]] && OSNICK=monterey
 	fi
 fi
 


### PR DESCRIPTION
Use monterey name for macOS arm artifacts