### PR TITLE
MOD-16514 - add another fix to bloom 

### DIFF
--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -5,6 +5,15 @@ processor=$(uname -m)
 OS_TYPE=$(uname -s)
 MODE="${1:-}" # whether to install using sudo or not (empty when already root)
 
+# Skip when an adequate cmake is already on PATH (distro package or another
+# module's bootstrap on the same host): re-running must be a no-op, and
+# blindly re-installing would overwrite /usr/local under other checkouts.
+have_ver="$(cmake --version 2>/dev/null | awk '/cmake version/ {print $3; exit}' || true)"
+if [[ -n "$have_ver" ]] && printf '%s\n' "$version" "$have_ver" | sort -V -C 2>/dev/null; then
+    echo "cmake $have_ver already installed (>= required $version) - skipping"
+    exit 0
+fi
+
 if [[ $OS_TYPE = 'Darwin' ]]
 then
     brew install cmake
@@ -16,8 +25,10 @@ else
         filename=cmake-${version}-linux-aarch64.sh
     fi
 
-    wget https://github.com/Kitware/CMake/releases/download/v${version}/${filename}
-    chmod u+x ./${filename}
-    $MODE ./${filename} --skip-license --prefix=/usr/local --exclude-subdir
+    tmpdir=$(mktemp -d)
+    wget -P "$tmpdir" https://github.com/Kitware/CMake/releases/download/v${version}/${filename}
+    chmod u+x "$tmpdir/$filename"
+    $MODE "$tmpdir/$filename" --skip-license --prefix=/usr/local --exclude-subdir
+    rm -rf "$tmpdir"
     cmake --version
 fi

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -48,7 +48,11 @@ apt_install() {
         $SUDO apt-get update -qq
         _pm_apt_updated=1
     fi
-    $SUDO apt-get install -yqq --no-install-recommends "$@"
+    # env goes THROUGH $SUDO: sudo's env_reset strips exported variables, so a
+    # plain export upstream never reaches dpkg — debconf (e.g. tzdata on focal,
+    # which the base image doesn't preinstall) then blocks on an interactive
+    # prompt and the bootstrap hangs.
+    $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends "$@"
 }
 
 # `--allowerasing` lets dnf pick our `curl` over the slimmer `curl-minimal`
@@ -102,22 +106,12 @@ brew_install() {
 
 debian_default_install() {
     apt_install $DEBIAN_BASE
-    # apt install clang on some Debian-family distros registers clang as the
-    # highest-priority alternative for cc/gcc/g++, causing the clang blocks
-    # path to be chosen in our defer/errdefer macros (requires -fblocks) and
-    # mixing LTO formats at link time. Explicitly pin all three to the highest
-    # real GCC installed by build-essential so the toolchain is consistent.
-    _GCC=$(ls /usr/bin/gcc-[0-9]* 2>/dev/null | sort -V | tail -1)
-    [ -n "$_GCC" ] || { echo "ERROR: no gcc binary found after apt install" >&2; exit 1; }
-    $SUDO update-alternatives --install /usr/bin/cc  cc  "$_GCC" 100
-    $SUDO update-alternatives --set     cc  "$_GCC"
-    $SUDO update-alternatives --install /usr/bin/gcc gcc "$_GCC" 100
-    $SUDO update-alternatives --set     gcc "$_GCC"
-    _GPP="${_GCC/gcc/g++}"
-    if [ -x "$_GPP" ]; then
-        $SUDO update-alternatives --install /usr/bin/g++ g++ "$_GPP" 100
-        $SUDO update-alternatives --set     g++ "$_GPP"
-    fi
+    # No update-alternatives here: pinning cc/gcc/g++ to "the highest gcc on
+    # the system" made the outcome depend on what OTHER checkouts' bootstraps
+    # had installed side-by-side (e.g. RediSearch's gcc-12 flipped the global
+    # default for everyone on the host). Distro defaults stay untouched; the
+    # one distro whose clang packaging hijacks cc (bullseye) restores its own
+    # fixed distro default in os/bullseye.sh.
 }
 
 rhel_default_install() {

--- a/.install/os/bullseye.sh
+++ b/.install/os/bullseye.sh
@@ -5,3 +5,16 @@
 . "$LIB/packages.sh"
 
 debian_default_install
+
+# Bullseye's clang packaging registers clang as the highest-priority
+# alternative for cc, which breaks the defer/errdefer macros (clang blocks
+# need -fblocks) and mixes LTO formats at link time. Restore the DISTRO
+# default (gcc-10 is bullseye's system gcc) — a fixed target, so every
+# module's bootstrap converges on the same state regardless of order or of
+# whatever newer side-by-side gcc another checkout installed.
+$SUDO update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 100
+$SUDO update-alternatives --set     cc  /usr/bin/gcc-10
+$SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
+$SUDO update-alternatives --set     gcc /usr/bin/gcc-10
+$SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
+$SUDO update-alternatives --set     g++ /usr/bin/g++-10


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes shared-host bootstrap behavior (cmake skip/reinstall, global Debian compiler alternatives, bullseye gcc pinning) and apt install env handling; wrong alternatives logic could affect builds on Debian 11 or multi-module CI hosts.
> 
> **Overview**
> Hardens **`.install` bootstrap** so repeated runs and multiple module checkouts on the same machine don’t fight each other or hang CI/images.
> 
> **`install_cmake.sh`** now **no-ops** when `cmake` on `PATH` is already **≥ 3.25.1**, avoiding redundant installs that could overwrite `/usr/local`. Linux installs download the Kitware installer into a **temp directory** and remove it after install instead of leaving the script in the cwd.
> 
> **`apt_install`** passes **`DEBIAN_FRONTEND=noninteractive` through `sudo env`**, so debconf (e.g. **tzdata** on focal) can’t block on an interactive prompt when `sudo` strips exported env vars.
> 
> **Compiler alternatives:** **`debian_default_install`** no longer pins **`cc`/`gcc`/`g++`** to the highest installed GCC on the host—a behavior that depended on what other checkouts had installed. **`os/bullseye.sh`** alone restores a **fixed gcc-10** default to undo bullseye’s clang hijacking of `cc` without affecting other Debian variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8114cd770e4160b6060883097118201cbf448601. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->