### PR TITLE
MOD-16383 ci: add code coverage to CI — PR + nightly (lcov -> Codecov)

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -68,3 +68,16 @@ jobs:
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit
+  # Code coverage (instrumented build + lcov -> Codecov). Runs on PRs too, so
+  # Codecov posts a per-PR diff-coverage comment. Skipped on draft PRs; toggle
+  # off via the repo variable ENABLE_CODE_COVERAGE='false'. Uploads require the
+  # CODECOV_TOKEN repo secret.
+  coverage:
+    if: ${{ vars.ENABLE_CODE_COVERAGE != 'false' && !github.event.pull_request.draft }}
+    uses: ./.github/workflows/flow-coverage.yml
+    needs: [prepare-values]
+    with:
+      redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      test-config: QUICK=1
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -78,6 +78,8 @@ jobs:
     needs: [prepare-values]
     with:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      test-config: QUICK=1
+      # Full topology suite (not QUICK=1) so replication/AOF/cluster code paths
+      # are exercised and coverage is not understated.
+      test-config: GEN=1 AOF=1 SLAVES=1 CLUSTER=1
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -83,8 +83,5 @@ jobs:
     needs: [prepare-values]
     with:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      # Full topology suite (not QUICK=1) so replication/AOF/cluster code paths
-      # are exercised and coverage is not understated.
-      test-config: GEN=1 AOF=1 SLAVES=1 CLUSTER=1
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -149,6 +149,18 @@ jobs:
   linter:
     uses: ./.github/workflows/flow-linter.yml
     secrets: inherit
+  coverage:
+    # Code coverage: instrumented build (COV=1 -> gcov) + tests -> lcov -> Codecov.
+    # Toggle off via the repo variable ENABLE_CODE_COVERAGE='false'. Uploads
+    # require the CODECOV_TOKEN repo secret.
+    if: ${{ vars.ENABLE_CODE_COVERAGE != 'false' }}
+    uses: ./.github/workflows/flow-coverage.yml
+    needs: [prepare-values]
+    with:
+      redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      test-config: QUICK=1
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   random-traffic:
     uses: ./.github/workflows/flow-random-traffic.yml
     needs: [prepare-values]
@@ -158,10 +170,10 @@ jobs:
     secrets: inherit
   test-summary:
     uses: ./.github/workflows/test-summary.yml
-    needs: [prepare-values, build-linux-x64, build-linux-arm64, macos, linux-valgrind, linux-sanitizer, random-traffic]
+    needs: [prepare-values, build-linux-x64, build-linux-arm64, macos, linux-valgrind, linux-sanitizer, random-traffic, coverage]
     if: always() && (github.event_name == 'schedule' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.send-slack-message == true))
     with:
       redis-ref: ${{ needs.prepare-values.outputs.redis-ref }}
       send-slack-message: ${{ github.event_name == 'schedule' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.send-slack-message == true) }}
-      job-failures: ${{ needs.build-linux-x64.result == 'failure' && 'build-linux-x64 ' || '' }}${{ needs.build-linux-arm64.result == 'failure' && 'build-linux-arm64 ' || '' }}${{ needs.macos.result == 'failure' && 'macos ' || '' }}${{ needs.linux-valgrind.result == 'failure' && 'linux-valgrind ' || '' }}${{ needs.linux-sanitizer.result == 'failure' && 'linux-sanitizer ' || '' }}${{ needs.random-traffic.result == 'failure' && 'random-traffic' || '' }}
+      job-failures: ${{ needs.build-linux-x64.result == 'failure' && 'build-linux-x64 ' || '' }}${{ needs.build-linux-arm64.result == 'failure' && 'build-linux-arm64 ' || '' }}${{ needs.macos.result == 'failure' && 'macos ' || '' }}${{ needs.linux-valgrind.result == 'failure' && 'linux-valgrind ' || '' }}${{ needs.linux-sanitizer.result == 'failure' && 'linux-sanitizer ' || '' }}${{ needs.random-traffic.result == 'failure' && 'random-traffic ' || '' }}${{ needs.coverage.result == 'failure' && 'coverage' || '' }}
     secrets: inherit

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -158,7 +158,9 @@ jobs:
     needs: [prepare-values]
     with:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      test-config: QUICK=1
+      # Full topology suite (not QUICK=1) so replication/AOF/cluster code paths
+      # are exercised and coverage is not understated.
+      test-config: GEN=1 AOF=1 SLAVES=1 CLUSTER=1
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   random-traffic:

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -159,9 +159,6 @@ jobs:
     needs: [prepare-values]
     with:
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
-      # Full topology suite (not QUICK=1) so replication/AOF/cluster code paths
-      # are exercised and coverage is not understated.
-      test-config: GEN=1 AOF=1 SLAVES=1 CLUSTER=1
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   random-traffic:

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -1,0 +1,126 @@
+name: Flow Coverage
+# Builds the module instrumented for coverage (COV=1 -> gcov), runs the flow +
+# unit tests, collects an lcov report (bin/<platform>/cov.info) and uploads it
+# to Codecov. Intended for the nightly; coverage is a slow instrumented build so
+# it is not run on the PR gate.
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      redis-ref:
+        description: 'Redis ref to checkout (empty -> pack/ramp.yml default)'
+        type: string
+        required: false
+        default: ''
+      test-config:
+        description: 'Topology selection for the coverage run (default QUICK=1 -> GEN only)'
+        type: string
+        required: false
+        default: 'QUICK=1'
+  workflow_call:
+    inputs:
+      redis-ref:
+        description: 'Redis ref to checkout'
+        type: string
+        required: true
+      test-config:
+        description: 'Topology selection for the coverage run (default QUICK=1 -> GEN only)'
+        type: string
+        required: false
+        default: 'QUICK=1'
+    secrets:
+      CODECOV_TOKEN:
+        description: 'Codecov upload token (repo secret)'
+        required: false
+
+jobs:
+  coverage:
+    name: coverage (jammy, x64)
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_IMAGE: redisbloom-jammy-cov:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: 'recursive'
+          # Full history so Codecov can resolve the PR base for accurate
+          # diff-coverage (the per-PR comment).
+          fetch-depth: 0
+
+      - name: Resolve redis-ref
+        id: redis
+        env:
+          INPUT_REDIS_REF: ${{ inputs.redis-ref }}
+        run: |
+          REF="$INPUT_REDIS_REF"
+          [ -z "$REF" ] && REF="$(.install/get-redis-ref.sh)"
+          echo "ref=$REF" >> $GITHUB_OUTPUT
+
+      - name: Build Docker Image
+        env:
+          REDIS_REF: ${{ steps.redis.outputs.ref }}
+        run: |
+          docker build -f Dockerfile.jammy --build-arg REDIS_REF="$REDIS_REF" -t "$DOCKER_IMAGE" .
+
+      - name: Run coverage
+        env:
+          TEST_CONFIG: ${{ inputs.test-config }}
+        run: |
+          # `make coverage COV=1` = build COV=1 (instrumented debug) + reset
+          # counters + run tests COV=1 + lcov collect -> bin/<platform>/cov.info.
+          # COV=1 must be set at the top level: the lcov reset/collect macros in
+          # readies/mk/coverage.defs are guarded by `ifeq ($(COV),1)`, so without
+          # it the build is instrumented but no report is produced. The test step
+          # is prefixed with `-` in the Makefile, so the report is still produced
+          # even if some tests fail.
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace \
+            --cap-add=SYS_PTRACE \
+            --security-opt seccomp=unconfined \
+            "$DOCKER_IMAGE" \
+            bash -c "make coverage COV=1 ${TEST_CONFIG} 2>&1 | tee /workspace/coverage_output.log; exit \${PIPESTATUS[0]}"
+
+      - name: Fix permissions
+        if: always()
+        run: |
+          sudo chown -R "$(id -u)":"$(id -g)" bin tests || true
+
+      - name: Locate coverage report
+        id: cov
+        if: always()
+        run: |
+          f="$(find bin -name cov.info 2>/dev/null | head -1)"
+          echo "file=$f" >> $GITHUB_OUTPUT
+          if [ -n "$f" ]; then
+            echo "Found coverage report: $f"
+            lcov --summary "$f" 2>/dev/null || true
+          else
+            echo "::warning::No cov.info produced by 'make coverage'"
+          fi
+
+      - name: Upload coverage to Codecov
+        if: ${{ always() && steps.cov.outputs.file != '' }}
+        uses: codecov/codecov-action@v5
+        with:
+          files: ${{ steps.cov.outputs.file }}
+          disable_search: true
+          flags: flow
+          # CODECOV_TOKEN is configured in the repo secrets, so treat upload
+          # failures as errors (fail the job) rather than silently passing.
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload coverage artifact
+        if: ${{ always() && steps.cov.outputs.file != '' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-report
+          path: |
+            ${{ steps.cov.outputs.file }}
+            coverage_output.log

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -77,8 +77,8 @@ jobs:
           # COV=1 must be set at the top level: the lcov reset/collect macros in
           # readies/mk/coverage.defs are guarded by `ifeq ($(COV),1)`, so without
           # it the build is instrumented but no report is produced. The test step
-          # is prefixed with `-` in the Makefile, so the report is still produced
-          # even if some tests fail.
+          # records its status in the Makefile so the report is still produced
+          # when tests fail, then `make coverage` returns that failing status.
           docker run --rm \
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ always() && steps.cov.outputs.file != '' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           files: ${{ steps.cov.outputs.file }}
           disable_search: true

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -105,9 +105,10 @@ jobs:
             echo "::warning::No cov.info produced by 'make coverage'"
           fi
 
+      # codecov/codecov-action v5.5.5
       - name: Upload coverage to Codecov
         if: ${{ always() && steps.cov.outputs.file != '' }}
-        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac
         with:
           files: ${{ steps.cov.outputs.file }}
           disable_search: true

--- a/.github/workflows/flow-coverage.yml
+++ b/.github/workflows/flow-coverage.yml
@@ -1,8 +1,9 @@
 name: Flow Coverage
 # Builds the module instrumented for coverage (COV=1 -> gcov), runs the flow +
 # unit tests, collects an lcov report (bin/<platform>/cov.info) and uploads it
-# to Codecov. Intended for the nightly; coverage is a slow instrumented build so
-# it is not run on the PR gate.
+# to Codecov. Runs on both the PR gate (for the Codecov diff comment) and the
+# nightly. The full topology suite is used (not QUICK=1) so replication/AOF/
+# cluster code paths are exercised and coverage is not understated.
 
 permissions:
   id-token: write
@@ -17,10 +18,10 @@ on:
         required: false
         default: ''
       test-config:
-        description: 'Topology selection for the coverage run (default QUICK=1 -> GEN only)'
+        description: 'Topology make-flags for the coverage run (default: full suite; pass QUICK=1 for a fast GEN-only manual run)'
         type: string
         required: false
-        default: 'QUICK=1'
+        default: 'GEN=1 AOF=1 SLAVES=1 CLUSTER=1'
   workflow_call:
     inputs:
       redis-ref:
@@ -28,10 +29,10 @@ on:
         type: string
         required: true
       test-config:
-        description: 'Topology selection for the coverage run (default QUICK=1 -> GEN only)'
+        description: 'Topology make-flags for the coverage run (default: full suite; pass QUICK=1 for a fast GEN-only manual run)'
         type: string
         required: false
-        default: 'QUICK=1'
+        default: 'GEN=1 AOF=1 SLAVES=1 CLUSTER=1'
     secrets:
       CODECOV_TOKEN:
         description: 'Codecov upload token (repo secret)'

--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,7 @@ endif
 coverage:
 	$(SHOW)$(MAKE) build COV=1
 	$(SHOW)$(COVERAGE_RESET)
-	$(SHOW)$(MAKE) test COV=1
+	-$(SHOW)$(MAKE) test COV=1
 	$(SHOW)$(COVERAGE_COLLECT_REPORT)
 
 .PHONY: coverage

--- a/Makefile
+++ b/Makefile
@@ -377,14 +377,19 @@ coverage:
 	$(SHOW)test_status=0; \
 		$(MAKE) test COV=1 || test_status=$$?; \
 		printf '%s\n' "$$test_status" > $(COV_DIR)/test.status
-	$(SHOW)$(COVERAGE_COLLECT_REPORT)
 	$(SHOW)test_status=$$(cat $(COV_DIR)/test.status); \
+		collect_status=0; \
+		$(MAKE) coverage-collect-report COV=1 || collect_status=$$?; \
 		if [ "$$test_status" -ne 0 ]; then \
 			echo "Coverage tests failed with status $$test_status"; \
 			exit "$$test_status"; \
-		fi
+		fi; \
+		exit "$$collect_status"
 
-.PHONY: coverage
+coverage-collect-report:
+	$(SHOW)$(COVERAGE_COLLECT_REPORT)
+
+.PHONY: coverage coverage-collect-report
 
 #----------------------------------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -374,8 +374,15 @@ endif
 coverage:
 	$(SHOW)$(MAKE) build COV=1
 	$(SHOW)$(COVERAGE_RESET)
-	-$(SHOW)$(MAKE) test COV=1
+	$(SHOW)test_status=0; \
+		$(MAKE) test COV=1 || test_status=$$?; \
+		printf '%s\n' "$$test_status" > $(COV_DIR)/test.status
 	$(SHOW)$(COVERAGE_COLLECT_REPORT)
+	$(SHOW)test_status=$$(cat $(COV_DIR)/test.status); \
+		if [ "$$test_status" -ne 0 ]; then \
+			echo "Coverage tests failed with status $$test_status"; \
+			exit "$$test_status"; \
+		fi
 
 .PHONY: coverage
 


### PR DESCRIPTION
## What

Adds code coverage to RedisBloom CI, mirroring the RedisTimeSeries setup in [RedisTimeSeries#2070](https://github.com/RedisTimeSeries/RedisTimeSeries/pull/2070).

- **New `flow-coverage.yml`** — reusable workflow that builds the module instrumented (`make coverage COV=1` → gcov), runs the flow + unit tests in a `Dockerfile.jammy` container, collects an lcov report (`bin/<platform>/cov.info`), and uploads it to Codecov.
- **`event-ci.yml`** — runs coverage on the PR gate (so Codecov posts a per-PR diff-coverage comment). Skipped on draft PRs.
- **`event-nightly.yml`** — runs coverage nightly, and wires the job into `test-summary` (`needs` + `job-failures`) so a failed coverage run shows up in the nightly Slack summary.
- **`Makefile`** — records the test status, collects the lcov report even when tests fail, and then returns the failing status to CI.

## Notes

- **Codecov baseline:** the project status currently compares against a master report that is 107 commits stale. Patch coverage is green (all modified coverable lines are covered); this PR establishes the current full-suite baseline once merged.

- Both jobs are gated by the repo variable `ENABLE_CODE_COVERAGE` (set to `'false'` to disable) and require the `CODECOV_TOKEN` repo secret, which is already configured.
- `fail_ci_if_error: true` — since the token is configured, upload failures fail the job rather than silently passing.
- Coverage infra (`codecov.yml`, the readies `coverage.defs`/`coverage.rules`, `make coverage`/`show-cov`/`upload-cov` targets) already existed; this PR only wires it into CI.

Jira: [MOD-16383](https://redislabs.atlassian.net/browse/MOD-16383)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MOD-16383]: https://redislabs.atlassian.net/browse/MOD-16383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflows and Makefile coverage orchestration; no runtime module or security-sensitive application logic is modified.
> 
> **Overview**
> Adds **code coverage** to RedisBloom CI by introducing a reusable **`flow-coverage.yml`** workflow that builds with **`COV=1`**, runs the full topology test suite in Docker, produces **`cov.info`**, and uploads to **Codecov** (with artifacts and **`fail_ci_if_error`**).
> 
> **PR CI** runs coverage on non-draft PRs (for Codecov diff comments); **nightly** includes the same job and reports **`coverage`** failures in the Slack **`test-summary`**. Both are gated by **`ENABLE_CODE_COVERAGE`** and **`CODECOV_TOKEN`**.
> 
> The **`Makefile`** **`coverage`** target now **always collects the lcov report after tests**, even when tests fail, while still exiting with the test failure status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14d3950e1e4845cdef2df8dab203c5a179519027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->