### PR TITLE
MOD-14715 add apt retries/timeouts to Debian/Ubuntu Dockerfiles

### DIFF
--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -3,6 +3,11 @@ FROM ubuntu:18.04
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Make apt resilient to transient network/CDN failures (e.g. archive.ubuntu.com /
+# deb.debian.org "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
+
 RUN apt update -qq \
     && apt upgrade -yqq \
     && apt dist-upgrade -yqq \

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -3,6 +3,11 @@ FROM debian:bookworm
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Make apt resilient to transient network/CDN failures (e.g. deb.debian.org / Fastly
+# "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
+
 RUN apt update -qq \
     && apt upgrade -yqq \
     && apt-get update \

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -3,6 +3,11 @@ FROM debian:bullseye
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Make apt resilient to transient network/CDN failures (e.g. deb.debian.org / Fastly
+# "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
+
 RUN apt-get update && apt-get install -y build-essential make cmake autoconf automake libtool lcov git wget zlib1g-dev lsb-release libssl-dev openssl ca-certificates curl unzip rsync libclang-dev clang git
 
 

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -3,6 +3,11 @@ FROM ubuntu:20.04
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Make apt resilient to transient network/CDN failures (e.g. archive.ubuntu.com /
+# deb.debian.org "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
+
 RUN apt update -qq \
     && apt-get update \
     && apt upgrade -yqq \

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -3,6 +3,11 @@ FROM ubuntu:22.04
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Make apt resilient to transient network/CDN failures (e.g. archive.ubuntu.com /
+# deb.debian.org "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
+
 RUN apt-get update && apt-get install -y \
     build-essential \
     make \

--- a/Dockerfile.noble
+++ b/Dockerfile.noble
@@ -4,6 +4,11 @@ FROM ubuntu:24.04
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Make apt resilient to transient network/CDN failures (e.g. archive.ubuntu.com /
+# deb.debian.org "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
+
 RUN apt-get update && apt-get install -y \
     build-essential \
     make \

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -3,6 +3,11 @@ FROM debian:trixie
 WORKDIR /workspace
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Make apt resilient to transient network/CDN failures (e.g. deb.debian.org / Fastly
+# "Connection reset by peer" on GitHub Actions runners). See MOD-14715.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+    > /etc/apt/apt.conf.d/80-retries
+
 RUN apt update -qq \
     && apt upgrade -yqq \
     && apt-get update \


### PR DESCRIPTION
Bullseye (and other Debian/Ubuntu) Docker builds intermittently fail in the dev nightly with `Connection reset by peer` from deb.debian.org / archive.ubuntu.com (Fastly CDN). Configure apt with Acquire::Retries=3 and 30s http/https timeouts via /etc/apt/apt.conf.d/80-retries so all subsequent apt / apt-get / add-apt-repository calls tolerate transient CDN drops.

Applied to: bionic, focal, jammy, noble, bullseye, bookworm, trixie.

Ported from RedisTimeSeries#1965.

Made-with: Cursor