### PR TITLE
RED-134847 support active defrag on all probabilistic data types. (#25)(#28)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,6 @@ TARGET=$(BINROOT)/redisbloom.so
 
 CC_C_STD=gnu99
 
-CC_COMMON_H=$(SRCDIR)/src/common.h
-
 define CC_DEFS +=
 	_GNU_SOURCE
 	REDIS_MODULE_TARGET

--- a/build/t-digest-c/Makefile
+++ b/build/t-digest-c/Makefile
@@ -31,14 +31,11 @@ TARGET=$(BINDIR)/libtdigest_static.a
 
 include $(MK)/defs
 
-define CMAKE_DEFS +=
-	BUILD_SHARED=OFF
-	BUILD_STATIC=ON
-	ENABLE_CODECOVERAGE=OFF
-	BUILD_TESTS=OFF
-	BUILD_BENCHMARK=OFF
-	BUILD_EXAMPLES=OFF
-endef
+# CMAKE_FLAGS will be used to compile tdigest using cmake, notice that we only want to compile the static library
+# and we compile it with costume allocator that allocate data using the RedisModule Allocator.
+# If we will try to compile the tests with this option it will failed to compile but because we do
+# not really run the tdigest tests here there is no need to compile them.
+CMAKE_FLAGS =-DBUILD_SHARED=OFF -DBUILD_STATIC=ON -DENABLE_CODECOVERAGE=OFF -DBUILD_TESTS=OFF -DBUILD_BENCHMARK=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_C_FLAGS=-DTD_MALLOC_INCLUDE=\\\"../../../src/td_redismodule_malloc.h\\\"
 
 #----------------------------------------------------------------------------------------------
 

--- a/src/common.h
+++ b/src/common.h
@@ -6,6 +6,12 @@
 
 #pragma once
 
+#include "redismodule.h"
 #if defined(DEBUG) || !defined(NDEBUG)
 #include "readies/cetara/diag/gdb.h"
 #endif
+
+static inline void *defragPtr(RedisModuleDefragCtx *ctx, void *ptr) {
+    void *tmp = RedisModule_DefragAlloc(ctx, ptr);
+    return tmp ? tmp : ptr;
+}

--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -13,6 +13,7 @@
 #include "rm_topk.h"
 #include "rm_tdigest.h"
 #include "version.h"
+#include "common.h"
 #include "rmutil/util.h"
 
 #include <assert.h>
@@ -1210,6 +1211,12 @@ static size_t BFMemUsage(const void *value) {
     return rv;
 }
 
+static int BFDefrag(RedisModuleDefragCtx *ctx, RedisModuleString *key, void **value) {
+    *value = defragPtr(ctx, *value);
+    SBChain *sb = *value;
+    sb->filters = defragPtr(ctx, sb->filters);
+}
+
 static void CFFree(void *value) {
     CuckooFilter_Free(value);
     RedisModule_Free(value);
@@ -1291,6 +1298,16 @@ static size_t CFMemUsage(const void *value) {
     }
 
     return sizeof(*cf) + sizeof(*cf->filters) * cf->numFilters + filtersSize;
+}
+
+static int CFDefrag(RedisModuleDefragCtx *ctx, RedisModuleString *key, void **value) {
+    *value = defragPtr(ctx, *value);
+    CuckooFilter *cf = *value;
+    if (cf->filters)
+        cf->filters = defragPtr(ctx, cf->filters);
+    for (size_t ii = 0; ii < cf->numFilters; ++ii) {
+        cf->filters[ii].data = defragPtr(ctx, cf->filters[ii].data);
+    }
 }
 
 static void CFAofRewrite(RedisModuleIO *aof, RedisModuleString *key, void *obj) {
@@ -1445,7 +1462,8 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
                                                .rdb_save = BFRdbSave,
                                                .aof_rewrite = BFAofRewrite,
                                                .free = BFFree,
-                                               .mem_usage = BFMemUsage};
+                                               .mem_usage = BFMemUsage,
+                                               .defrag = BFDefrag};
     BFType = RedisModule_CreateDataType(ctx, "MBbloom--", BF_MIN_GROWTH_ENC, &typeprocs);
     if (BFType == NULL) {
         return REDISMODULE_ERR;
@@ -1456,7 +1474,8 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
                                                  .rdb_save = CFRdbSave,
                                                  .aof_rewrite = CFAofRewrite,
                                                  .free = CFFree,
-                                                 .mem_usage = CFMemUsage};
+                                                 .mem_usage = CFMemUsage,
+                                                 .defrag = CFDefrag};
     CFType = RedisModule_CreateDataType(ctx, "MBbloomCF", CF_MIN_EXPANSION_VERSION, &cfTypeProcs);
     if (CFType == NULL) {
         return REDISMODULE_ERR;

--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -10,6 +10,7 @@
 #include "rm_cms.h"
 
 #include "redismodule.h"
+#include "common.h"
 
 #include <math.h>
 #include <stdlib.h>
@@ -898,6 +899,13 @@ void TDigestFree(void *value) {
     td_free(tdigest);
 }
 
+static int TDigestDefrag(RedisModuleDefragCtx *ctx, RedisModuleString *key, void **value) {
+    *value = defragPtr(ctx, *value);
+    td_histogram_t *tdigest = *value;
+    tdigest->nodes_mean = defragPtr(ctx, tdigest->nodes_mean);
+    tdigest->nodes_weight = defragPtr(ctx, tdigest->nodes_weight);
+}
+
 size_t TDigestMemUsage(const void *value) {
     td_histogram_t *tdigest = (td_histogram_t *)value;
     size_t size = sizeof(tdigest);
@@ -912,7 +920,8 @@ int TDigestModule_onLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
                                  .rdb_save = TDigestRdbSave,
                                  .aof_rewrite = RMUtil_DefaultAofRewrite,
                                  .mem_usage = TDigestMemUsage,
-                                 .free = TDigestFree};
+                                 .free = TDigestFree,
+                                 .defrag = TDigestDefrag};
 
     TDigestSketchType = RedisModule_CreateDataType(ctx, "TDIS-TYPE", TDIGEST_ENC_VER, &tm);
     if (TDigestSketchType == NULL)

--- a/src/rm_topk.c
+++ b/src/rm_topk.c
@@ -12,6 +12,7 @@
 #include "topk.h"
 #include "rm_topk.h"
 #include "rm_cms.h"
+#include "common.h"
 
 // clang-format off
 #define INNER_ERROR(x) \
@@ -312,6 +313,17 @@ static void *TopKRdbLoad(RedisModuleIO *io, int encver) {
 
 static void TopKFree(void *value) { TopK_Destroy(value); }
 
+static int TopKDefrag(RedisModuleDefragCtx *ctx, RedisModuleString *key, void **value) {
+    *value = defragPtr(ctx, *value);
+    TopK *topk = *value;
+    topk->data = defragPtr(ctx, topk->data);
+    topk->heap = defragPtr(ctx, topk->heap);
+    for (uint32_t i = 0; i < topk->k; ++i) {
+        if (topk->heap[i].item)
+            topk->heap[i].item = defragPtr(ctx, topk->heap[i].item);
+    }
+}
+
 static size_t TopKMemUsage(const void *value) {
     TopK *topk = (TopK *)value;
     return sizeof(TopK) + ((size_t)topk->width) * topk->depth * sizeof(Bucket) +
@@ -325,7 +337,8 @@ int TopKModule_onLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
                                  .rdb_save = TopKRdbSave,
                                  .aof_rewrite = RMUtil_DefaultAofRewrite,
                                  .mem_usage = TopKMemUsage,
-                                 .free = TopKFree};
+                                 .free = TopKFree,
+                                 .defrag = TopKDefrag};
 
     TopKType = RedisModule_CreateDataType(ctx, "TopK-TYPE", TOPK_ENC_VER, &tm);
     if (TopKType == NULL)

--- a/src/td_redismodule_malloc.h
+++ b/src/td_redismodule_malloc.h
@@ -1,0 +1,22 @@
+/**
+ * Adaptive histogram based on something like streaming k-means crossed with Q-digest.
+ * The implementation is a direct descendent of MergingDigest
+ * https://github.com/tdunning/t-digest/
+ *
+ * Copyright (c) 2021 Redis, All rights reserved.
+ *
+ * Allocator selection.
+ *
+ * This file is used in order to change the t-digest allocator at compile time.
+ * Just define the following defines to what you want to use. Also add
+ * the include of your alternate allocator if needed (not needed in order
+ * to use the default libc allocator). */
+
+#ifndef TD_ALLOC_H
+#define TD_ALLOC_H
+#include "../deps/RedisModulesSDK/redismodule.h"
+#define __td_malloc RedisModule_Alloc
+#define __td_calloc RedisModule_Calloc
+#define __td_realloc RedisModule_Realloc
+#define __td_free RedisModule_Free
+#endif

--- a/tests/flow/test_defrag.py
+++ b/tests/flow/test_defrag.py
@@ -1,0 +1,71 @@
+import time
+from common import *
+
+from RLTest import Defaults
+
+def enableDefrag(env):
+    version = env.cmd('info', 'server')['redis_version']
+    if '6.0' in version:
+        # skil on version 6.0 and defrag API for modules was not supported on this version.
+        env.skip()
+
+    # make defrag as aggressive as possible
+    env.cmd('CONFIG', 'SET', 'hz', '100')
+    env.cmd('CONFIG', 'SET', 'active-defrag-ignore-bytes', '1')
+    env.cmd('CONFIG', 'SET', 'active-defrag-threshold-lower', '0')
+    env.cmd('CONFIG', 'SET', 'active-defrag-cycle-min', '99')
+
+    try:
+        env.cmd('CONFIG', 'SET', 'activedefrag', 'yes')
+    except Exception:
+        # If active defrag is not supported by the current Redis, simply skip the test.
+        env.skip()
+
+def testDefrag(env):
+    enableDefrag(env)
+
+    # Disable defrag so we can actually create fragmentation
+    env.cmd('CONFIG', 'SET', 'activedefrag', 'no')
+    
+    # Create a key for each datatype
+    for i in range(10000):
+        env.expect('cms.initbydim', 'cms%d' % i, '20', '5').equal(b'OK')
+        env.expect('cf.add', 'cf%d' % i, 'k1').equal(1)
+        env.expect('bf.add', 'bf%d' % i, 'k1').equal(1)
+        env.expect("tdigest.create", "tdigest%d" % i).equal(b'OK')
+        env.expect("TDIGEST.ADD", "tdigest%d" % i, "20").equal(b'OK')
+        env.expect('topk.reserve', 'topk%d' % i, '20', '50', '5', '0.9').equal(b'OK')
+        env.expect('topk.add', 'topk%d' % i, 'a').equal([None])
+    
+    # Delete keys at even position
+    for i in range(0, 10000, 2):
+        env.expect('del', 'cms%d' % i).equal(1)
+        env.expect('del', 'cf%d' % i).equal(1)
+        env.expect('del', 'bf%d' % i).equal(1)
+        env.expect("del", "tdigest%d" % i).equal(1)
+        env.expect('del', 'topk%d' % i).equal(1)
+
+    # wait for fragmentation for up to 30 seconds
+    frag = env.cmd('info', 'memory')['allocator_frag_ratio']
+    startTime = time.time()
+    while frag < 1.4:
+        time.sleep(0.1)
+        frag = env.cmd('info', 'memory')['allocator_frag_ratio']
+        if time.time() - startTime > 30:
+            # We will wait for up to 30 seconds and then we consider it a failure
+            env.assertTrue(False, message='Failed waiting for fragmentation, current value %s which is expected to be above 1.4.' % frag)
+            return
+
+    #enable active defrag
+    env.cmd('CONFIG', 'SET', 'activedefrag', 'yes')
+
+    # wait for fragmentation for go down for up to 30 seconds
+    frag = env.cmd('info', 'memory')['allocator_frag_ratio']
+    startTime = time.time()
+    while frag > 1.1:
+        time.sleep(0.1)
+        frag = env.cmd('info', 'memory')['allocator_frag_ratio']
+        if time.time() - startTime > 30:
+            # We will wait for up to 30 seconds and then we consider it a failure
+            env.assertTrue(False, message='Failed waiting for fragmentation to go down, current value %s which is expected to be bellow 1.1.' % frag)
+            return


### PR DESCRIPTION

The PR adds support for active defrag on all probabilistic data types. The implementation is strate forward, for each pointer in each datatype we call `RedisModule_DefragAlloc` to defrag the memory pointed by the poiter.

Notice that as part of the changes, t-digest-c library was modified to use RedisModule Allocator for memory allocation. This is not the case before this PR and it was wrong, the memory allocation should be done via Redis allocator.

Test was added to cover the new functionality.

(cherry picked from commit 00cc08d2d3284f025bc18b650d41301619abb606) (cherry picked from commit 202a4b2c7b34be49e5fc0edbf6b34e711af6f69e)