### PR TITLE
MOD-7946 CP into 2.4 - pin redis-py version to 5.0.8 (#806)

### DIFF
--- a/tests/flow/requirements.txt
+++ b/tests/flow/requirements.txt
@@ -1,2 +1,3 @@
 RLTest ~= 0.7.2
+redis~=5.0.8
 numpy


### PR DESCRIPTION
(cherry picked from commit 8edac98a518104e61b7bd76f89687cbeb7b9440d)