### PR TITLE
Prevent numpy warning in tests

### DIFF
--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -1,7 +1,7 @@
 
 from ast import arg
 from common import *
-from numpy import NaN
+import numpy as np
 import redis
 import math
 import random
@@ -703,7 +703,7 @@ class testTDigest:
         self.assertRaises(redis.exceptions.ResponseError, self.cmd, "tdigest.rank")
         # parsing
         self.assertRaises(
-            redis.exceptions.ResponseError, self.cmd, "tdigest.rank", "tdigest", NaN
+            redis.exceptions.ResponseError, self.cmd, "tdigest.rank", "tdigest", np.nan
         )
         self.assertRaises(
             redis.exceptions.ResponseError, self.cmd, "tdigest.rank", "tdigest", "a", 0.9
@@ -777,7 +777,7 @@ class testTDigest:
         )
         # parsing
         self.assertRaises(
-            redis.exceptions.ResponseError, self.cmd, "tdigest.byrank", "tdigest", NaN
+            redis.exceptions.ResponseError, self.cmd, "tdigest.byrank", "tdigest", np.nan
         )
         self.assertRaises(
             redis.exceptions.ResponseError, self.cmd, "tdigest.byrank", "tdigest", "a", 0.9


### PR DESCRIPTION
Lately, we get 

```
Problems in file /home/runner/work/RedisBloom/RedisBloom/tests/flow/test_tdigest.py: cannot import name 'NaN' from 'numpy' (/opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/site-packages/numpy/__init__.py)
```

Use a workaround to prevent this warning.

Note: Seems like this is causing test failure for mariner build. 