### PR TITLE
Cherry-pick: nightly snapshot improvements to 8.0

### DIFF
--- a/.github/actions/pack-module/action.yml
+++ b/.github/actions/pack-module/action.yml
@@ -1,5 +1,10 @@
 name: Run pack module script
 
+inputs:
+  beta-version:
+    description: 'Version suffix for beta builds (YYYYMMDD.HHMMSS.RUN_NUMBER format)'
+    required: false
+
 runs:
   using: composite
   steps:
@@ -13,4 +18,7 @@ runs:
         . venv/bin/activate
         export PATH="$GITHUB_WORKSPACE/redis/src:$PATH"
         git config --global --add safe.directory $GITHUB_WORKSPACE
+          if [[ -n "${{ inputs.beta-version }}" ]]; then
+            export BETA_VERSION="${{ inputs.beta-version }}"
+          fi
         make pack BRANCH=$TAG_OR_BRANCH SHOW=1

--- a/.github/actions/upload-artifacts-to-s3/action.yml
+++ b/.github/actions/upload-artifacts-to-s3/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'OS Nickname'
     required: false
     default: ''
+  beta-version:
+    description: 'Beta version for S3 uploads to beta folder'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -60,5 +64,19 @@ runs:
           if [[ $REF =~ $PATTERN ]]; then
             echo "This is a tagged build"
             SHOW=1 VERBOSE=1 make upload-release
+          fi
+        echo ::endgroup::
+        
+        echo ::group::upload to beta folder with version
+          # Use provided beta version if available
+          if [[ -n "${{ inputs.beta-version }}" ]]; then
+            BETA_VERSION="${{ inputs.beta-version }}"
+            echo "Using provided beta version: ${BETA_VERSION}"
+            
+            # Upload to beta folder
+            export BETA_VERSION="${BETA_VERSION}"
+            BETA=1 SHOW=1 VERBOSE=1 ./sbin/upload-artifacts
+          else
+            echo "No beta version provided, skipping beta upload"
           fi
         echo ::endgroup::

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -26,7 +26,12 @@ jobs:
     outputs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
       beta-version: ${{ steps.set-env.outputs.beta-version }}
+      module-version: ${{ steps.get-version.outputs.module-version }}
+      snapshot-template: ${{ steps.set-env.outputs.snapshot-template }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: set env
         id: set-env
         run: |
@@ -38,9 +43,33 @@ jobs:
           TIME_PART=$(date +'%H%M%S')
           RUN_NUMBER="${{ github.run_number }}"
           BETA_VERSION="${DATE_PART}.${TIME_PART}.${RUN_NUMBER}"
+          TIMESTAMP="${DATE_PART}.${TIME_PART}"
+          WORKFLOW_NUM="${RUN_NUMBER}"
           
           echo "beta-version=${BETA_VERSION}" >> $GITHUB_OUTPUT
           echo "Generated beta version: ${BETA_VERSION}"
+
+          BRANCH_NAME="${{ github.ref_name }}"
+          BRANCH_NAME="${BRANCH_NAME//[^A-Za-z0-9._-]/_}"
+          SNAPSHOT_TEMPLATE="redisbloom/snapshots/redisbloom.@OS.${BRANCH_NAME}.${TIMESTAMP}.${WORKFLOW_NUM}.zip"
+          echo "snapshot-template=${SNAPSHOT_TEMPLATE}" >> $GITHUB_OUTPUT
+          echo "Snapshot template: ${SNAPSHOT_TEMPLATE}"
+
+      - name: Extract module version
+        id: get-version
+        run: |
+          MAJOR=$(grep '#define REBLOOM_VERSION_MAJOR' src/version.h | awk '{print $3}')
+          MINOR=$(grep '#define REBLOOM_VERSION_MINOR' src/version.h | awk '{print $3}')
+          PATCH=$(grep '#define REBLOOM_VERSION_PATCH' src/version.h | awk '{print $3}')
+          MODULE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "module-version=${MODULE_VERSION}" >> $GITHUB_OUTPUT
+          echo "Module version: ${MODULE_VERSION}"
+
+      - name: Summary
+        run: |
+          echo "### Nightly Build Info" >> $GITHUB_STEP_SUMMARY
+          echo "- **Module Version:** ${{ steps.get-version.outputs.module-version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Snapshot Template:** \`${{ steps.set-env.outputs.snapshot-template }}\`" >> $GITHUB_STEP_SUMMARY
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -70,6 +70,23 @@ jobs:
           echo "### Nightly Build Info" >> $GITHUB_STEP_SUMMARY
           echo "- **Module Version:** ${{ steps.get-version.outputs.module-version }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Snapshot Template:** \`${{ steps.set-env.outputs.snapshot-template }}\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Create build metadata
+        run: |
+          echo '{}' | jq \
+            --arg snapshot_template "$SNAPSHOT_TEMPLATE" \
+            --arg module_version "$MODULE_VERSION" \
+            '{snapshot_template: $snapshot_template, module_version: $module_version}' \
+            > build-metadata.json
+        env:
+          SNAPSHOT_TEMPLATE: ${{ steps.set-env.outputs.snapshot-template }}
+          MODULE_VERSION: ${{ steps.get-version.outputs.module-version }}
+
+      - name: Upload build metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-metadata
+          path: build-metadata.json
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
+      beta-version: ${{ steps.set-env.outputs.beta-version }}
     steps:
       - name: set env
         id: set-env
@@ -47,6 +48,7 @@ jobs:
       arch: x64
       os: bionic focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
     secrets: inherit
   build-linux-arm64:
     uses: ./.github/workflows/flow-linux.yml
@@ -55,12 +57,14 @@ jobs:
       arch: arm64
       os: bionic focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
     secrets: inherit
   macos:
     uses: ./.github/workflows/flow-macos.yml
     needs: [prepare-values]
     with:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
     secrets: inherit
   linux-valgrind:
     uses: ./.github/workflows/flow-linux.yml
@@ -69,6 +73,7 @@ jobs:
       arch: x64
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       run_valgrind: true
     secrets: inherit
   linux-sanitizer:
@@ -78,6 +83,7 @@ jobs:
       arch: x64
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      beta-version: ${{needs.prepare-values.outputs.beta-version}}
       run_sanitizer: true
     secrets: inherit
   spellcheck:

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -56,6 +56,10 @@ on:
         description: 'Redis ref to checkout'  # todo change per version/tag
         type: string
         required: true
+      beta-version:
+        description: 'Version suffix for beta builds (YYYYMMDD.HHMMSS.RUN_NUMBER format)'
+        type: string
+        required: false
 
 
 jobs:
@@ -88,6 +92,7 @@ jobs:
         with:
           github-ref: ${{ github.ref }}
           redis-ref: ${{ inputs.redis-ref }}
+          beta-version: ${{ inputs.beta-version }}
       
   macos:
     runs-on: ${{ matrix.os }}
@@ -143,6 +148,8 @@ jobs:
           redis-ref: ${{ needs.prepare-values.outputs.redis-ref }}
       - name: Pack module
         uses: ./.github/actions/pack-module
+        with:
+          beta-version: ${{ inputs.beta-version }}
       - name: Upload artifacts to S3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -360,6 +360,10 @@ if [[ $WITH_GITSHA == 1 ]]; then
 	BRANCH="${BRANCH}-${GIT_COMMIT}"
 fi
 
+if [[ -n $BETA_VERSION ]]; then
+	BRANCH="${BRANCH}.${BETA_VERSION}"
+fi
+
 #----------------------------------------------------------------------------------------------
 
 RELEASE_ramp=${PACKAGE_NAME}.$OS-$OSNICK-$ARCH.$SEMVER${VARIANT}.zip

--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -220,6 +220,45 @@ pack_ramp() {
 		fi
 	fi
 
+	# For nightly builds, create files in both beta and snapshots directories
+	echo "# Debug: SNAPSHOT=$SNAPSHOT, BETA_VERSION=$BETA_VERSION"
+	if [[ $SNAPSHOT == 1 && -n $BETA_VERSION ]]; then
+		echo "# Creating beta and branch files for beta build..."
+		# Get the original branch name (without beta version)
+		local original_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "master")
+		original_branch=${original_branch//[^A-Za-z0-9._-]/_}
+		
+		# Create beta directory for versioned files
+		mkdir -p $ARTDIR/beta
+		
+		# Create versioned filenames for beta directory
+		local versioned_package=$stem.${SEMVER}${VARIANT}.zip
+		local versioned_package_debug=$stem_debug.${SEMVER}${VARIANT}.zip
+		
+		# Copy versioned files to beta directory
+		if [[ -f $ARTDIR/$packdir/$fq_package ]]; then
+			runn cp $ARTDIR/$packdir/$fq_package $ARTDIR/beta/$versioned_package
+			echo "# Created beta version $(realpath $ARTDIR/beta/$versioned_package)"
+		fi
+		if [[ -f $ARTDIR/$packdir/$fq_package_debug ]]; then
+			runn cp $ARTDIR/$packdir/$fq_package_debug $ARTDIR/beta/$versioned_package_debug
+			echo "# Created beta debug version $(realpath $ARTDIR/beta/$versioned_package_debug)"
+		fi
+		
+		# Create branch-named files in snapshots directory (overwrite the versioned ones)
+		local branch_package=$stem.${original_branch}${VARIANT}.zip
+		local branch_package_debug=$stem_debug.${original_branch}${VARIANT}.zip
+		
+		if [[ -f $ARTDIR/$packdir/$fq_package ]]; then
+			runn cp $ARTDIR/$packdir/$fq_package $ARTDIR/$packdir/$branch_package
+			echo "# Created branch snapshot $(realpath $ARTDIR/$packdir/$branch_package)"
+		fi
+		if [[ -f $ARTDIR/$packdir/$fq_package_debug ]]; then
+			runn cp $ARTDIR/$packdir/$fq_package_debug $ARTDIR/$packdir/$branch_package_debug
+			echo "# Created branch debug snapshot $(realpath $ARTDIR/$packdir/$branch_package_debug)"
+		fi
+	fi
+
 	cd $ROOT
 }
 
@@ -278,6 +317,16 @@ pack_deps() {
 
 NUMVER="$(NUMERIC=1 $SBIN/getver)"
 SEMVER="$($SBIN/getver)"
+
+# Debug: Show environment variables
+echo "# Debug: BETA_VERSION environment variable: '$BETA_VERSION'"
+echo "# Debug: Original SEMVER: '$SEMVER'"
+
+# Append beta version suffix if provided
+if [[ -n $BETA_VERSION ]]; then
+	SEMVER="${SEMVER}.${BETA_VERSION}"
+	echo "# Debug: Modified SEMVER with beta version: '$SEMVER'"
+fi
 
 if [[ -n $VARIANT ]]; then
 	_VARIANT="-${VARIANT}"
@@ -375,6 +424,7 @@ if [[ $RAMP == 1 ]]; then
 	MODULE=$(realpath $MODULE)
 
 	[[ $RELEASE == 1 ]] && SNAPSHOT=0 pack_ramp
+	echo "# Debug: About to call pack_ramp with SNAPSHOT=$SNAPSHOT, BRANCH='$BRANCH'"
 	[[ $SNAPSHOT == 1 ]] && pack_ramp
 
 	echo "# Done."

--- a/sbin/upload-artifacts
+++ b/sbin/upload-artifacts
@@ -140,4 +140,30 @@ s3_upload() {
 
 #----------------------------------------------------------------------------------------------
 
-PROD=redisbloom PREFIX=redisbloom s3_upload
+if [[ $BETA == 1 ]]; then
+	echo "# Uploading to BETA folder with version: $BETA_VERSION"
+	
+	# Upload beta files from beta directory if it exists
+	if [[ -d $ROOT/bin/artifacts/beta ]]; then
+		cd $ROOT/bin/artifacts/beta
+		
+		if du --help | grep -q -- --apparent-size; then
+			DU_ARGS='--apparent-size'
+		fi
+		[[ $VERBOSE == 1 ]] && du -ah ${DU_ARGS} *
+		
+		# Upload beta files to beta directory (production only)
+		beta_upload_dir="${S3_URL}/redisbloom/beta"
+		
+		files=$(ls redisbloom.*${PLATFORM}*.zip 2>/dev/null || true)
+		for file in $files; do
+			$OP aws s3 cp $file $beta_upload_dir/ --acl public-read --no-progress
+		done
+		[[ $VERBOSE == 1 ]] && $OP aws s3 ls $beta_upload_dir/
+	else
+		echo "# No beta directory found at $ROOT/bin/artifacts/beta"
+	fi
+else
+	# Regular upload
+	PROD=redisbloom PREFIX=redisbloom s3_upload
+fi


### PR DESCRIPTION
## Summary

- Adds missing beta-version infrastructure from PR #901 (adapted for this branch)
- Cherry-picks nightly snapshot improvements:
  - f7e3d2248891d325fdb27b846b4ad50cfd27a88e — unique snapshot name + new output params for nightly event (#977)
  - 2e3919a9b62fd12ca892ad45fd7f1ec741128f2f — nightly build, upload snapshot artifact (#981)

Note: `pack/ramp.yml` (`compatible_redis_version`) is intentionally left unchanged.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes artifact naming and S3 upload destinations for nightly builds; miswiring `BETA_VERSION`/flags could lead to missing or misnamed artifacts being published.
> 
> **Overview**
> Nightly workflow now generates a unique `beta-version` (timestamp + run number), derives a branch-specific snapshot name template, extracts the module version, and publishes this metadata as both job outputs and a `build-metadata.json` artifact.
> 
> Packaging and upload steps are updated to accept/pass `beta-version`: `sbin/pack.sh` appends the beta suffix to `SEMVER`/snapshot `BRANCH`, and for snapshot builds also duplicates artifacts into `bin/artifacts/beta/` (versioned) while keeping branch-named snapshot files. S3 upload logic adds an explicit beta upload path (`redisbloom/beta`) when `BETA=1`/`BETA_VERSION` is provided, and the composite actions/workflows wire these inputs through (including macOS).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 255e4209ebb9d5ac6f8dff4955c71d9f2c460098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->