### PR TITLE
MOD-9015 backport Log configs using new names to 8.0 (#862)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -140,11 +140,11 @@ static RedisModuleString *getIntegerValue(const char *name, void *privdata) {
             RedisModule_Log(ctx, "warning", "Failed to register config option `%s`", name);        \
             return REDISMODULE_ERR;                                                                \
         }                                                                                          \
+        RedisModule_Log(ctx, "notice", "\t{ %-*s:%*s }", 20, name, 10, default_val);               \
     } while (0)
 
 int RM_RegisterConfigs(RedisModuleCtx *ctx) {
-    RedisModule_Log(ctx, "notice", "Registering configuration options");
-
+    RedisModule_Log(ctx, "notice", "Registering configuration options: [");
     registerConfigVar(bf_error_rate);
     registerConfigVar(bf_initial_size);
     registerConfigVar(bf_expansion_factor);
@@ -153,6 +153,7 @@ int RM_RegisterConfigs(RedisModuleCtx *ctx) {
     registerConfigVar(cf_max_iterations);
     registerConfigVar(cf_expansion_factor);
     registerConfigVar(cf_max_expansions);
+    RedisModule_Log(ctx, "notice", "]");
 
     return REDISMODULE_OK;
 }

--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -1446,13 +1446,13 @@ static int rsStrcasecmp(const RedisModuleString *rs1, const char *s2) {
     ({                                                                                             \
         const bool legacy = !rsStrcasecmp(argv[idx], configNameLegacy);                            \
         if (legacy || !RM_ConfigRMStrCaseCmp(argv[idx], configName)) {                             \
-            getConfigFromString(argv[idx + 1], configName);                                        \
             if (legacy) {                                                                          \
                 RedisModule_Log(ctx, "warning",                                                    \
                                 "The '" configNameLegacy                                           \
                                 "' configuration is deprecated. Please use '%s' instead",          \
                                 RM_ConfigOptionToString(configName));                              \
             }                                                                                      \
+            getConfigFromString(argv[idx + 1], configName);                                        \
             continue;                                                                              \
         };                                                                                         \
     })
@@ -1488,7 +1488,8 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
     }
     if (rm_config.bf_error_rate.value > BF_ERROR_RATE_CAP) {
         rm_config.bf_error_rate.value = BF_ERROR_RATE_CAP;
-        RedisModule_Log(ctx, "warning", "Error rate is capped at %f", BF_ERROR_RATE_CAP);
+        RedisModule_Log(ctx, "warning", "%s is capped at %f",
+                        RM_ConfigOptionToString(bf_error_rate), BF_ERROR_RATE_CAP);
     }
 
     if (!RedisModule_RegisterStringConfig || !RedisModule_LoadConfigs) {


### PR DESCRIPTION
#862 
[MOD-9015](https://redislabs.atlassian.net/browse/MOD-9015)

[MOD-9015]: https://redislabs.atlassian.net/browse/MOD-9015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ