### PR TITLE
MOD-14675 - oss refresh list

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -22,9 +22,9 @@ runs:
         fi
         echo ::group::Activate virtual environment
         python3 -m venv venv
-        echo "source $PWD/venv/bin/activate" >> ~/.bash_profile
-        . venv/bin/activate
-        echo ". venv/bin/activate" >> $HOME/.bash_profile
+        echo "source ${GITHUB_WORKSPACE}/venv/bin/activate" >> ~/.bashrc
+        echo "source ${GITHUB_WORKSPACE}/venv/bin/activate" >> ~/.zshrc
+        . "${GITHUB_WORKSPACE}/venv/bin/activate"
         echo ::endgroup::
         echo ::group::Install python dependencies
           ./.install/common_installations.sh

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -37,18 +37,16 @@ runs:
       shell: bash
       id: set-git-info
       run: |
-        if [[ "${{github.event_name}}" == "pull_request" ]]; then
-          BRANCH="${{github.event.pull_request.base.ref}}"
-        else
+        if [[ "${{github.event_name}}" != "pull_request" ]]; then
           REF="${{ github.ref }}"
-          BRANCH_PATTERN="^refs/heads/(.*)$"
           TAG_PATTERN="^refs/tags/(.*)$"
-          if [[ $REF =~ $BRANCH_PATTERN ]]; then
-            BRANCH=${BASH_REMATCH[1]}
-          fi
           if [[ $REF =~ $TAG_PATTERN ]]; then
             TAG=${BASH_REMATCH[1]}
           fi
+        fi
+
+        if [[ -z $TAG ]]; then
+          BRANCH=${{ github.head_ref || github.ref_name }}
         fi
         echo "TAG=${TAG}" >> $GITHUB_OUTPUT
         echo "BRANCH=${BRANCH}" >> $GITHUB_OUTPUT
@@ -56,12 +54,13 @@ runs:
     - name: Set the tagged flag
       shell: bash
       id: set-tagged
+      env:
+        REF: ${{ inputs.github-ref }}
       run: |
         # If this is a version tag, then set to false, meaning this
         # is not a production build.
-        export REF="${{ inputs.github-ref }}"
         export PATTERN="refs/tags/v[0-9]+.*"
-        if [[ $REF =~ $PATTERN ]]; then
+        if [[ "$REF" =~ $PATTERN ]]; then
           echo "This is a tagged build"
           echo "TAGGED=1" >> $GITHUB_OUTPUT
         else

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -51,7 +51,7 @@ jobs:
     needs: [prepare-values]
     with:
       arch: x64
-      os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine
+      os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       beta-version: ${{needs.prepare-values.outputs.beta-version}}
     secrets: inherit
@@ -60,7 +60,7 @@ jobs:
     needs: [prepare-values]
     with:
       arch: arm64
-      os: bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine
+      os: bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       beta-version: ${{needs.prepare-values.outputs.beta-version}}
     secrets: inherit

--- a/.github/workflows/event-tag.yml
+++ b/.github/workflows/event-tag.yml
@@ -31,7 +31,7 @@ jobs:
     needs: [prepare-values]
     with:
       arch: x64
-      os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine
+      os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
     secrets: inherit
   build-linux-arm64:
@@ -39,7 +39,7 @@ jobs:
     needs: [prepare-values]
     with:
       arch: arm64
-      os: bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine
+      os: bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
     secrets: inherit
   macos:

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -18,7 +18,7 @@ on:
         required: true
         default: 'x64'
       os:
-        description: 'OS to build on (space-separated, e.g. "focal jammy rocky9")'
+        description: 'OS to build on (space-separated, e.g. "jammy noble resolute rocky10")'
         type: string
         required: false
         default: ''
@@ -46,7 +46,7 @@ on:
         type: string
         required: true
       os:
-        description: 'OS to build on (space-separated, e.g. "focal jammy rocky9")'
+        description: 'OS to build on (space-separated, e.g. "jammy noble resolute rocky10")'
         type: string
         required: false
         default: ''
@@ -99,9 +99,9 @@ jobs:
           OS="${{ inputs.os }}"
           if [ -z "${OS}" ]; then
             if [ "${{ inputs.arch }}" == "arm64" ]; then
-              OS="bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine"
+              OS="bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2"
             else
-              OS="bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine"
+              OS="bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie"
             fi
           fi
           MATRIX="["
@@ -175,6 +175,8 @@ jobs:
 
       - name: Pack module
         if: ${{ !inputs.run_valgrind && !inputs.run_sanitizer }}
+        env:
+          BETA_VERSION: ${{ inputs.beta-version }}
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
@@ -182,12 +184,14 @@ jobs:
             -e BRANCH=${{ env.BRANCH }} \
             -e VERSION=${{ env.VERSION }} \
             -e TAGGED=${{ env.TAGGED }} \
-            -e BETA_VERSION=${{ inputs.beta-version }} \
+            -e BETA_VERSION="${BETA_VERSION}" \
             ${{ env.DOCKER_IMAGE }} \
             bash -c "git config --global --add safe.directory /workspace && make pack BRANCH=${{ env.TAG_OR_BRANCH }} SHOW=1"
 
       - name: Upload artifacts to S3
         if: ${{ !inputs.run_valgrind && !inputs.run_sanitizer }}
+        env:
+          BETA_VERSION: ${{ inputs.beta-version }}
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
@@ -195,6 +199,6 @@ jobs:
             -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
             -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
             -e GITHUB_REF=${{ github.ref }} \
-            -e BETA_VERSION=${{ inputs.beta-version }} \
+            -e BETA_VERSION="${BETA_VERSION}" \
             ${{ env.DOCKER_IMAGE }} \
             bash -c "git config --global --add safe.directory /workspace && ./sbin/upload-artifacts-s3"

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           OS="${{ inputs.os }}"
           if [ -z "${OS}" ]; then
-            OS='["macos-14", "macos-15", "macos-26"]'
+            OS='["macos-14", "macos-15", "macos-26", "macos-14-large", "macos-15-intel", "macos-26-intel"]'
           else
             OS='["${OS}"]'
           fi
@@ -127,6 +127,13 @@ jobs:
           ref: ${{ needs.prepare-values.outputs.redis-ref }}
           path: 'redis'
           submodules: recursive
+      - name: Setup macOS 26 SDK
+        if: startsWith(matrix.os, 'macos-26')
+        run: |
+          _SDK="$(xcrun --sdk macosx --show-sdk-path)"
+          echo "SDKROOT=$_SDK" >> $GITHUB_ENV
+          echo "CC=/usr/bin/clang" >> $GITHUB_ENV
+          echo "CXX=/usr/bin/clang++" >> $GITHUB_ENV
       - name: Setup specific
         working-directory: .install
         run: ./install_script.sh

--- a/.github/workflows/flow-random-traffic.yml
+++ b/.github/workflows/flow-random-traffic.yml
@@ -46,7 +46,7 @@ jobs:
             echo "os=${INPUT_OS}" >> $GITHUB_OUTPUT
             echo "Using specified OS: ${INPUT_OS}"
           else
-            OS_LIST=(bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 azurelinux3 mariner2 alpine)
+            OS_LIST=(bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie)
             RANDOM_INDEX=$((RANDOM % ${#OS_LIST[@]}))
             SELECTED=${OS_LIST[$RANDOM_INDEX]}
             echo "os=${SELECTED}" >> $GITHUB_OUTPUT

--- a/Dockerfile.alma10
+++ b/Dockerfile.alma10
@@ -1,16 +1,12 @@
-FROM rockylinux:8
+# AlmaLinux 10.x — Redis 8.8 support matrix
+FROM almalinux:10
 
 WORKDIR /workspace
 
-RUN dnf update -y
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dnf -y update
+RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip clang jq
 
-RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf config-manager --set-enabled powertools
-RUN dnf install epel-release -yqq
-RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl python3.11-devel
-
-RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
@@ -23,6 +19,5 @@ ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-
 COPY requirements_docker.txt /workspace/requirements.txt
 RUN uv pip install -r requirements.txt

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -1,14 +1,15 @@
-FROM rockylinux:8
+FROM almalinux:8
 
 WORKDIR /workspace
 
-RUN dnf update -y
+RUN dnf -y update
+RUN dnf -y install epel-release
+RUN dnf -y install dnf-plugins-core
+RUN dnf config-manager --set-enabled powertools || dnf config-manager --set-enabled crb || true
 
 RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf config-manager --set-enabled powertools
-RUN dnf install epel-release -yqq
 RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl python3.11-devel
+    bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl jq python3.11-devel
 
 RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 COPY .install /workspace/.install
@@ -23,6 +24,5 @@ ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-
 COPY requirements_docker.txt /workspace/requirements.txt
 RUN uv pip install -r requirements.txt

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -1,16 +1,12 @@
-FROM rockylinux:8
+FROM almalinux:9
 
 WORKDIR /workspace
 
-RUN dnf update -y
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dnf -y update
+RUN dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ make wget git openssl openssl-devel which rsync unzip clang jq
+RUN cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh
 
-RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf config-manager --set-enabled powertools
-RUN dnf install epel-release -yqq
-RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl python3.11-devel
-
-RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
@@ -23,6 +19,5 @@ ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-
 COPY requirements_docker.txt /workspace/requirements.txt
 RUN uv pip install -r requirements.txt

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -1,16 +1,14 @@
-FROM rockylinux:8
+FROM debian:bookworm
 
 WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN dnf update -y
+RUN apt update -qq \
+    && apt upgrade -yqq \
+    && apt-get update \
+    && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
+    rsync unzip libclang-dev clang python3-dev
 
-RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf config-manager --set-enabled powertools
-RUN dnf install epel-release -yqq
-RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl python3.11-devel
-
-RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
@@ -23,6 +21,5 @@ ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-
 COPY requirements_docker.txt /workspace/requirements.txt
 RUN uv pip install -r requirements.txt

--- a/Dockerfile.noble
+++ b/Dockerfile.noble
@@ -1,0 +1,39 @@
+# Ubuntu 24.04 LTS (Noble Numbat) — Redis 8.8 support matrix
+FROM ubuntu:24.04
+
+WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    make \
+    gcc \
+    g++ \
+    gdb \
+    clang \
+    valgrind \
+    git \
+    jq \
+    libssl-dev \
+    autoconf \
+    automake \
+    libtool \
+    cmake \
+    curl \
+    wget \
+    libblocksruntime-dev \
+    unzip \
+    rsync
+
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requirements_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.resolute
+++ b/Dockerfile.resolute
@@ -1,0 +1,39 @@
+# Ubuntu 26.04 LTS (Resolute Raccoon) — Redis 8.8 support matrix
+FROM ubuntu:26.04
+
+WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    make \
+    gcc \
+    g++ \
+    gdb \
+    clang \
+    valgrind \
+    git \
+    jq \
+    libssl-dev \
+    autoconf \
+    automake \
+    libtool \
+    cmake \
+    curl \
+    wget \
+    libblocksruntime-dev \
+    unzip \
+    rsync
+
+ARG REDIS_REF=unstable
+ARG SANITIZER=
+COPY .install /workspace/.install
+RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh
+ENV PATH="/usr/local/bin:${PATH}"
+RUN uv venv --python=3.11 /opt/.venv
+ENV VIRTUAL_ENV=/opt/.venv
+ENV PATH="/opt/.venv/bin:${PATH}"
+COPY requirements_docker.txt /workspace/requirements.txt
+RUN uv pip install -r requirements.txt

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -1,16 +1,12 @@
-FROM rockylinux:8
+# Rocky Linux 10.x — Redis 8.8 support matrix (official library tag may lag; quay is canonical)
+FROM quay.io/rockylinux/rockylinux:10
 
 WORKDIR /workspace
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN dnf update -y
+RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync unzip clang jq
 
-RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf config-manager --set-enabled powertools
-RUN dnf install epel-release -yqq
-RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl python3.11-devel
-
-RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
@@ -23,6 +19,5 @@ ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-
 COPY requirements_docker.txt /workspace/requirements.txt
 RUN uv pip install -r requirements.txt

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -1,16 +1,14 @@
-FROM rockylinux:8
+FROM debian:trixie
 
 WORKDIR /workspace
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN dnf update -y
+RUN apt update -qq \
+    && apt upgrade -yqq \
+    && apt-get update \
+    && apt install -yqq git wget curl build-essential lcov openssl libssl-dev \
+    rsync unzip libclang-dev clang
 
-RUN dnf groupinstall "Development Tools" -yqq
-RUN dnf config-manager --set-enabled powertools
-RUN dnf install epel-release -yqq
-RUN dnf install -y gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel make wget git openssl openssl-devel \
-    bzip2-devel libffi-devel zlib-devel tar xz which rsync clang curl python3.11-devel
-
-RUN cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
@@ -23,6 +21,5 @@ ENV PATH="/usr/local/bin:${PATH}"
 RUN uv venv --python=3.11 /opt/.venv
 ENV VIRTUAL_ENV=/opt/.venv
 ENV PATH="/opt/.venv/bin:${PATH}"
-
 COPY requirements_docker.txt /workspace/requirements.txt
 RUN uv pip install -r requirements.txt

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -66,18 +66,27 @@ OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS=Linux
 
 OSNICK=$($READIES/bin/platform --osnick)
+# platform reports centosN on Alma; use real ID from the image
+if [[ -r /etc/os-release ]]; then
+	# shellcheck disable=SC1091
+	. /etc/os-release
+	[[ ${ID:-} == almalinux ]] && OSNICK=alma${VERSION_ID%%.*}
+fi
 [[ $OSNICK == trusty ]]  && OSNICK=ubuntu14.04
 [[ $OSNICK == xenial ]]  && OSNICK=ubuntu16.04
 [[ $OSNICK == bionic ]]  && OSNICK=ubuntu18.04
 [[ $OSNICK == focal ]]   && OSNICK=ubuntu20.04
 [[ $OSNICK == jammy ]]   && OSNICK=ubuntu22.04
+[[ $OSNICK == noble ]]   && OSNICK=ubuntu24.04
+[[ $OSNICK == resolute ]] && OSNICK=ubuntu26.04
 [[ $OSNICK == centos7 ]] && OSNICK=rhel7
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
 [[ $OSNICK == centos9 ]] && OSNICK=rhel9
+[[ $OSNICK == centos10 ]] && OSNICK=rhel10
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
 [[ $OSNICK == rocky9 ]]  && OSNICK=rhel9
-
+[[ $OSNICK == rocky10 ]] && OSNICK=rhel10
 
 PLATFORM="$OS-$OSNICK-$ARCH"
 

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -42,17 +42,26 @@ OS=$($READIES/bin/platform --os)
 [[ $OS == linux ]] && OS="Linux"
 
 [[ -z $OSNICK ]] && OSNICK=$($READIES/bin/platform --osnick)
+if [[ -r /etc/os-release ]]; then
+	# shellcheck disable=SC1091
+	. /etc/os-release
+	[[ ${ID:-} == almalinux ]] && OSNICK=alma${VERSION_ID%%.*}
+fi
 [[ $OSNICK == trusty ]]  && OSNICK=ubuntu14.04
 [[ $OSNICK == xenial ]]  && OSNICK=ubuntu16.04
 [[ $OSNICK == bionic ]]  && OSNICK=ubuntu18.04
 [[ $OSNICK == focal ]]   && OSNICK=ubuntu20.04
 [[ $OSNICK == jammy ]]   && OSNICK=ubuntu22.04
+[[ $OSNICK == noble ]]   && OSNICK=ubuntu24.04
+[[ $OSNICK == resolute ]] && OSNICK=ubuntu26.04
 [[ $OSNICK == centos7 ]] && OSNICK=rhel7
 [[ $OSNICK == centos8 ]] && OSNICK=rhel8
 [[ $OSNICK == centos9 ]] && OSNICK=rhel9
+[[ $OSNICK == centos10 ]] && OSNICK=rhel10
 [[ $OSNICK == ol8 ]]     && OSNICK=rhel8
 [[ $OSNICK == rocky8 ]]  && OSNICK=rhel8
 [[ $OSNICK == rocky9 ]]  && OSNICK=rhel9
+[[ $OSNICK == rocky10 ]] && OSNICK=rhel10
 
 PLATFORM="$OS-$OSNICK-$ARCH"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes primarily affect CI/build packaging and artifact naming across many platforms; failures would surface as broken builds, incorrect platform labels, or missing uploads rather than runtime product regressions.
> 
> **Overview**
> Extends the CI/build support matrix across workflows to include **new Linux distros** (Ubuntu `noble`/`resolute`, Rocky `10`, Alma `8`/`9`/`10`, Debian `bookworm`/`trixie`) and **additional macOS runners** (including `*-intel` and `*-large` variants), plus a macOS-26-specific SDK setup step.
> 
> Adds new Dockerfiles for the newly supported Linux platforms and refreshes the existing `Dockerfile.rocky8` package/toolchain setup. Updates packaging/upload scripts (`sbin/pack.sh`, `sbin/upload-artifacts`) to correctly derive `OSNICK` for Alma and map the new Ubuntu/RHEL/Rocky versions.
> 
> Tightens workflow plumbing: `setup-env` branch/tag resolution is simplified (using `github.head_ref`/`github.ref_name`), `run-tests` venv activation is made workspace-absolute and persisted via `~/.bashrc`/`~/.zshrc`, and `flow-linux` passes `BETA_VERSION` via step env to Docker runs for pack/upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8186d47c3a6a14c1291dac389c769504c4aa868e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->