### PR TITLE
MOD-16050 - CF.LOADCHUNK: replicate data chunks (fix silent CF data loss on failover)

### DIFF
--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -1010,6 +1010,7 @@ static int CFLoadChunk_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **arg
     if (CF_LoadEncodedChunk(cf, pos, blob, bloblen) != REDISMODULE_OK) {
         return RedisModule_ReplyWithError(ctx, "Couldn't load chunk!");
     }
+    RedisModule_ReplicateVerbatim(ctx);
     return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
 

--- a/tests/flow/test_cuckoo.py
+++ b/tests/flow/test_cuckoo.py
@@ -1,4 +1,5 @@
 import random
+import time
 
 from common import *
 
@@ -688,3 +689,56 @@ class testCuckooNoCodec():
         self.cmd('FLUSHALL')
         rdb_payload = b'\x07\x810\x16\xe5\xa2\x89\x82\x14\x04\x02\x00\x02\x08\x02\x01\x02\x00\x02\x01\x02\x01\x02\x01\x00\xff\x0c\x00`\x07q:\xe0pL\r'
         self.env.expect('RESTORE', "hax", 0, rdb_payload, 'REPLACE').error().contains('Bad data format')
+
+
+def test_cf_loadchunk_replicates_to_replica():
+    # MOD-16050: CF.LOADCHUNK must replicate its data chunks, not only the header.
+    # Otherwise a replica of a CF.LOADCHUNK-restored filter has the correct
+    # metadata (CF.INFO reports the full item count) but empty buckets, and a
+    # failover silently loses all the data.
+    # freshEnv=True forces a dedicated master+replica env, so this test is not
+    # affected by env reuse from preceding (non-replicated) tests.
+    env = Env(useSlaves=True, decodeResponses=False, freshEnv=True)
+    if env.isCluster():
+        env.skip()
+
+    master = env.getConnection()
+    slave = env.getSlaveConnection()
+
+    n = 2000
+    # Build a source filter that spans several sub-filters (expansion), then
+    # serialize it with CF.SCANDUMP.
+    master.execute_command('CF.RESERVE', 'src', 100, 'EXPANSION', 2)
+    for i in range(n):
+        master.execute_command('CF.ADD', 'src', 'item%d' % i)
+
+    chunks = []
+    pos = 0
+    while True:
+        pos, data = master.execute_command('CF.SCANDUMP', 'src', pos)
+        if pos == 0:
+            break
+        chunks.append((pos, data))
+    # Must have data chunks beyond the header, otherwise this would not exercise
+    # the data-chunk replication path.
+    env.assertGreater(len(chunks), 1)
+
+    # Restore into a fresh key via CF.LOADCHUNK on the master.
+    for pos, data in chunks:
+        master.execute_command('CF.LOADCHUNK', 'cf', pos, data)
+
+    # The replica must be caught up to the master's replication offset. Poll WAIT
+    # to tolerate the replica still connecting/doing its initial sync.
+    acked = 0
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        acked = master.execute_command('WAIT', 1, 1000)
+        if acked >= 1:
+            break
+    env.assertEqual(acked, 1)
+
+    # ...and must hold the actual filter data, not just the header metadata.
+    missing = [i for i in range(n)
+               if slave.execute_command('CF.EXISTS', 'cf', 'item%d' % i) != 1]
+    env.assertEqual(missing, [],
+                    message='%d/%d items missing on replica after CF.LOADCHUNK' % (len(missing), n))


### PR DESCRIPTION
## Problem
`CF.LOADCHUNK` only replicates the **header** chunk (`pos == 1`). The subsequent **data** chunks are applied on the primary but **never propagated** to replicas / AOF.

A replica of a cuckoo filter that was restored via `CF.SCANDUMP`/`CF.LOADCHUNK` therefore ends up with correct metadata (`CF.INFO` reports the full `Number of items inserted`) but **empty buckets**. The divergence is silent — `master_link_status:up`, equal `master_repl_offset`/`slave_repl_offset`, and matching `CF.INFO` all look healthy — until a **failover** promotes the replica, at which point every `CF.EXISTS` misses. A cuckoo filter has no false negatives, so this is real, total data loss for that key.

`BFLoadChunk_RedisCommand` (Bloom) already replicates its data chunks; `CFLoadChunk_RedisCommand` (Cuckoo) was missing the call.

## Fix
Add `RedisModule_ReplicateVerbatim(ctx)` to the data-chunk branch of `CFLoadChunk_RedisCommand`, mirroring the Bloom path.

The RDB / `DUMP` / `RESTORE` / full-sync path was already correct (so a full resync heals an affected replica); this closes the **incremental replication** gap.

## Reproduction (stock OSS Redis, primary + replica)
Build one filter via `CF.ADD` (control) and one via `CF.LOADCHUNK` on the primary, `WAIT 1`, then read both on the replica:
- `CF.ADD`-built key -> 0 missing.
- `CF.LOADCHUNK`-built key -> **100% missing**, while replica `CF.INFO` still reports the full inserted count.

Also reproduced on a 3-node Redis Enterprise cluster (promoted replica serves an empty filter). Verified the fix: with the change, the `CF.LOADCHUNK`-built key replicates fully.

## Test
Adds `test_cf_loadchunk_replicates_to_replica` (replicated env): builds a multi-sub-filter CF via `CF.LOADCHUNK` on the primary, `WAIT`s, and asserts every member is present on the replica. Verified the test **fails on the unpatched build** (2000/2000 missing) and **passes with the fix**. Full `test_cuckoo.py` suite green (31/31) with `--enable-debug-command`.

Jira: MOD-16050

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Fixes silent total data loss on replica failover for CF.LOADCHUNK-restored keys; change is a one-line replication call aligned with Bloom, but the failure mode was security/data-critical.
> 
> **Overview**
> **`CF.LOADCHUNK`** now calls **`RedisModule_ReplicateVerbatim`** after each successful **data** chunk load (`pos != 1`), matching **`BF.LOADCHUNK`** and the existing header-chunk path. Without this, replicas could show correct **`CF.INFO`** counts but empty buckets after incremental restore, causing total membership loss after failover.
> 
> A new master/replica test builds a multi-chunk filter via **`CF.SCANDUMP`** / **`CF.LOADCHUNK`**, waits for replication, and asserts every member exists on the replica with **`CF.EXISTS`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8d0991f5a26d6be382e39ed4f73a9f8cf42bd77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->