### PR TITLE
RED-134847 support active defrag on all probabilistic data types.

### DIFF
--- a/build/t-digest-c/Makefile
+++ b/build/t-digest-c/Makefile
@@ -31,14 +31,7 @@ TARGET=$(BINDIR)/libtdigest_static.a
 
 include $(MK)/defs
 
-define CMAKE_DEFS +=
-	BUILD_SHARED=OFF
-	BUILD_STATIC=ON
-	ENABLE_CODECOVERAGE=OFF
-	BUILD_TESTS=OFF
-	BUILD_BENCHMARK=OFF
-	BUILD_EXAMPLES=OFF
-endef
+CMAKE_FLAGS =-DBUILD_SHARED=OFF -DBUILD_STATIC=ON -DENABLE_CODECOVERAGE=OFF -DBUILD_TESTS=OFF -DBUILD_BENCHMARK=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_C_FLAGS=-DTD_MALLOC_INCLUDE=\\\"../../../src/td_redismodule_malloc.h\\\"
 
 #----------------------------------------------------------------------------------------------
 

--- a/src/common.h
+++ b/src/common.h
@@ -9,3 +9,11 @@
 #if defined(DEBUG) || !defined(NDEBUG)
 #include "readies/cetara/diag/gdb.h"
 #endif
+
+#define RM_DEFRAG(ctx, ptr) \
+    do { \
+        void *tmp = RedisModule_DefragAlloc(ctx, ptr); \
+        if (tmp) { \
+            ptr = tmp; \
+        } \
+    } while(0);

--- a/src/common.h
+++ b/src/common.h
@@ -10,10 +10,10 @@
 #include "readies/cetara/diag/gdb.h"
 #endif
 
-#define RM_DEFRAG(ctx, ptr) \
-    do { \
-        void *tmp = RedisModule_DefragAlloc(ctx, ptr); \
-        if (tmp) { \
-            ptr = tmp; \
-        } \
-    } while(0);
+#define RM_DEFRAG(ctx, ptr)                                                                        \
+    do {                                                                                           \
+        void *tmp = RedisModule_DefragAlloc(ctx, ptr);                                             \
+        if (tmp) {                                                                                 \
+            ptr = tmp;                                                                             \
+        }                                                                                          \
+    } while (0);

--- a/src/rm_cms.c
+++ b/src/rm_cms.c
@@ -303,6 +303,12 @@ void *CMSRdbLoad(RedisModuleIO *io, int encver) {
 
 void CMSFree(void *value) { CMS_Destroy(value); }
 
+static int CMSDefrag(RedisModuleDefragCtx *ctx, RedisModuleString *key, void **value) {
+    RM_DEFRAG(ctx, *value);
+    CMSketch *cms = *value;
+    RM_DEFRAG(ctx, cms->array);
+}
+
 size_t CMSMemUsage(const void *value) {
     CMSketch *cms = (CMSketch *)value;
     return sizeof(cms) + cms->width * cms->depth * sizeof(size_t);
@@ -315,7 +321,8 @@ int CMSModule_onLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                                  .rdb_save = CMSRdbSave,
                                  .aof_rewrite = RMUtil_DefaultAofRewrite,
                                  .mem_usage = CMSMemUsage,
-                                 .free = CMSFree};
+                                 .free = CMSFree,
+                                 .defrag = CMSDefrag};
 
     CMSketchType = RedisModule_CreateDataType(ctx, "CMSk-TYPE", CMS_ENC_VER, &tm);
     if (CMSketchType == NULL)

--- a/src/rm_topk.c
+++ b/src/rm_topk.c
@@ -319,7 +319,8 @@ static int TopKDefrag(RedisModuleDefragCtx *ctx, RedisModuleString *key, void **
     RM_DEFRAG(ctx, topk->data);
     RM_DEFRAG(ctx, topk->heap);
     for (uint32_t i = 0; i < topk->k; ++i) {
-        if (topk->heap[i].item) RM_DEFRAG(ctx, topk->heap[i].item);
+        if (topk->heap[i].item)
+            RM_DEFRAG(ctx, topk->heap[i].item);
     }
 }
 

--- a/src/td_redismodule_malloc.h
+++ b/src/td_redismodule_malloc.h
@@ -1,0 +1,22 @@
+/**
+ * Adaptive histogram based on something like streaming k-means crossed with Q-digest.
+ * The implementation is a direct descendent of MergingDigest
+ * https://github.com/tdunning/t-digest/
+ *
+ * Copyright (c) 2021 Redis, All rights reserved.
+ *
+ * Allocator selection.
+ *
+ * This file is used in order to change the t-digest allocator at compile time.
+ * Just define the following defines to what you want to use. Also add
+ * the include of your alternate allocator if needed (not needed in order
+ * to use the default libc allocator). */
+
+#ifndef TD_ALLOC_H
+#define TD_ALLOC_H
+#include "../deps/RedisModulesSDK/redismodule.h"
+#define __td_malloc RedisModule_Alloc
+#define __td_calloc RedisModule_Calloc
+#define __td_realloc RedisModule_Realloc
+#define __td_free RedisModule_Free
+#endif

--- a/tests/flow/test_defrag.py
+++ b/tests/flow/test_defrag.py
@@ -1,0 +1,68 @@
+import time
+from common import *
+
+from RLTest import Defaults
+
+Defaults.decode_responses = True
+
+def enableDefrag(env):
+    # make defrag as aggressive as possible
+    env.cmd('CONFIG', 'SET', 'hz', '100')
+    env.cmd('CONFIG', 'SET', 'active-defrag-ignore-bytes', '1')
+    env.cmd('CONFIG', 'SET', 'active-defrag-threshold-lower', '0')
+    env.cmd('CONFIG', 'SET', 'active-defrag-cycle-min', '99')
+
+    try:
+        env.cmd('CONFIG', 'SET', 'activedefrag', 'yes')
+    except Exception:
+        # If active defrag is not supported by the current Redis, simply skip the test.
+        env.skip()
+
+def testDefrag(env):
+    enableDefrag(env)
+
+    # Disable defrag so we can actually create fragmentation
+    env.cmd('CONFIG', 'SET', 'activedefrag', 'no')
+    
+    # Create a key for each datatype
+    for i in range(10000):
+        env.expect('cms.initbydim', 'cms%d' % i, '20', '5').ok()
+        env.expect('cf.add', 'cf%d' % i, 'k1').equal(1)
+        env.expect('bf.add', 'bf%d' % i, 'k1').equal(1)
+        env.expect("tdigest.create", "tdigest%d" % i).ok()
+        env.expect("TDIGEST.ADD", "tdigest%d" % i, "20").ok()
+        env.expect('topk.reserve', 'topk%d' % i, '20', '50', '5', '0.9').ok()
+        env.expect('topk.add', 'topk%d' % i, 'a').equal([None])
+    
+    # Delete keys at even position
+    for i in range(0, 10000, 2):
+        env.expect('del', 'cms%d' % i).equal(1)
+        env.expect('del', 'cf%d' % i).equal(1)
+        env.expect('del', 'bf%d' % i).equal(1)
+        env.expect("del", "tdigest%d" % i).equal(1)
+        env.expect('del', 'topk%d' % i).equal(1)
+
+    # wait for fragmentation for up to 30 seconds
+    frag = env.cmd('info', 'memory')['allocator_frag_ratio']
+    startTime = time.time()
+    while frag < 1.4:
+        time.sleep(0.1)
+        frag = env.cmd('info', 'memory')['allocator_frag_ratio']
+        if time.time() - startTime > 30:
+            # We will wait for up to 30 seconds and then we consider it a failure
+            env.assertTrue(False, message='Failed waiting for fragmentation, current value %s which is expected to be above 1.4.' % frag)
+            return
+
+    #enable active defrag
+    env.cmd('CONFIG', 'SET', 'activedefrag', 'yes')
+
+    # wait for fragmentation for go down for up to 30 seconds
+    frag = env.cmd('info', 'memory')['allocator_frag_ratio']
+    startTime = time.time()
+    while frag > 1.1:
+        time.sleep(0.1)
+        frag = env.cmd('info', 'memory')['allocator_frag_ratio']
+        if time.time() - startTime > 30:
+            # We will wait for up to 30 seconds and then we consider it a failure
+            env.assertTrue(False, message='Failed waiting for fragmentation to go down, current value %s which is expected to be bellow 1.1.' % frag)
+            return

--- a/tests/flow/test_defrag.py
+++ b/tests/flow/test_defrag.py
@@ -3,8 +3,6 @@ from common import *
 
 from RLTest import Defaults
 
-Defaults.decode_responses = True
-
 def enableDefrag(env):
     # make defrag as aggressive as possible
     env.cmd('CONFIG', 'SET', 'hz', '100')
@@ -26,12 +24,12 @@ def testDefrag(env):
     
     # Create a key for each datatype
     for i in range(10000):
-        env.expect('cms.initbydim', 'cms%d' % i, '20', '5').ok()
+        env.expect('cms.initbydim', 'cms%d' % i, '20', '5').equal(b'OK')
         env.expect('cf.add', 'cf%d' % i, 'k1').equal(1)
         env.expect('bf.add', 'bf%d' % i, 'k1').equal(1)
-        env.expect("tdigest.create", "tdigest%d" % i).ok()
-        env.expect("TDIGEST.ADD", "tdigest%d" % i, "20").ok()
-        env.expect('topk.reserve', 'topk%d' % i, '20', '50', '5', '0.9').ok()
+        env.expect("tdigest.create", "tdigest%d" % i).equal(b'OK')
+        env.expect("TDIGEST.ADD", "tdigest%d" % i, "20").equal(b'OK')
+        env.expect('topk.reserve', 'topk%d' % i, '20', '50', '5', '0.9').equal(b'OK')
         env.expect('topk.add', 'topk%d' % i, 'a').equal([None])
     
     # Delete keys at even position


### PR DESCRIPTION
The PR adds support for active defrag on all probabilistic data types. The implementation is strate forward, for each pointer in each datatype we call `RedisModule_DefragAlloc` to defrag the memory pointed by the poiter.

Notice that as part of the changes, t-digest-c library was modified to use RedisModule Allocator for memory allocation. This is not the case before this PR and it was wrong, the memory allocation should be done via Redis allocator.

Test was added to cover the new functionality.