### PR TITLE
MOD-14675 fix event nightly to 2.8

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -3,6 +3,7 @@ name: Event Nightly
 permissions:
   id-token: write
   contents: read
+  actions: read
 
 on:
   push:
@@ -84,12 +85,4 @@ jobs:
     secrets: inherit
   linter:
     uses: ./.github/workflows/flow-linter.yml
-    secrets: inherit
-  test-summary:
-    uses: ./.github/workflows/test-summary.yml
-    needs: [prepare-values, build-linux-x64, build-linux-arm64, macos, linux-valgrind, linux-sanitizer]
-    if: always() && (github.event_name == 'schedule' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.send-slack-message == true))
-    with:
-      redis-ref: ${{ needs.prepare-values.outputs.redis-ref }}
-      send-slack-message: ${{ github.event_name == 'schedule' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.send-slack-message == true) }}
     secrets: inherit


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk since this only changes a GitHub Actions workflow, but it may reduce visibility by no longer running/posting the `test-summary` step/Slack notification.
> 
> **Overview**
> **Updates the `Event Nightly` GitHub Actions workflow** by adding `actions: read` to the workflow `permissions`.
> 
> Removes the `test-summary` job (including its conditional Slack-message behavior), so nightly runs no longer aggregate/publish the consolidated test summary step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a2e7bc93978532d99b4dec6b4df345815bf1d1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->