### PR TITLE
MOD-15418 - fix load rdb mem leak

### DIFF
--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -1340,11 +1340,7 @@ static void *CFRdbLoad(RedisModuleIO *io, int encver) {
 
     bool err = false;
     CuckooFilter *cf = RedisModule_Calloc(1, sizeof(*cf));
-    /* CuckooFilter_Free does not free the struct itself (see CFFree); errdefer must. */
-    errdefer(err, {
-        CuckooFilter_Free(cf);
-        RedisModule_Free(cf);
-    });
+    errdefer(err, CFFree(cf));
     cf->numFilters = LoadUnsigned_IOError(io, err, NULL);
     cf->numBuckets = LoadUnsigned_IOError(io, err, NULL);
     if (cf->numFilters == 0 || cf->numBuckets == 0) {

--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -1340,7 +1340,11 @@ static void *CFRdbLoad(RedisModuleIO *io, int encver) {
 
     bool err = false;
     CuckooFilter *cf = RedisModule_Calloc(1, sizeof(*cf));
-    errdefer(err, CuckooFilter_Free(cf));
+    /* CuckooFilter_Free does not free the struct itself (see CFFree); errdefer must. */
+    errdefer(err, {
+        CuckooFilter_Free(cf);
+        RedisModule_Free(cf);
+    });
     cf->numFilters = LoadUnsigned_IOError(io, err, NULL);
     cf->numBuckets = LoadUnsigned_IOError(io, err, NULL);
     if (cf->numFilters == 0 || cf->numBuckets == 0) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches RDB deserialization error handling for Cuckoo filters, which is persistence-critical and could affect crash/recovery paths if the new cleanup behavior is wrong.
> 
> **Overview**
> Fixes Cuckoo Filter RDB load cleanup to avoid leaking memory on I/O/validation failures by switching the `CFRdbLoad` `errdefer` handler from `CuckooFilter_Free` to `CFFree`, ensuring both the filter internals *and* the `CuckooFilter` struct itself are released on error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e36a3e161f70a208b656cbb34b10cd44fd1a7f3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->