### PR TITLE
fix redis versiob

### DIFF
--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -19,7 +19,7 @@ runs:
       id: artifact-names
       shell: bash
       run: | # Invalid characters include: Double quote ", Colon :, Less than <, Greater than >, Vertical bar |, Asterisk *, Question mark ?
-        echo "name=$(echo "${{ inputs.image }} ${{ runner.arch }}, Redis ${{ inputs.redis-ref || 'unstable' }}" | \
+        echo "name=$(echo "${{ inputs.image }} ${{ runner.arch }}, Redis ${{ inputs.redis-ref || '8.8' }}" | \
           sed -e 's/[":\/\\<>\|*?]/_/g' -e 's/__*/_/g' -e 's/^_//' -e 's/_$//')" >> $GITHUB_OUTPUT
     - name: Upload test artifacts
       if: inputs.image != 'amazonlinux:2' && inputs.image != 'ubuntu:bionic'

--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=unstable" >> $GITHUB_OUTPUT  # todo change per version/tag
+          echo "redis-ref=8.8" >> $GITHUB_OUTPUT  # todo change per version/tag
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -19,7 +19,7 @@ on:
       redis-ref:
         description: 'Redis ref to checkout'
         required: true
-        default: 'unstable'
+        default: '8.8'
       send-slack-message:
         description: 'Send summary message to Slack channel'
         required: false
@@ -40,7 +40,7 @@ jobs:
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=${{ inputs.redis-ref || 'unstable' }}" >> $GITHUB_OUTPUT  # todo change per version/tag
+          echo "redis-ref=${{ inputs.redis-ref || '8.8' }}" >> $GITHUB_OUTPUT  # todo change per version/tag
           
           # Generate unique beta version with date and GitHub run number
           # Format: YYYYMMDD.HHMMSS.RUN_NUMBER (to handle parallel runs and multiple daily runs)

--- a/.github/workflows/event-tag.yml
+++ b/.github/workflows/event-tag.yml
@@ -14,7 +14,7 @@ on:
       redis-ref:
         description: 'Redis ref to checkout'
         required: true
-        default: 'unstable'
+        default: '8.8'
 
 jobs:
   prepare-values:
@@ -25,7 +25,7 @@ jobs:
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=${{ inputs.redis-ref || 'unstable' }}" >> $GITHUB_OUTPUT
+          echo "redis-ref=${{ inputs.redis-ref || '8.8' }}" >> $GITHUB_OUTPUT
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/.github/workflows/flow-random-traffic.yml
+++ b/.github/workflows/flow-random-traffic.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       redis-ref:
         description: 'Redis ref to checkout'
-        default: 'unstable'
+        default: '8.8'
       timeout-minutes:
         description: 'Timeout in minutes'
         default: '30'
@@ -17,7 +17,7 @@ on:
       redis-ref:
         description: 'Redis ref to checkout'
         type: string
-        default: 'unstable'
+        default: '8.8'
       timeout-minutes:
         description: 'Timeout in minutes'
         type: string
@@ -64,7 +64,7 @@ jobs:
         generator: [BloomGen, CuckooGen, CmsGen, TopKGen, TDigestGen]
     env:
       DOCKER_IMAGE: redisbloom-${{ needs.pick-os.outputs.os }}:latest
-      REDIS_REF: ${{ inputs.redis-ref || 'unstable' }}
+      REDIS_REF: ${{ inputs.redis-ref || '8.8' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Dockerfile.alma10
+++ b/Dockerfile.alma10
@@ -10,7 +10,7 @@ RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync u
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -18,7 +18,7 @@ ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -12,7 +12,7 @@ ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -40,7 +40,7 @@ RUN apk add --no-cache \
 
 COPY .install /workspace/.install
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -29,7 +29,7 @@ ENV LD_LIBRARY_PATH="/opt/rh/devtoolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 
 COPY .install /workspace/.install
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.amazonlinux2023
+++ b/Dockerfile.amazonlinux2023
@@ -18,7 +18,7 @@ RUN dnf install -y  --allowerasing \
     which 
 COPY .install /workspace/.install
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.azurelinux3
+++ b/Dockerfile.azurelinux3
@@ -25,7 +25,7 @@ RUN tdnf -y update && \
 
 COPY .install /workspace/.install
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -25,7 +25,7 @@ RUN wget https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz \
 
 COPY .install /workspace/.install
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -12,7 +12,7 @@ RUN apt update -qq \
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y build-essential make cmake autoconf aut
 
 COPY .install /workspace/.install
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -12,7 +12,7 @@ RUN apt update -qq \
 
 COPY .install /workspace/.install
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY .install /workspace/.install
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.mariner2
+++ b/Dockerfile.mariner2
@@ -6,7 +6,7 @@ RUN tdnf install --noplugins --skipsignature -y ca-certificates git build-essent
 
 COPY .install /workspace/.install
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.noble
+++ b/Dockerfile.noble
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y \
     unzip \
     rsync
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh

--- a/Dockerfile.resolute
+++ b/Dockerfile.resolute
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y \
     unzip \
     rsync
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -10,7 +10,7 @@ RUN dnf install -y gcc gcc-c++ make wget git openssl openssl-devel which rsync u
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -17,7 +17,7 @@ ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -14,7 +14,7 @@ ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
 
 COPY .install /workspace/.install
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -12,7 +12,7 @@ RUN apt update -qq \
 COPY .install /workspace/.install
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+ARG REDIS_REF=8.8
 ARG SANITIZER=
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 

--- a/src/version.h
+++ b/src/version.h
@@ -20,7 +20,7 @@
 #endif
 
 #ifndef REBLOOM_VERSION_PATCH
-#define REBLOOM_VERSION_PATCH 90
+#define REBLOOM_VERSION_PATCH 91
 
 #endif
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates build/CI defaults to target Redis `8.8` instead of `unstable`, which could affect CI and packaging if the ref/tag is missing or incompatible across supported platforms.
> 
> **Overview**
> CI/build pipelines now default to checking out/building against Redis `8.8` rather than `unstable`, including workflow inputs, env vars, and Docker `REDIS_REF` build args (plus artifact naming).
> 
> Bumps `REBLOOM_VERSION_PATCH` from `90` to `91` in `src/version.h`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b83aadc85c7cb17d35dffbd46b8684797951216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->