### PR TITLE
MOD-14675 - fix event nightly to 8.2

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -3,6 +3,7 @@ name: Event Nightly
 permissions:
   id-token: write
   contents: read
+  actions: read
 
 on:
   push:
@@ -84,12 +85,4 @@ jobs:
     secrets: inherit
   linter:
     uses: ./.github/workflows/flow-linter.yml
-    secrets: inherit
-  test-summary:
-    uses: ./.github/workflows/test-summary.yml
-    needs: [prepare-values, build-linux-x64, build-linux-arm64, macos, linux-valgrind, linux-sanitizer]
-    if: always() && (github.event_name == 'schedule' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.send-slack-message == true))
-    with:
-      redis-ref: ${{ needs.prepare-values.outputs.redis-ref }}
-      send-slack-message: ${{ github.event_name == 'schedule' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.send-slack-message == true) }}
     secrets: inherit


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it removes the `test-summary`/Slack reporting step which could reduce visibility into nightly failures.
> 
> **Overview**
> **Event Nightly workflow behavior changes.** Adds `actions: read` to the workflow `permissions`.
> 
> Removes the `test-summary` job (and its conditional Slack notification) from `.github/workflows/event-nightly.yml`, leaving the build/test matrix, spellcheck, and linter jobs without the aggregated summary step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28e80eebba562c1c9b0df8a6750477b648af17ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->