### PR TITLE
MOD-12727 unique snapshot name + new output params for nighly event

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -31,7 +31,12 @@ jobs:
     outputs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
       beta-version: ${{ steps.set-env.outputs.beta-version }}
+      module-version: ${{ steps.get-version.outputs.module-version }}
+      snapshot-template: ${{ steps.set-env.outputs.snapshot-template }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: set env
         id: set-env
         run: |
@@ -43,9 +48,33 @@ jobs:
           TIME_PART=$(date +'%H%M%S')
           RUN_NUMBER="${{ github.run_number }}"
           BETA_VERSION="${DATE_PART}.${TIME_PART}.${RUN_NUMBER}"
+          TIMESTAMP="${DATE_PART}.${TIME_PART}"
+          WORKFLOW_NUM="${RUN_NUMBER}"
           
           echo "beta-version=${BETA_VERSION}" >> $GITHUB_OUTPUT
           echo "Generated beta version: ${BETA_VERSION}"
+
+          BRANCH_NAME="${{ github.ref_name }}"
+          BRANCH_NAME="${BRANCH_NAME//[^A-Za-z0-9._-]/_}"
+          SNAPSHOT_TEMPLATE="redisbloom/snapshots/redisbloom.@OS.${BRANCH_NAME}.${TIMESTAMP}.${WORKFLOW_NUM}.zip"
+          echo "snapshot-template=${SNAPSHOT_TEMPLATE}" >> $GITHUB_OUTPUT
+          echo "Snapshot template: ${SNAPSHOT_TEMPLATE}"
+
+      - name: Extract module version
+        id: get-version
+        run: |
+          MAJOR=$(grep '#define REBLOOM_VERSION_MAJOR' src/version.h | awk '{print $3}')
+          MINOR=$(grep '#define REBLOOM_VERSION_MINOR' src/version.h | awk '{print $3}')
+          PATCH=$(grep '#define REBLOOM_VERSION_PATCH' src/version.h | awk '{print $3}')
+          MODULE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "module-version=${MODULE_VERSION}" >> $GITHUB_OUTPUT
+          echo "Module version: ${MODULE_VERSION}"
+
+      - name: Summary
+        run: |
+          echo "### Nightly Build Info" >> $GITHUB_STEP_SUMMARY
+          echo "- **Module Version:** ${{ steps.get-version.outputs.module-version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Snapshot Template:** \`${{ steps.set-env.outputs.snapshot-template }}\`" >> $GITHUB_STEP_SUMMARY
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -351,6 +351,11 @@ if [[ $WITH_GITSHA == 1 ]]; then
 	BRANCH="${BRANCH}-${GIT_COMMIT}"
 fi
 
+if [[ -n $BETA_VERSION ]]; then
+	BETA_SUFFIX=$(echo "$BETA_VERSION" | cut -d'.' -f4,5,6)
+	BRANCH="${BRANCH}.${BETA_SUFFIX}"
+fi
+
 #----------------------------------------------------------------------------------------------
 
 RELEASE_ramp=${PACKAGE_NAME}.$OS-$OSNICK-$ARCH.$SEMVER${VARIANT}.zip

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -352,8 +352,7 @@ if [[ $WITH_GITSHA == 1 ]]; then
 fi
 
 if [[ -n $BETA_VERSION ]]; then
-	BETA_SUFFIX=$(echo "$BETA_VERSION" | cut -d'.' -f4,5,6)
-	BRANCH="${BRANCH}.${BETA_SUFFIX}"
+	BRANCH="${BRANCH}.${BETA_VERSION}"
 fi
 
 #----------------------------------------------------------------------------------------------


### PR DESCRIPTION
1. Make snapshot upload artifact name unique
2. Adding two output parameters to nightly event(snapshot name and version number)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI outputs and snapshot/package naming by appending beta/timestamp data, which could break downstream tooling that expects previous artifact names or S3 paths. No runtime code paths are affected beyond build/packaging scripts.
> 
> **Overview**
> Nightly workflow now computes and exposes additional metadata: `module-version` (parsed from `src/version.h`) and a unique `snapshot-template` that includes branch, timestamp, and run number, and writes both into the GitHub job summary.
> 
> Packaging (`sbin/pack.sh`) now appends `BETA_VERSION` to the computed `BRANCH` string, making snapshot artifact names unique across nightly runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17561afcf0b5fae809db29297d4b1760753fba0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->