### PR TITLE
MOD-15999 - optimize the way we use redis-ref in our ci & dockers

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -18,10 +18,12 @@ jobs:
     outputs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: set env
         id: set-env
         run: |
-          echo "redis-ref=unstable" >> $GITHUB_OUTPUT  # todo change per version/tag
+          echo "redis-ref=$(.install/get-redis-ref.sh)" >> $GITHUB_OUTPUT
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -17,9 +17,9 @@ on:
   workflow_dispatch:
     inputs:
       redis-ref:
-        description: 'Redis ref to checkout'
-        required: true
-        default: 'unstable'
+        description: 'Redis ref to checkout (leave empty to use redis_ref from pack/ramp.yml)'
+        required: false
+        default: ''
       send-slack-message:
         description: 'Send summary message to Slack channel'
         required: false
@@ -39,8 +39,14 @@ jobs:
 
       - name: set env
         id: set-env
+        env:
+          INPUT_REDIS_REF: ${{ inputs.redis-ref }}
         run: |
-          echo "redis-ref=${{ inputs.redis-ref || 'unstable' }}" >> $GITHUB_OUTPUT  # todo change per version/tag
+          REDIS_REF="${INPUT_REDIS_REF}"
+          if [ -z "$REDIS_REF" ]; then
+            REDIS_REF="$(.install/get-redis-ref.sh)"
+          fi
+          echo "redis-ref=${REDIS_REF}" >> $GITHUB_OUTPUT
           
           # Generate unique beta version with date and GitHub run number
           # Format: YYYYMMDD.HHMMSS.RUN_NUMBER (to handle parallel runs and multiple daily runs)

--- a/.github/workflows/event-tag.yml
+++ b/.github/workflows/event-tag.yml
@@ -12,9 +12,9 @@ on:
   workflow_dispatch:
     inputs:
       redis-ref:
-        description: 'Redis ref to checkout'
-        required: true
-        default: 'unstable'
+        description: 'Redis ref to checkout (leave empty to use redis_ref from pack/ramp.yml)'
+        required: false
+        default: ''
 
 jobs:
   prepare-values:
@@ -22,10 +22,18 @@ jobs:
     outputs:
       redis-ref: ${{ steps.set-env.outputs.redis-ref }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: set env
         id: set-env
+        env:
+          INPUT_REDIS_REF: ${{ inputs.redis-ref }}
         run: |
-          echo "redis-ref=${{ inputs.redis-ref || 'unstable' }}" >> $GITHUB_OUTPUT
+          REDIS_REF="${INPUT_REDIS_REF}"
+          if [ -z "$REDIS_REF" ]; then
+            REDIS_REF="$(.install/get-redis-ref.sh)"
+          fi
+          echo "redis-ref=${REDIS_REF}" >> $GITHUB_OUTPUT
   build-linux-x64:
     uses: ./.github/workflows/flow-linux.yml
     needs: [prepare-values]

--- a/.install/get-redis-ref.sh
+++ b/.install/get-redis-ref.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Print the Redis git ref that redisbloom is built/tested against.
+#
+# The ref is derived from the `compatible_redis_version` field of the RAMP
+# manifest (pack/ramp.yml), so the version lives in a single place and is not
+# duplicated across Dockerfiles and CI workflows:
+#   * the dev/unreleased placeholder 99.99 (or 99.99.99) -> "unstable" branch
+#   * any real version (e.g. "8.8") is used as the git ref verbatim
+# The value may be quoted or unquoted; an inline '#' comment, if any, is stripped.
+#
+# It lives under .install/ (not sbin/) so it is copied into the Docker build
+# context together with the rest of .install/, letting install_redis.sh reuse
+# the very same reader instead of re-implementing the parse.
+#
+# Usage:
+#   .install/get-redis-ref.sh        # prints the ref, e.g. "unstable" or "8.8"
+#
+# In a GitHub Actions step:
+#   echo "redis-ref=$(.install/get-redis-ref.sh)" >> "$GITHUB_OUTPUT"
+
+set -euo pipefail
+
+PROGNAME="${BASH_SOURCE[0]}"
+HERE="$(cd "$(dirname "$PROGNAME")" &>/dev/null && pwd)"
+ROOT="$(cd "$HERE/.." &>/dev/null && pwd)"
+RAMP_FILE="$ROOT/pack/ramp.yml"
+
+if [[ ! -f "$RAMP_FILE" ]]; then
+	echo "Error: RAMP manifest not found at $RAMP_FILE" >&2
+	exit 1
+fi
+
+# Value of the top-level `compatible_redis_version:` key, with inline comment,
+# surrounding whitespace and quotes stripped.
+COMPAT_VERSION="$(sed -nE 's/^compatible_redis_version:[[:space:]]*(.*)$/\1/p' "$RAMP_FILE" | head -n1 \
+	| sed -E 's/[[:space:]]*#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//; s/^"(.*)"$/\1/; s/^'\''(.*)'\''$/\1/')"
+
+if [[ -z "$COMPAT_VERSION" ]]; then
+	echo "Error: 'compatible_redis_version' is not defined in $RAMP_FILE" >&2
+	exit 1
+fi
+
+# The dev/unreleased placeholder (99.99 or 99.99.99) means we track the
+# 'unstable' branch; a real version is used as the git ref directly.
+case "$COMPAT_VERSION" in
+	99.99 | 99.99.99) REDIS_REF="unstable" ;;
+	*)                REDIS_REF="$COMPAT_VERSION" ;;
+esac
+
+echo "$REDIS_REF"

--- a/.install/install_redis.sh
+++ b/.install/install_redis.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 set -e
 
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# If REDIS_REF was not provided explicitly, derive it from the manifest's
+# compatible_redis_version (pack/ramp.yml) via the shared reader that ships in
+# this same directory (.install/get-redis-ref.sh). Both this script and
+# pack/ramp.yml are copied into the Docker build context, so the reader works
+# here exactly as it does in CI.
 if [ -z "${REDIS_REF}" ]; then
-    echo "Error: REDIS_REF environment variable is required"
+    REDIS_REF="$(bash "$HERE/get-redis-ref.sh")"
+fi
+
+if [ -z "${REDIS_REF}" ]; then
+    echo "Error: REDIS_REF is not set and could not be derived from pack/ramp.yml"
     exit 1
 fi
 

--- a/Dockerfile.alma10
+++ b/Dockerfile.alma10
@@ -8,8 +8,10 @@ COPY .install /workspace/.install
 RUN bash /workspace/.install/install_script.sh
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.alma8
+++ b/Dockerfile.alma8
@@ -14,8 +14,10 @@ RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install
 ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.alma9
+++ b/Dockerfile.alma9
@@ -12,8 +12,10 @@ RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install
 ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -13,9 +13,11 @@ COPY .install /workspace/.install
 RUN bash /workspace/.install/install_script.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Use system Python with venv (like the old flow-alpine workflow)

--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -12,8 +12,10 @@ RUN bash /workspace/.install/install_script.sh
 ENV PATH="/opt/rh/devtoolset-11/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/devtoolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.amazonlinux2023
+++ b/Dockerfile.amazonlinux2023
@@ -8,9 +8,11 @@ COPY .install /workspace/.install
 RUN bash /workspace/.install/install_script.sh && dnf clean all
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Install uv and Python environment

--- a/Dockerfile.azurelinux3
+++ b/Dockerfile.azurelinux3
@@ -7,8 +7,10 @@ WORKDIR /workspace
 COPY .install /workspace/.install
 RUN bash /workspace/.install/install_script.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -15,8 +15,10 @@ COPY .install /workspace/.install
 RUN bash /workspace/.install/install_script.sh
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -12,8 +12,10 @@ RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https:
 COPY .install /workspace/.install
 RUN bash /workspace/.install/install_script.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -13,8 +13,10 @@ RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https:
 COPY .install /workspace/.install
 RUN bash /workspace/.install/install_script.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -14,9 +14,11 @@ COPY .install /workspace/.install
 RUN bash /workspace/.install/install_script.sh
 
 # Install Redis (SANITIZER can be 'address' for ASAN builds)
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
 
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 # Install uv and Python environment

--- a/Dockerfile.mariner2
+++ b/Dockerfile.mariner2
@@ -7,8 +7,10 @@ WORKDIR /workspace
 COPY .install /workspace/.install
 RUN bash /workspace/.install/install_script.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.noble
+++ b/Dockerfile.noble
@@ -13,8 +13,10 @@ RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https:
 COPY .install /workspace/.install
 RUN bash /workspace/.install/install_script.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.resolute
+++ b/Dockerfile.resolute
@@ -8,8 +8,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 COPY .install /workspace/.install
 RUN bash /workspace/.install/install_script.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.rocky10
+++ b/Dockerfile.rocky10
@@ -8,8 +8,10 @@ COPY .install /workspace/.install
 RUN bash /workspace/.install/install_script.sh
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -11,8 +11,10 @@ RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install
 ENV PATH="/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-11/root/usr/lib64:${LD_LIBRARY_PATH}"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -11,8 +11,10 @@ RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install
 ENV PATH="/opt/rh/gcc-toolset-13/root/usr/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-13/root/usr/lib64:${LD_LIBRARY_PATH}"
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh

--- a/Dockerfile.trixie
+++ b/Dockerfile.trixie
@@ -14,8 +14,10 @@ COPY .install /workspace/.install
 RUN bash /workspace/.install/install_script.sh
 RUN chmod +x /workspace/.install/install_cmake.sh && /workspace/.install/install_cmake.sh
 
-ARG REDIS_REF=unstable
+# Empty default: install_redis.sh falls back to pack/ramp.yml (single source of truth)
+ARG REDIS_REF=
 ARG SANITIZER=
+COPY pack/ramp.yml /workspace/pack/ramp.yml
 RUN chmod +x /workspace/.install/install_redis.sh && REDIS_REF=${REDIS_REF} SANITIZER=${SANITIZER} /workspace/.install/install_redis.sh
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR="/usr/local/bin" sh


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Wide CI/Docker surface area; wrong parsing or manifest values could build/test against the wrong Redis branch/tag across all platforms.
> 
> **Overview**
> Centralizes **which Redis git ref** CI and Docker builds use, driven by `compatible_redis_version` in `pack/ramp.yml` instead of hardcoding `unstable` everywhere.
> 
> Adds `.install/get-redis-ref.sh` to read that field (placeholder `99.99` / `99.99.99` → `unstable`; real versions like `8.8` used as the ref). **CI** (`event-ci`, `event-nightly`, `event-tag`) checks out the repo and sets `redis-ref` from that script; nightly/tag `workflow_dispatch` inputs are optional and default empty so the manifest wins unless overridden. **`install_redis.sh`** derives `REDIS_REF` the same way when unset. **All OS Dockerfiles** drop `ARG REDIS_REF=unstable`, use an empty default, and `COPY pack/ramp.yml` so image builds share the same source of truth (explicit `REDIS_REF` build-arg still overrides).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3bacbd6c747f48dab362e06c7d3fb37323d47d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->