### PR TITLE
Cherry-pick: nightly snapshot improvements to 8.4

### DIFF
--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -25,7 +25,12 @@ jobs:
     outputs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
       beta-version: ${{ steps.set-env.outputs.beta-version }}
+      module-version: ${{ steps.get-version.outputs.module-version }}
+      snapshot-template: ${{ steps.set-env.outputs.snapshot-template }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: set env
         id: set-env
         run: |
@@ -37,9 +42,33 @@ jobs:
           TIME_PART=$(date +'%H%M%S')
           RUN_NUMBER="${{ github.run_number }}"
           BETA_VERSION="${DATE_PART}.${TIME_PART}.${RUN_NUMBER}"
+          TIMESTAMP="${DATE_PART}.${TIME_PART}"
+          WORKFLOW_NUM="${RUN_NUMBER}"
           
           echo "beta-version=${BETA_VERSION}" >> $GITHUB_OUTPUT
           echo "Generated beta version: ${BETA_VERSION}"
+
+          BRANCH_NAME="${{ github.ref_name }}"
+          BRANCH_NAME="${BRANCH_NAME//[^A-Za-z0-9._-]/_}"
+          SNAPSHOT_TEMPLATE="redisbloom/snapshots/redisbloom.@OS.${BRANCH_NAME}.${TIMESTAMP}.${WORKFLOW_NUM}.zip"
+          echo "snapshot-template=${SNAPSHOT_TEMPLATE}" >> $GITHUB_OUTPUT
+          echo "Snapshot template: ${SNAPSHOT_TEMPLATE}"
+
+      - name: Extract module version
+        id: get-version
+        run: |
+          MAJOR=$(grep '#define REBLOOM_VERSION_MAJOR' src/version.h | awk '{print $3}')
+          MINOR=$(grep '#define REBLOOM_VERSION_MINOR' src/version.h | awk '{print $3}')
+          PATCH=$(grep '#define REBLOOM_VERSION_PATCH' src/version.h | awk '{print $3}')
+          MODULE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "module-version=${MODULE_VERSION}" >> $GITHUB_OUTPUT
+          echo "Module version: ${MODULE_VERSION}"
+
+      - name: Summary
+        run: |
+          echo "### Nightly Build Info" >> $GITHUB_STEP_SUMMARY
+          echo "- **Module Version:** ${{ steps.get-version.outputs.module-version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Snapshot Template:** \`${{ steps.set-env.outputs.snapshot-template }}\`" >> $GITHUB_STEP_SUMMARY
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -69,6 +69,23 @@ jobs:
           echo "### Nightly Build Info" >> $GITHUB_STEP_SUMMARY
           echo "- **Module Version:** ${{ steps.get-version.outputs.module-version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Snapshot Template:** \`${{ steps.set-env.outputs.snapshot-template }}\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Create build metadata
+        run: |
+          echo '{}' | jq \
+            --arg snapshot_template "$SNAPSHOT_TEMPLATE" \
+            --arg module_version "$MODULE_VERSION" \
+            '{snapshot_template: $snapshot_template, module_version: $module_version}' \
+            > build-metadata.json
+        env:
+          SNAPSHOT_TEMPLATE: ${{ steps.set-env.outputs.snapshot-template }}
+          MODULE_VERSION: ${{ steps.get-version.outputs.module-version }}
+
+      - name: Upload build metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-metadata
+          path: build-metadata.json
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -360,6 +360,10 @@ if [[ $WITH_GITSHA == 1 ]]; then
 	BRANCH="${BRANCH}-${GIT_COMMIT}"
 fi
 
+if [[ -n $BETA_VERSION ]]; then
+	BRANCH="${BRANCH}.${BETA_VERSION}"
+fi
+
 #----------------------------------------------------------------------------------------------
 
 RELEASE_ramp=${PACKAGE_NAME}.$OS-$OSNICK-$ARCH.$SEMVER${VARIANT}.zip


### PR DESCRIPTION
Cherry-pick of the following commits onto 8.4:

- f7e3d2248891d325fdb27b846b4ad50cfd27a88e — unique snapshot name + new output params for nightly event (#977)
- 2e3919a9b62fd12ca892ad45fd7f1ec741128f2f — nightly build, upload snapshot artifact (#981)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to packaging/naming; risk is limited to nightly artifact naming/consumption potentially breaking if downstream expects the old snapshot format.
> 
> **Overview**
> Nightly workflow now checks out the repo, derives a unique `beta-version` and branch-based `snapshot-template`, extracts the module version from `src/version.h`, and uploads this info as a `build-metadata.json` artifact (and job outputs) for downstream consumers.
> 
> Packaging (`sbin/pack.sh`) updates snapshot naming so `BETA_VERSION` is appended to the computed `BRANCH`, making nightly snapshot artifact names unique per run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 894ee88cb619ab517f8285c8bf3b7f518c673df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->