### PR TITLE
ci: bump GitHub Actions to Node24-compatible versions

### DIFF
--- a/.github/actions/capture-test-results/action.yml
+++ b/.github/actions/capture-test-results/action.yml
@@ -142,7 +142,7 @@ runs:
     - name: Upload test results artifact
       continue-on-error: true
       if: always() && steps.parse.outputs.results-file != '' && steps.parse.outputs.results-file != 'null'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ steps.parse.outputs.artifact-name }}
         path: ${{ steps.parse.outputs.results-file }}

--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -23,7 +23,7 @@ runs:
           sed -e 's/[":\/\\<>\|*?]/_/g' -e 's/__*/_/g' -e 's/^_//' -e 's/_$//')" >> $GITHUB_OUTPUT
     - name: Upload test artifacts
       if: inputs.image != 'amazonlinux:2'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Test logs ${{ steps.artifact-names.outputs.name }}
         path: tests/**/logs/*.log*

--- a/.github/workflows/benchmark-flow.yml
+++ b/.github/workflows/benchmark-flow.yml
@@ -40,7 +40,7 @@ jobs:
     container: ${{ inputs.container }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - run: |
           git init
           git config --global --add safe.directory '*'
@@ -50,7 +50,7 @@ jobs:
         run: ./sbin/system-setup.py
 
       - name: Get Redis
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: redis/redis
           ref: '7.2'

--- a/.github/workflows/benchmark-trigger.yml
+++ b/.github/workflows/benchmark-trigger.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       benchmark: ${{ steps.haslabel.outputs.labeled-run-benchmark }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check if labeled with run-benchmark
         id: haslabel
         uses: DanielTamkin/HasLabel@v1.0.4

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -57,7 +57,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.validate-and-check.outputs.release_branch }}
           path: release-branch

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,13 +39,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         submodules: true
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.c }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -74,4 +74,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -35,7 +35,7 @@ jobs:
       snapshot-template: ${{ steps.set-env.outputs.snapshot-template }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: set env
         id: set-env
@@ -88,7 +88,7 @@ jobs:
           MODULE_VERSION: ${{ steps.get-version.outputs.module-version }}
 
       - name: Upload build metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-metadata
           path: build-metadata.json

--- a/.github/workflows/flow-linter.yml
+++ b/.github/workflows/flow-linter.yml
@@ -6,7 +6,7 @@ jobs:
   linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
       - name: Install build dependencies

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -77,7 +77,7 @@ jobs:
       TAG_OR_BRANCH: ${{ steps.set-env.outputs.TAG }}${{ steps.set-env.outputs.BRANCH }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: set env
         id: set-env
         uses: ./.github/actions/setup-env
@@ -129,7 +129,7 @@ jobs:
       DOCKER_IMAGE: redisbloom-${{ matrix.platform.os }}:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -166,7 +166,7 @@ jobs:
 
       - name: Upload test artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-artifacts-${{ inputs.arch }}-${{ matrix.platform.os }}
           path: |

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -75,7 +75,7 @@ jobs:
       TAG_OR_BRANCH: ${{ steps.set-env.outputs.TAG }}${{ steps.set-env.outputs.BRANCH }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set matrix
         id: set-matrix
         run: |
@@ -117,11 +117,11 @@ jobs:
         run: |
           brew install make coreutils autoconf automake pyenv-virtualenv libtool
       - name: Full checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Checkout Redis
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: 'redis/redis'
           ref: ${{ needs.prepare-values.outputs.redis-ref }}

--- a/.github/workflows/flow-random-traffic.yml
+++ b/.github/workflows/flow-random-traffic.yml
@@ -67,7 +67,7 @@ jobs:
       REDIS_REF: ${{ inputs.redis-ref || 'unstable' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload random traffic log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: random-traffic-${{ needs.pick-os.outputs.os }}-${{ matrix.generator }}-log
           path: random_traffic.txt

--- a/.github/workflows/flow-spellcheck.yml
+++ b/.github/workflows/flow-spellcheck.yml
@@ -6,7 +6,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Spellcheck
         uses: rojopolis/spellcheck-github-actions@0.45.0
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,6 +14,5 @@ jobs:
       - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-           config-name: release-drafter-config.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          config-name: release-drafter-config.yml
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-summary.yml
+++ b/.github/workflows/test-summary.yml
@@ -28,12 +28,12 @@ jobs:
     if: always()
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       
       - name: Download all test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
       
       - name: Get commit information


### PR DESCRIPTION
## Summary

GitHub is removing Node20 from Actions runners on **2026-06-16** (default switch to Node24), with full removal in fall 2026.
See the [deprecation announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

Bumps each action to the lowest Node24-compatible major:

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v5 |
| `actions/upload-artifact` | v4 | v6 (v5 is still node20) |
| `actions/download-artifact` | v4 | v7 (v5/v6 are still node20) |
| `github/codeql-action/init` | v3 | v4 |
| `github/codeql-action/analyze` | v3 | v4 |
| `release-drafter/release-drafter` | v5 | v7 (v6 is still node20) |

### Not changed
- `DanielTamkin/HasLabel@v1.0.4` — only ships node12; no Node24 release available. Small enough to inline if it becomes a problem.
- `rojopolis/spellcheck-github-actions@0.45.0` — docker action, runtime unaffected.

## Test plan
- [ ] CI passes on this branch
- [ ] CodeQL analysis still runs to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes to CI YAML with no product code; main risk is transient workflow breakage if a new action major changes behavior.
> 
> **Overview**
> Updates **GitHub Actions** across composite actions and workflows so CI stays compatible before **Node 20** is removed from runners in favor of **Node 24**.
> 
> **Checkout** moves from `actions/checkout@v4` to **v5** everywhere it appears (benchmark, bump-version, CodeQL, nightly, Linux/macOS/random-traffic flows, linter, spellcheck, test summary, etc.). **Artifact upload** moves from `actions/upload-artifact@v4` to **v6** in `capture-test-results`, `upload-artifacts`, nightly metadata, Linux failure logs, and random-traffic logs. **Artifact download** in `test-summary` moves from `actions/download-artifact@v4` to **v7**.
> 
> **CodeQL** init/analyze steps upgrade from `github/codeql-action/*@v3` to **v4**. **Release Drafter** upgrades from `release-drafter/release-drafter@v5` to **v7**, with the GitHub token passed via the action’s `token` input instead of a top-level `env: GITHUB_TOKEN`.
> 
> No application or RedisBloom module code changes—only workflow/action version pins and the release-drafter input shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59a9ecf5d4c59b612145042fc7ddc39af8e100ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->