### PR TITLE
fix(ci): stop uploading unversioned snapshot in nightly

### DIFF
--- a/sbin/pack.sh
+++ b/sbin/pack.sh
@@ -219,14 +219,10 @@ pack_ramp() {
 		fi
 	fi
 
-	# For nightly builds, create files in both beta and snapshots directories
+	# For nightly builds, create versioned files in the beta directory
 	echo "# Debug: SNAPSHOT=$SNAPSHOT, BETA_VERSION=$BETA_VERSION"
 	if [[ $SNAPSHOT == 1 && -n $BETA_VERSION ]]; then
-		echo "# Creating beta and branch files for beta build..."
-		# Get the original branch name (without beta version)
-		local original_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "master")
-		original_branch=${original_branch//[^A-Za-z0-9._-]/_}
-		
+		echo "# Creating beta files for beta build..."
 		# Create beta directory for versioned files
 		mkdir -p $ARTDIR/beta
 		
@@ -242,19 +238,6 @@ pack_ramp() {
 		if [[ -f $ARTDIR/$packdir/$fq_package_debug ]]; then
 			runn cp $ARTDIR/$packdir/$fq_package_debug $ARTDIR/beta/$versioned_package_debug
 			echo "# Created beta debug version $(realpath $ARTDIR/beta/$versioned_package_debug)"
-		fi
-		
-		# Create branch-named files in snapshots directory (overwrite the versioned ones)
-		local branch_package=$stem.${original_branch}${VARIANT}.zip
-		local branch_package_debug=$stem_debug.${original_branch}${VARIANT}.zip
-		
-		if [[ -f $ARTDIR/$packdir/$fq_package ]]; then
-			runn cp $ARTDIR/$packdir/$fq_package $ARTDIR/$packdir/$branch_package
-			echo "# Created branch snapshot $(realpath $ARTDIR/$packdir/$branch_package)"
-		fi
-		if [[ -f $ARTDIR/$packdir/$fq_package_debug ]]; then
-			runn cp $ARTDIR/$packdir/$fq_package_debug $ARTDIR/$packdir/$branch_package_debug
-			echo "# Created branch debug snapshot $(realpath $ARTDIR/$packdir/$branch_package_debug)"
 		fi
 	fi
 


### PR DESCRIPTION
## Problem

Nightly (`event-nightly`) uploads each snapshot to S3 under **two** names:

```
redisbloom.Linux-rhel9-x86_64.master.20260608.210715.940.zip   # versioned (wanted)
redisbloom.Linux-rhel9-x86_64.master.zip                        # unversioned (unwanted)
```

We want only the unique/versioned name.

## Root cause

`pack_ramp()` in `sbin/pack.sh` has a nightly block (added in c2a6478, MOD-11490) that copies the versioned snapshot to an **unversioned, branch-named** file inside the snapshots dir.

MOD-12727 (#977) later made the snapshot name unique by appending `BETA_VERSION` to `BRANCH`, so `fq_package` is already versioned — but that change left the old branch-copy block in place. Both files end up in `bin/artifacts/snapshots`, and `upload-artifacts`'s glob `${prefix}.*${PLATFORM}*.zip` matches both, so both get uploaded.

## Fix

Remove the branch-named snapshot copy block and the now-unused `original_branch` variable. Beta-directory versioned copies (used for the beta S3 folder) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change in `sbin/pack.sh`; beta uploads are unchanged and snapshot uploads become a single versioned object per build.
> 
> **Overview**
> Nightly snapshot packaging no longer writes a second **unversioned, branch-named** zip into `bin/artifacts/snapshots`. Only the already-unique snapshot name (with `BETA_VERSION` in the stem) remains there for upload.
> 
> The nightly block in `pack_ramp()` in `sbin/pack.sh` now only copies **versioned** release and debug zips into `bin/artifacts/beta`; the `original_branch` logic and extra copies under `snapshots/` are removed. That stops `upload-artifacts` globs from matching both `*.master.<timestamp>.<run>.zip` and `*.master.zip` on S3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26b6bd8f730e812b9b6f155a3a2cb6fbcca25690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->