### PR TITLE
MOD-14675 - fix event nightly to 8.0

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -3,6 +3,7 @@ name: Event Nightly
 permissions:
   id-token: write
   contents: read
+  actions: read
 
 on:
   push:
@@ -84,12 +85,4 @@ jobs:
     secrets: inherit
   linter:
     uses: ./.github/workflows/flow-linter.yml
-    secrets: inherit
-  test-summary:
-    uses: ./.github/workflows/test-summary.yml
-    needs: [prepare-values, build-linux-x64, build-linux-arm64, macos, linux-valgrind, linux-sanitizer]
-    if: always() && (github.event_name == 'schedule' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.send-slack-message == true))
-    with:
-      redis-ref: ${{ needs.prepare-values.outputs.redis-ref }}
-      send-slack-message: ${{ github.event_name == 'schedule' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.send-slack-message == true) }}
     secrets: inherit


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions workflow permissions and job orchestration, with no product code impact. Main risk is reduced visibility if the removed test summary/slack reporting was relied on.
> 
> **Overview**
> Updates the `Event Nightly` GitHub Actions workflow by granting `actions: read` permissions.
> 
> Removes the `test-summary` job (and its conditional Slack notification), leaving the build/test matrix plus `spellcheck` and `linter` jobs without a final aggregation step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08ccf9354be2ee3972e9cb1aab2ef740fb5f95c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->