### PR TITLE
align 8.10 to master and bump version to 8.9.81

### DIFF
--- a/.install/install_cmake.sh
+++ b/.install/install_cmake.sh
@@ -5,6 +5,15 @@ processor=$(uname -m)
 OS_TYPE=$(uname -s)
 MODE="${1:-}" # whether to install using sudo or not (empty when already root)
 
+# Skip when an adequate cmake is already on PATH (distro package or another
+# module's bootstrap on the same host): re-running must be a no-op, and
+# blindly re-installing would overwrite /usr/local under other checkouts.
+have_ver="$(cmake --version 2>/dev/null | awk '/cmake version/ {print $3; exit}' || true)"
+if [[ -n "$have_ver" ]] && printf '%s\n' "$version" "$have_ver" | sort -V -C 2>/dev/null; then
+    echo "cmake $have_ver already installed (>= required $version) - skipping"
+    exit 0
+fi
+
 if [[ $OS_TYPE = 'Darwin' ]]
 then
     brew install cmake
@@ -16,8 +25,10 @@ else
         filename=cmake-${version}-linux-aarch64.sh
     fi
 
-    wget https://github.com/Kitware/CMake/releases/download/v${version}/${filename}
-    chmod u+x ./${filename}
-    $MODE ./${filename} --skip-license --prefix=/usr/local --exclude-subdir
+    tmpdir=$(mktemp -d)
+    wget -P "$tmpdir" https://github.com/Kitware/CMake/releases/download/v${version}/${filename}
+    chmod u+x "$tmpdir/$filename"
+    $MODE "$tmpdir/$filename" --skip-license --prefix=/usr/local --exclude-subdir
+    rm -rf "$tmpdir"
     cmake --version
 fi

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -10,6 +10,22 @@
 # Sourced by os/<osnick>.sh after lib/pm.sh. All variables here are plain
 # space-separated strings so callers can splat them with `apt_install $SET`.
 
+# Install AWS CLI v2 from the official installer (arch-aware). Skips if
+# already present — handles pre-installed AMIs without failing.
+install_aws_cli() {
+    if command -v aws &>/dev/null; then
+        return 0
+    fi
+    local arch
+    arch=$(uname -m)
+    local url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+    [ "$arch" = "aarch64" ] && url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
+    curl -fSL --retry 3 "$url" -o /tmp/awscliv2.zip
+    unzip -o /tmp/awscliv2.zip -d /tmp/awscli-install
+    $SUDO /tmp/awscli-install/aws/install
+    rm -rf /tmp/awscliv2.zip /tmp/awscli-install
+}
+
 # ----------------------------------------------------------------------------
 # Debian family (apt)
 # ----------------------------------------------------------------------------

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -48,7 +48,11 @@ apt_install() {
         $SUDO apt-get update -qq
         _pm_apt_updated=1
     fi
-    $SUDO apt-get install -yqq --no-install-recommends "$@"
+    # env goes THROUGH $SUDO: sudo's env_reset strips exported variables, so a
+    # plain export upstream never reaches dpkg — debconf (e.g. tzdata on focal,
+    # which the base image doesn't preinstall) then blocks on an interactive
+    # prompt and the bootstrap hangs.
+    $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends "$@"
 }
 
 # `--allowerasing` lets dnf pick our `curl` over the slimmer `curl-minimal`
@@ -102,22 +106,12 @@ brew_install() {
 
 debian_default_install() {
     apt_install $DEBIAN_BASE
-    # apt install clang on some Debian-family distros registers clang as the
-    # highest-priority alternative for cc/gcc/g++, causing the clang blocks
-    # path to be chosen in our defer/errdefer macros (requires -fblocks) and
-    # mixing LTO formats at link time. Explicitly pin all three to the highest
-    # real GCC installed by build-essential so the toolchain is consistent.
-    _GCC=$(ls /usr/bin/gcc-[0-9]* 2>/dev/null | sort -V | tail -1)
-    [ -n "$_GCC" ] || { echo "ERROR: no gcc binary found after apt install" >&2; exit 1; }
-    $SUDO update-alternatives --install /usr/bin/cc  cc  "$_GCC" 100
-    $SUDO update-alternatives --set     cc  "$_GCC"
-    $SUDO update-alternatives --install /usr/bin/gcc gcc "$_GCC" 100
-    $SUDO update-alternatives --set     gcc "$_GCC"
-    _GPP="${_GCC/gcc/g++}"
-    if [ -x "$_GPP" ]; then
-        $SUDO update-alternatives --install /usr/bin/g++ g++ "$_GPP" 100
-        $SUDO update-alternatives --set     g++ "$_GPP"
-    fi
+    # No update-alternatives here: pinning cc/gcc/g++ to "the highest gcc on
+    # the system" made the outcome depend on what OTHER checkouts' bootstraps
+    # had installed side-by-side (e.g. RediSearch's gcc-12 flipped the global
+    # default for everyone on the host). Distro defaults stay untouched; the
+    # one distro whose clang packaging hijacks cc (bullseye) restores its own
+    # fixed distro default in os/bullseye.sh.
 }
 
 rhel_default_install() {

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -102,6 +102,22 @@ brew_install() {
 
 debian_default_install() {
     apt_install $DEBIAN_BASE
+    # apt install clang on some Debian-family distros registers clang as the
+    # highest-priority alternative for cc/gcc/g++, causing the clang blocks
+    # path to be chosen in our defer/errdefer macros (requires -fblocks) and
+    # mixing LTO formats at link time. Explicitly pin all three to the highest
+    # real GCC installed by build-essential so the toolchain is consistent.
+    _GCC=$(ls /usr/bin/gcc-[0-9]* 2>/dev/null | sort -V | tail -1)
+    [ -n "$_GCC" ] || { echo "ERROR: no gcc binary found after apt install" >&2; exit 1; }
+    $SUDO update-alternatives --install /usr/bin/cc  cc  "$_GCC" 100
+    $SUDO update-alternatives --set     cc  "$_GCC"
+    $SUDO update-alternatives --install /usr/bin/gcc gcc "$_GCC" 100
+    $SUDO update-alternatives --set     gcc "$_GCC"
+    _GPP="${_GCC/gcc/g++}"
+    if [ -x "$_GPP" ]; then
+        $SUDO update-alternatives --install /usr/bin/g++ g++ "$_GPP" 100
+        $SUDO update-alternatives --set     g++ "$_GPP"
+    fi
 }
 
 rhel_default_install() {
@@ -172,8 +188,15 @@ el8_default_install() {
     rhel_default_install
     dnf_install \
         gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel \
-        python3.11 python3.11-devel xz
+        python3.11 python3.11-devel python3.11-pip xz
     $SUDO cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh 2>/dev/null || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/gcc  /usr/local/bin/gcc  || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/g++  /usr/local/bin/g++  || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/cc   /usr/local/bin/cc   || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/as   /usr/local/bin/as   || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/make /usr/local/bin/make || true
+    $SUDO update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 2000000
+    $SUDO update-alternatives --set python3 /usr/bin/python3.11
     export SETUP_PYTHON_VERSION="${SETUP_PYTHON_VERSION:-3.11}"
 }
 
@@ -184,4 +207,9 @@ el9_default_install() {
     dnf_install \
         gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ gcc-toolset-13-libatomic-devel
     $SUDO cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh 2>/dev/null || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/gcc  /usr/local/bin/gcc  || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/g++  /usr/local/bin/g++  || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/cc   /usr/local/bin/cc   || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/as   /usr/local/bin/as   || true
+    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/make /usr/local/bin/make || true
 }

--- a/.install/os/amazonlinux2.sh
+++ b/.install/os/amazonlinux2.sh
@@ -24,8 +24,12 @@ $SUDO yum -y install --nogpgcheck --skip-broken \
 
 rhel_default_install
 $SUDO ln -sf "$(command -v cmake3)" /usr/bin/cmake
+if [ -f /opt/rh/devtoolset-11/root/usr/bin/gcc ]; then
+    $SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/make /usr/local/bin/make
+    $SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/gcc /usr/local/bin/gcc
+    $SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/g++ /usr/local/bin/g++
+    $SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/cc /usr/local/bin/cc
+fi
 
 # Install aws-cli for uploading artifacts to s3
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-unzip awscliv2.zip
-./aws/install
+install_aws_cli

--- a/.install/os/azurelinux3.sh
+++ b/.install/os/azurelinux3.sh
@@ -9,4 +9,4 @@ tdnf_default_install
 git config --global --add safe.directory '*' || true
 
 # Install AWS CLI for uploading to S3
-pip3 install awscli --upgrade
+install_aws_cli

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -1,35 +1,52 @@
 #!/usr/bin/env bash
-# Ubuntu 18.04 (bionic). Two distinct quirks beyond the Debian default:
-#
-#   1. Apt's default gcc is 7.x — too old for our C++. Pull gcc-10/g++-10
-#      from the toolchain-r/test PPA and switch /usr/bin/{gcc,g++} to them.
-#
-#   2. Apt's cmake is 3.10 — too old for our CMakeLists. Build cmake 3.28
-#      from source (~5 minutes on a typical CI runner) and symlink it as
-#      /usr/bin/cmake so the older apt cmake is shadowed.
-#
-# We deliberately do *not* call debian_default_install before adding the PPA
-# because software-properties-common (which provides add-apt-repository) is
-# not in the base image and pulling it via apt_install lets us populate the
-# apt cache in a single update pass.
+# Ubuntu 18.04 (bionic). cmake 3.28 built from source — apt cmake is 3.10.
+# gcc-10 via toolchain-r PPA; || true so launchpad failures are non-fatal
+# (ESM repos already carry gcc-10 on Ubuntu Pro machines).
 
 # shellcheck source=../lib/packages.sh
 . "$LIB/packages.sh"
 
+export DEBIAN_FRONTEND=noninteractive
+echo 'debconf debconf/frontend select Noninteractive' | $SUDO debconf-set-selections 2>/dev/null || true
+echo 'tzdata tzdata/Areas select Etc' | $SUDO debconf-set-selections 2>/dev/null || true
+echo 'tzdata tzdata/Zones/Etc select UTC' | $SUDO debconf-set-selections 2>/dev/null || true
+# apt_install (not a raw apt-get call) so this runs apt-get update first —
+# on a fresh base image with no apt index yet, a raw "apt-get install"
+# here can fail silently and leave gnupg/wget missing for the next step.
+apt_install gnupg wget curl ca-certificates
+wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg || true
+wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r-2.gpg || true
+echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list
+$SUDO apt-get update -qq
 apt_install software-properties-common lsb-core binfmt-support cargo zlib1g-dev
-$SUDO add-apt-repository ppa:ubuntu-toolchain-r/test -y
 debian_default_install
 apt_install gcc-10 g++-10
-$SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
-    --slave /usr/bin/g++ g++ /usr/bin/g++-10
+# Only move the active compiler up, never down — another module's bootstrap
+# may have already pinned something newer in this shared build container.
+_cur=$(gcc -dumpversion | cut -d. -f1)
+if [ "$_cur" -lt 10 ]; then
+    # cc/gcc/g++ are each registered as their own independent master by
+    # debian_default_install, not slaves of each other — --slave-grouping
+    # would conflict with that.
+    $SUDO update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 60
+    $SUDO update-alternatives --set     cc  /usr/bin/gcc-10
+    $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
+    $SUDO update-alternatives --set     gcc /usr/bin/gcc-10
+    $SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60
+    $SUDO update-alternatives --set     g++ /usr/bin/g++-10
+fi
 
-cd /tmp
-wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
-tar -xzf cmake-3.28.0.tar.gz
-cd cmake-3.28.0
-./configure
-make -j"$(nproc)"
-$SUDO make install
-cd /
-rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz
-$SUDO ln -sf /usr/local/bin/cmake /usr/bin/cmake
+if ! cmake --version 2>/dev/null | grep -qE 'cmake version 3\.(2[89]|[3-9][0-9])'; then
+    cd /tmp
+    wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
+    tar -xzf cmake-3.28.0.tar.gz
+    cd cmake-3.28.0
+    ./configure
+    make -j"$(nproc)"
+    $SUDO make install
+    cd /
+    rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz
+    $SUDO ln -sf /usr/local/bin/cmake /usr/bin/cmake
+fi
+
+pip3 install dataclasses

--- a/.install/os/bullseye.sh
+++ b/.install/os/bullseye.sh
@@ -5,3 +5,16 @@
 . "$LIB/packages.sh"
 
 debian_default_install
+
+# Bullseye's clang packaging registers clang as the highest-priority
+# alternative for cc, which breaks the defer/errdefer macros (clang blocks
+# need -fblocks) and mixes LTO formats at link time. Restore the DISTRO
+# default (gcc-10 is bullseye's system gcc) — a fixed target, so every
+# module's bootstrap converges on the same state regardless of order or of
+# whatever newer side-by-side gcc another checkout installed.
+$SUDO update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 100
+$SUDO update-alternatives --set     cc  /usr/bin/gcc-10
+$SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
+$SUDO update-alternatives --set     gcc /usr/bin/gcc-10
+$SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
+$SUDO update-alternatives --set     g++ /usr/bin/g++-10

--- a/.install/os/focal.sh
+++ b/.install/os/focal.sh
@@ -7,5 +7,14 @@
 
 debian_default_install
 apt_install gcc-10 g++-10
-$SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 \
-    --slave /usr/bin/g++ g++ /usr/bin/g++-10
+# Only move the active compiler up, never down — another module's bootstrap
+# may have already pinned something newer in this shared build container.
+_cur=$(gcc -dumpversion | cut -d. -f1)
+if [ "$_cur" -lt 10 ]; then
+    $SUDO update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 60
+    $SUDO update-alternatives --set     cc  /usr/bin/gcc-10
+    $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
+    $SUDO update-alternatives --set     gcc /usr/bin/gcc-10
+    $SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60
+    $SUDO update-alternatives --set     g++ /usr/bin/g++-10
+fi

--- a/.install/os/mariner2.sh
+++ b/.install/os/mariner2.sh
@@ -9,6 +9,4 @@ tdnf_default_install
 git config --global --add safe.directory '*' || true
 
 # Install aws-cli for uploading artifacts to s3
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-unzip awscliv2.zip
-./aws/install
+install_aws_cli

--- a/.install/os/rocky8.sh
+++ b/.install/os/rocky8.sh
@@ -8,6 +8,4 @@
 el8_default_install
 
 # Install aws-cli for uploading artifacts to s3
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-unzip awscliv2.zip
-./aws/install
+install_aws_cli

--- a/.install/os/rocky9.sh
+++ b/.install/os/rocky9.sh
@@ -7,12 +7,5 @@
 
 el9_default_install
 
-# Install aws-cli for uploading artifacts to s3 (arch-aware: x86_64 / aarch64)
-ARCH=$(uname -m)
-if [[ $ARCH == "aarch64" ]]; then
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
-else
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-fi
-unzip awscliv2.zip
-./aws/install
+# Install aws-cli for uploading artifacts to s3
+install_aws_cli

--- a/src/version.h
+++ b/src/version.h
@@ -20,7 +20,7 @@
 #endif
 
 #ifndef REBLOOM_VERSION_PATCH
-#define REBLOOM_VERSION_PATCH 80
+#define REBLOOM_VERSION_PATCH 81
 
 #endif
 

--- a/tests/flow/requirements.txt
+++ b/tests/flow/requirements.txt
@@ -1,3 +1,3 @@
-RLTest == 0.7.15
-numpy
+RLTest == 0.7.27
+numpy<2
 setuptools<81

--- a/tests/flow/test_cuckoo.py
+++ b/tests/flow/test_cuckoo.py
@@ -29,7 +29,10 @@ class testCuckoo():
     def test_counter_overflow_with_large_number_of_items(self):
         self.cmd('FLUSHALL')
         self.cmd('CF.RESERVE', 'cf', 2, 'BUCKETSIZE', 1, 'EXPANSION', 1)
-        self.cmd('CF.INSERT', 'cf', 'ITEMS', *["1 "]*140000)
+        try:
+            self.cmd('CF.INSERT', 'cf', 'ITEMS', *["1 "]*140000)
+        except ResponseError:
+            pass
 
     def test_count(self):
         self.cmd('FLUSHALL')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect CI/bootstrap on many distros (compiler defaults, python3 on EL8, apt under sudo); mistakes could break builds or alter global host state, but intent is to reduce cross-checkout interference.
> 
> **Overview**
> Hardens **`.install` bootstrap** so repeated runs and **shared CI hosts** with multiple Redis module checkouts converge instead of fighting over global toolchain state.
> 
> **Idempotency and safety:** `install_cmake.sh` skips when PATH already has cmake ≥ 3.25.1 and installs via a temp dir. Shared **`install_aws_cli()`** replaces duplicated curl/unzip blocks on Rocky, Mariner, Azure Linux, and Amazon Linux 2 (skips if `aws` exists).
> 
> **Debian/Ubuntu:** `apt_install` passes **`DEBIAN_FRONTEND=noninteractive` through `sudo`** so debconf (e.g. tzdata on focal) cannot hang. **`debian_default_install`** no longer pins gcc via `update-alternatives`; **bionic** gets debconf preseeding, manual PPA key setup, **gcc-10 only if current gcc &lt; 10**, conditional cmake 3.28 build, and `dataclasses` via pip; **focal** uses the same “only upgrade compiler, never downgrade” rule; **bullseye** explicitly restores **gcc-10** for `cc`/`gcc`/`g++` after clang hijacks `cc`.
> 
> **RHEL family:** EL8 adds **python3.11-pip**, symlinks **gcc-toolset-11** tools under `/usr/local/bin`, and sets **python3** to 3.11; EL9 and **Amazon Linux 2** (devtoolset-11) get similar compiler/make symlinks.
> 
> Also bumps **patch version** to 8.9.81, upgrades flow tests to **RLTest 0.7.27** with **`numpy&lt;2`**, and relaxes one cuckoo overflow test to ignore **`ResponseError`** on huge inserts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e107d9b255bf46df73f93fb354a6575537b34223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->