### PR TITLE
MOD-16050 - CF.LOADCHUNK: replicate data chunks (backport to 8.6)

### DIFF
--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -1010,6 +1010,7 @@ static int CFLoadChunk_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **arg
     if (CF_LoadEncodedChunk(cf, pos, blob, bloblen) != REDISMODULE_OK) {
         return RedisModule_ReplyWithError(ctx, "Couldn't load chunk!");
     }
+    RedisModule_ReplicateVerbatim(ctx);
     return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
 

--- a/tests/flow/test_cuckoo.py
+++ b/tests/flow/test_cuckoo.py
@@ -1,4 +1,5 @@
 import random
+import time
 
 from common import *
 
@@ -688,3 +689,56 @@ class testCuckooNoCodec():
         self.cmd('FLUSHALL')
         rdb_payload = b'\x07\x810\x16\xe5\xa2\x89\x82\x14\x04\x02\x00\x02\x08\x02\x01\x02\x00\x02\x01\x02\x01\x02\x01\x00\xff\x0c\x00`\x07q:\xe0pL\r'
         self.env.expect('RESTORE', "hax", 0, rdb_payload, 'REPLACE').error().contains('Bad data format')
+
+
+def test_cf_loadchunk_replicates_to_replica():
+    # MOD-16050: CF.LOADCHUNK must replicate its data chunks, not only the header.
+    # Otherwise a replica of a CF.LOADCHUNK-restored filter has the correct
+    # metadata (CF.INFO reports the full item count) but empty buckets, and a
+    # failover silently loses all the data.
+    # freshEnv=True forces a dedicated master+replica env, so this test is not
+    # affected by env reuse from preceding (non-replicated) tests.
+    env = Env(useSlaves=True, decodeResponses=False, freshEnv=True)
+    if env.isCluster():
+        env.skip()
+
+    master = env.getConnection()
+    slave = env.getSlaveConnection()
+
+    n = 2000
+    # Build a source filter that spans several sub-filters (expansion), then
+    # serialize it with CF.SCANDUMP.
+    master.execute_command('CF.RESERVE', 'src', 100, 'EXPANSION', 2)
+    for i in range(n):
+        master.execute_command('CF.ADD', 'src', 'item%d' % i)
+
+    chunks = []
+    pos = 0
+    while True:
+        pos, data = master.execute_command('CF.SCANDUMP', 'src', pos)
+        if pos == 0:
+            break
+        chunks.append((pos, data))
+    # Must have data chunks beyond the header, otherwise this would not exercise
+    # the data-chunk replication path.
+    env.assertGreater(len(chunks), 1)
+
+    # Restore into a fresh key via CF.LOADCHUNK on the master.
+    for pos, data in chunks:
+        master.execute_command('CF.LOADCHUNK', 'cf', pos, data)
+
+    # The replica must be caught up to the master's replication offset. Poll WAIT
+    # to tolerate the replica still connecting/doing its initial sync.
+    acked = 0
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        acked = master.execute_command('WAIT', 1, 1000)
+        if acked >= 1:
+            break
+    env.assertEqual(acked, 1)
+
+    # ...and must hold the actual filter data, not just the header metadata.
+    missing = [i for i in range(n)
+               if slave.execute_command('CF.EXISTS', 'cf', 'item%d' % i) != 1]
+    env.assertEqual(missing, [],
+                    message='%d/%d items missing on replica after CF.LOADCHUNK' % (len(missing), n))


### PR DESCRIPTION
Backport of MOD-16050 to the `8.6` release branch (cherry-pick of master PR #1014).

**Problem:** `CF.LOADCHUNK` replicated only the header chunk, not the data chunks, so a replica of a `CF.SCANDUMP`/`CF.LOADCHUNK`-restored cuckoo filter ended up with correct `CF.INFO` metadata but empty buckets — silent, and exposed as total data loss when a failover promotes the replica.

**Fix:** add `RedisModule_ReplicateVerbatim(ctx)` to the data-chunk branch of `CFLoadChunk_RedisCommand` (mirroring `BFLoadChunk_RedisCommand`) + a replication regression test (`test_cf_loadchunk_replicates_to_replica`).

Verified end-to-end on 2.4 (build + test: fails on unpatched, passes with fix); identical change cherry-picked across all release branches. CI will run the regression test here.

Jira: MOD-16050

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes replication correctness for restore/migration paths; behavior change is limited to CF.LOADCHUNK after successful chunk load, aligned with BF.LOADCHUNK.
> 
> **Overview**
> **`CF.LOADCHUNK`** now replicates **data** chunks to replicas, not only the header chunk. After a successful `CF_LoadEncodedChunk`, the handler calls **`RedisModule_ReplicateVerbatim`**, matching **`BF.LOADCHUNK`**.
> 
> Without this, a replica restored via `CF.SCANDUMP`/`CF.LOADCHUNK` on the master could show correct **`CF.INFO`** counts but **empty buckets**, so failover could **lose all items** with no obvious error.
> 
> A new **`test_cf_loadchunk_replicates_to_replica`** builds a multi-chunk filter on master, reloads it with **`CF.LOADCHUNK`**, waits for replication, and asserts all items exist on the slave.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aba650240ea449762fd7f6d58e26dae145361c2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->