### PR TITLE
Fix BF.INSERT short-option OOB read

### DIFF
--- a/tests/flow/test_overall.py
+++ b/tests/flow/test_overall.py
@@ -183,6 +183,8 @@ class testRedisBloom():
             env.cmd('bf.insert', 'missingFilter', 'NOCREATE', 'ITEMS', 'foo', 'bar')
         with env.assertResponseError():
             env.cmd('bf.insert', 'missingFilter', 'DONTEXIST', 'NOCREATE')
+        env.expect('bf.insert', 'missingFilter', 'n', 'ITEMS', 'foo').error().contains(
+            'Unknown argument received')
         with env.assertResponseError():
             env.cmd('bf.insert', 'missingFilter')
         with env.assertResponseError():


### PR DESCRIPTION
This PR fixes an out-of-bounds read in `BF.INSERT` option parsing.

- Replaced index-based parsing with length-checked keyword matching.
- Removed unsafe reads from short option tokens.
- Added a regression test to ensure short invalid tokens (e.g. `"n"`) return `Unknown argument received`.

Validated with ASan: the previous trigger no longer crashes.