### PR TITLE
MOD-15020 - uses gcc 8.0

### DIFF
--- a/.install/ubuntu_18.04.sh
+++ b/.install/ubuntu_18.04.sh
@@ -6,12 +6,13 @@ MODE=$1 # whether to install using sudo or not
 $MODE apt update -qq
 $MODE apt upgrade -yqq
 
-add-apt-repository ppa:ubuntu-toolchain-r/test -y
-apt update
-apt-get install -yqq --fix-missing build-essential make autoconf automake libtool lcov git \
-  wget zlib1g-dev lsb-release libssl-dev openssl ca-certificates curl unzip gcc-10 g++-10 \
+$MODE apt-get install -yqq software-properties-common
+$MODE add-apt-repository universe -y
+$MODE apt update
+$MODE apt-get install -yqq --fix-missing build-essential make autoconf automake libtool lcov git \
+  wget zlib1g-dev lsb-release libssl-dev openssl ca-certificates curl unzip gcc-8 g++-8 \
   binfmt-support lsb-core awscli libclang-dev clang libffi-dev
-update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+$MODE update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8
 
 wget https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
 tar -xzvf cmake-3.28.0.tar.gz

--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -12,11 +12,11 @@ RUN apt update -qq \
     && apt upgrade -yqq \
     && apt dist-upgrade -yqq \
     && apt install -yqq software-properties-common unzip rsync \
-    && add-apt-repository ppa:ubuntu-toolchain-r/test -y \
+    && add-apt-repository universe -y \
     && apt update \
-    && apt install -yqq build-essential wget curl make gcc-10 g++-10 openssl libssl-dev cargo binfmt-support \
+    && apt install -yqq build-essential wget curl make gcc-8 g++-8 openssl libssl-dev cargo binfmt-support \
     lsb-core libclang-dev clang zlib1g-dev jq automake libtool git \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8
 
 RUN wget https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz \
     && tar -xzvf cmake-3.28.0.tar.gz \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the compiler toolchain and apt repositories for Ubuntu 18.04 builds, which can affect build outputs and compatibility. Changes are limited to environment provisioning scripts/Docker image setup.
> 
> **Overview**
> Updates the Ubuntu 18.04 install script and `Dockerfile.bionic` to **stop using the `ubuntu-toolchain-r/test` PPA and GCC 10**, and instead **enable the `universe` repo and install `gcc-8`/`g++-8`**.
> 
> Adjusts package installation to ensure `software-properties-common` is installed before adding repositories, and updates `update-alternatives` to point the default `gcc/g++` to version 8.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 908e75dcde4ec83a1c571dad5a60562a7baea31d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->