### PR TITLE
Delete macOS builds from circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,44 +293,6 @@ jobs:
       - vm-build-platforms-steps:
           platform: <<parameters.platform>>
 
-  build-macos-x64:
-    macos:
-      xcode: 12.5.1
-    resource_class: macos.x86.medium.gen2
-    parameters:
-      upload:
-        type: string
-        default: "yes"
-    steps:
-      - early-returns
-      - build-steps
-      - run:
-          name: Upload artifacts to S3
-          command: |
-            if [[ -n $CIRCLE_BRANCH && "<<parameters.upload>>" == "yes" ]]; then
-                make upload-artifacts SHOW=1 VERBOSE=1
-            fi
-      - persist-artifacts
-
-  build-macos-m1:
-    macos:
-      xcode: 14.2.0
-    resource_class: macos.m1.large.gen1
-    parameters:
-      upload:
-        type: string
-        default: "yes"
-    steps:
-      - early-returns
-      - build-steps
-      - run:
-          name: Upload artifacts to S3
-          command: |
-            if [[ -n $CIRCLE_BRANCH && "<<parameters.upload>>" == "yes" ]]; then
-                make upload-artifacts SHOW=1 VERBOSE=1
-            fi
-      - persist-artifacts
-
   coverage:
     docker:
       - image: redisfab/rmbuilder:6.2.7-x64-bullseye
@@ -507,12 +469,6 @@ workflows:
           matrix:
             parameters:
               platform: [jammy, focal, bionic]
-      - build-macos-x64:
-          context: common
-          <<: *on-integ-and-version-tags
-      - build-macos-m1:
-          context: common
-          <<: *on-integ-and-version-tags
       - upload-artifacts:
           name: upload-artifacts-to-staging-lab
           staging-lab: "1"
@@ -521,8 +477,6 @@ workflows:
           requires:
             - build-platforms
             - build-arm-platforms
-            - build-macos-x64
-            - build-macos-m1
       - upload-artifacts:
           name: upload-release-artifacts
           context: common
@@ -530,8 +484,6 @@ workflows:
           requires:
             - build-platforms
             - build-arm-platforms
-            - build-macos-x64
-            - build-macos-m1
       - release-qa-tests:
           context: common
           <<: *on-version-tags


### PR DESCRIPTION
MacOS builds on CircleCI started to fail as Circle is dropping support of some instance types.
We already have macOS builds on GH actions. 