### PR TITLE
External Tdigest Merge function

### DIFF
--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -17,7 +17,9 @@
 #include "common.h"
 
 #include <math.h>
+#include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 #include <strings.h>
 #include <stdbool.h>
 
@@ -32,6 +34,14 @@
     RedisModule_TryRealloc ? RedisModule_TryRealloc(__VA_ARGS__) : RedisModule_Realloc(__VA_ARGS__)
 #define td_free_ RedisModule_Free
 #define TD_DEFAULT_COMPRESSION 100
+/* Real t-digest usage never needs more than a few thousand centroids
+ * (compression of 100-1000 is the documented sweet spot). TD_MAX_CENTROIDS
+ * bounds the per-digest node-array allocation (cap = 6*compression+10, see
+ * cap_from_compression() in the t-digest lib) to a sane size regardless of
+ * how the compression value arrives: TDIGEST.CREATE, TDIGEST.MERGE's
+ * COMPRESSION keyword, or an EXTERNALMERGE blob's declared compression. */
+#define TD_MAX_CENTROIDS (100000u) /* cap*16 bytes => <= ~1.6 MiB per digest */
+#define TD_MAX_COMPRESSION ((TD_MAX_CENTROIDS - 10) / 6)
 
 #include "tdigest.h"
 #include "load_io_error.h"
@@ -68,6 +78,10 @@ static int _TDigest_ParseCompressionParameter(RedisModuleCtx *ctx, const RedisMo
     if (*compression <= 0) {
         RedisModule_ReplyWithError(
             ctx, "ERR T-Digest: compression parameter needs to be a positive integer");
+        return REDISMODULE_ERR;
+    }
+    if (*compression > TD_MAX_COMPRESSION) {
+        RedisModule_ReplyWithError(ctx, "ERR T-Digest: compression parameter exceeds maximum allowed");
         return REDISMODULE_ERR;
     }
     return REDISMODULE_OK;
@@ -368,6 +382,250 @@ cleanup:
     if (from_tdigests)
         td_free_(from_tdigests);
     return res;
+}
+
+/*
+ * TDIGEST.EXTERNALMERGE blob format v1 ("TDB1"):
+ *
+ *   offset  size       field             notes
+ *   ------  ---------  ----------------  -----------------------------------
+ *   0       4          magic             ASCII "TDB1"
+ *   4       1          version           uint8 = 1
+ *   5       8          compression       float64 LE, > 0 (used verbatim as the
+ *                                        new digest's compression if {key}
+ *                                        doesn't exist yet; ignored otherwise)
+ *   13      4          num_centroids     uint32 LE (<= EXTERNALMERGE_MAX_CENTROIDS)
+ *   17      8 * N      means             float64 LE x N, sorted ascending, finite
+ *   17+8N   8 * N      weights           int64   LE x N, > 0
+ *   17+16N  4          crc32             uint32 LE, IEEE poly over bytes [0,17+16N)
+ *
+ * Total length: exactly 21 + 16*N bytes.
+ */
+#define EXTERNALMERGE_MAGIC "TDB1"
+#define EXTERNALMERGE_VERSION 1
+#define EXTERNALMERGE_HEADER_LEN 17
+#define EXTERNALMERGE_TRAILER_LEN 4
+/* Shares TD_MAX_CENTROIDS / TD_MAX_COMPRESSION with TDIGEST.CREATE and
+ * TDIGEST.MERGE so every path that can size a digest's node arrays is bound
+ * by the same ceiling. Without the compression bound, a tiny blob could
+ * declare an arbitrarily large compression and force a huge allocation for
+ * a brand-new key, independent of the blob's own centroid count. */
+#define EXTERNALMERGE_MAX_CENTROIDS TD_MAX_CENTROIDS
+#define EXTERNALMERGE_MAX_COMPRESSION TD_MAX_COMPRESSION
+
+typedef enum {
+    EM_OK = 0,
+    EM_ERR_TOO_SHORT,
+    EM_ERR_BAD_MAGIC,
+    EM_ERR_BAD_VERSION,
+    EM_ERR_TOO_MANY,
+    EM_ERR_LENGTH_MISMATCH,
+    EM_ERR_BAD_COMPRESSION,
+    EM_ERR_COMPRESSION_TOO_LARGE,
+    EM_ERR_BAD_MEAN,
+    EM_ERR_BAD_WEIGHT,
+    EM_ERR_UNSORTED,
+    EM_ERR_CRC,
+} ExternalMergeErr;
+
+static const char *_ExternalMerge_ErrMsg(ExternalMergeErr e) {
+    switch (e) {
+    case EM_ERR_TOO_SHORT:            return "ERR T-Digest: blob too short";
+    case EM_ERR_BAD_MAGIC:            return "ERR T-Digest: blob bad magic";
+    case EM_ERR_BAD_VERSION:          return "ERR T-Digest: blob unsupported version";
+    case EM_ERR_TOO_MANY:             return "ERR T-Digest: blob has too many centroids";
+    case EM_ERR_LENGTH_MISMATCH:      return "ERR T-Digest: blob length mismatch";
+    case EM_ERR_BAD_COMPRESSION:      return "ERR T-Digest: blob has invalid compression";
+    case EM_ERR_COMPRESSION_TOO_LARGE: return "ERR T-Digest: blob compression exceeds maximum allowed";
+    case EM_ERR_BAD_MEAN:             return "ERR T-Digest: blob has non-finite mean";
+    case EM_ERR_BAD_WEIGHT:           return "ERR T-Digest: blob has non-positive weight";
+    case EM_ERR_UNSORTED:             return "ERR T-Digest: blob centroids not sorted";
+    case EM_ERR_CRC:                  return "ERR T-Digest: blob crc mismatch";
+    default:                          return "ERR T-Digest: blob parse error";
+    }
+}
+
+/* Reflected IEEE CRC-32 (zlib polynomial 0xEDB88320), bytewise. */
+static uint32_t _ExternalMerge_Crc32(const uint8_t *data, size_t len) {
+    uint32_t crc = 0xFFFFFFFFu;
+    for (size_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (int b = 0; b < 8; b++) {
+            uint32_t mask = -(int32_t)(crc & 1u);
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+    return crc ^ 0xFFFFFFFFu;
+}
+
+/* Little-endian readers — explicit so host endianness never sneaks in. */
+static inline uint32_t _ExternalMerge_LoadU32LE(const uint8_t *p) {
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) |
+           ((uint32_t)p[3] << 24);
+}
+
+static inline int64_t _ExternalMerge_LoadI64LE(const uint8_t *p) {
+    uint64_t u = (uint64_t)p[0] | ((uint64_t)p[1] << 8) | ((uint64_t)p[2] << 16) |
+                 ((uint64_t)p[3] << 24) | ((uint64_t)p[4] << 32) | ((uint64_t)p[5] << 40) |
+                 ((uint64_t)p[6] << 48) | ((uint64_t)p[7] << 56);
+    return (int64_t)u;
+}
+
+static inline double _ExternalMerge_LoadF64LE(const uint8_t *p) {
+    uint64_t u = (uint64_t)p[0] | ((uint64_t)p[1] << 8) | ((uint64_t)p[2] << 16) |
+                 ((uint64_t)p[3] << 24) | ((uint64_t)p[4] << 32) | ((uint64_t)p[5] << 40) |
+                 ((uint64_t)p[6] << 48) | ((uint64_t)p[7] << 56);
+    double d;
+    memcpy(&d, &u, sizeof(d));
+    return d;
+}
+
+/*
+ * Parse and validate an EXTERNALMERGE blob. On success returns EM_OK with out_* populated.
+ * On error returns the specific EM_ERR_* code; out_* unchanged.
+ *
+ * The blob is bounds-checked up front: a single 4-byte field tells us the
+ * expected length, and we reject anything else. After that, all reads are
+ * inside [data, data+len) by construction.
+ */
+static ExternalMergeErr _ExternalMerge_Parse(const uint8_t *data, size_t len,
+                                              uint32_t *out_num_centroids,
+                                              const uint8_t **out_means_ptr,
+                                              const uint8_t **out_weights_ptr,
+                                              double *out_compression) {
+    if (len < EXTERNALMERGE_HEADER_LEN + EXTERNALMERGE_TRAILER_LEN) {
+        return EM_ERR_TOO_SHORT;
+    }
+    if (memcmp(data, EXTERNALMERGE_MAGIC, 4) != 0) {
+        return EM_ERR_BAD_MAGIC;
+    }
+    if (data[4] != EXTERNALMERGE_VERSION) {
+        return EM_ERR_BAD_VERSION;
+    }
+    double compression = _ExternalMerge_LoadF64LE(data + 5);
+    if (!isfinite(compression) || compression <= 0.0) {
+        return EM_ERR_BAD_COMPRESSION;
+    }
+    if (compression > (double)EXTERNALMERGE_MAX_COMPRESSION) {
+        return EM_ERR_COMPRESSION_TOO_LARGE;
+    }
+    uint32_t n = _ExternalMerge_LoadU32LE(data + 13);
+    if (n > EXTERNALMERGE_MAX_CENTROIDS) {
+        return EM_ERR_TOO_MANY;
+    }
+    size_t expected = (size_t)EXTERNALMERGE_HEADER_LEN + (size_t)n * 16u + EXTERNALMERGE_TRAILER_LEN;
+    if (expected != len) {
+        return EM_ERR_LENGTH_MISMATCH;
+    }
+    const uint8_t *means_ptr = data + EXTERNALMERGE_HEADER_LEN;
+    const uint8_t *weights_ptr = means_ptr + (size_t)n * 8u;
+    /* CRC over everything except the 4-byte trailer. */
+    uint32_t crc_stored = _ExternalMerge_LoadU32LE(data + len - EXTERNALMERGE_TRAILER_LEN);
+    uint32_t crc_calc = _ExternalMerge_Crc32(data, len - EXTERNALMERGE_TRAILER_LEN);
+    if (crc_stored != crc_calc) {
+        return EM_ERR_CRC;
+    }
+    /* Per-field validation; means must be finite + sorted, weights > 0. */
+    double prev_mean = -INFINITY;
+    for (uint32_t i = 0; i < n; i++) {
+        double m = _ExternalMerge_LoadF64LE(means_ptr + (size_t)i * 8u);
+        if (!isfinite(m)) {
+            return EM_ERR_BAD_MEAN;
+        }
+        if (m < prev_mean) {
+            return EM_ERR_UNSORTED;
+        }
+        prev_mean = m;
+        int64_t w = _ExternalMerge_LoadI64LE(weights_ptr + (size_t)i * 8u);
+        if (w <= 0) {
+            return EM_ERR_BAD_WEIGHT;
+        }
+    }
+    *out_num_centroids = n;
+    *out_means_ptr = means_ptr;
+    *out_weights_ptr = weights_ptr;
+    *out_compression = compression;
+    return EM_OK;
+}
+
+/**
+ * Command: TDIGEST.EXTERNALMERGE {key} {blob}
+ *
+ * Merges a client-side-serialized t-digest (in the TDB1 wire format above)
+ * into {key}. If {key} already exists, its compression governs storage and
+ * the blob's own `compression` field is ignored. If {key} does not exist,
+ * it is created using the blob's declared compression, so a high-fidelity
+ * client-side digest isn't silently downsampled on its first flush.
+ *
+ * Like TDIGEST.MERGE, this builds the result in a scratch digest and only
+ * installs it into {key} once every centroid has been merged successfully
+ * — a rejected/overflowing blob never partially mutates (or creates) the
+ * destination key.
+ *
+ * Reply: simple string "OK" on success, error otherwise.
+ */
+int TDigestSketch_ExternalMerge(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 3) {
+        return RedisModule_WrongArity(ctx);
+    }
+    size_t blob_len = 0;
+    const char *blob_raw = RedisModule_StringPtrLen(argv[2], &blob_len);
+    const uint8_t *blob = (const uint8_t *)blob_raw;
+
+    uint32_t n = 0;
+    const uint8_t *means_ptr = NULL;
+    const uint8_t *weights_ptr = NULL;
+    double blob_compression = 0.0;
+    ExternalMergeErr perr =
+        _ExternalMerge_Parse(blob, blob_len, &n, &means_ptr, &weights_ptr, &blob_compression);
+    if (perr != EM_OK) {
+        return RedisModule_ReplyWithError(ctx, _ExternalMerge_ErrMsg(perr));
+    }
+
+    RedisModuleString *keyName = argv[1];
+    RedisModuleKey *key = RedisModule_OpenKey(ctx, keyName, REDISMODULE_READ);
+    td_histogram_t *tdigestStart = NULL;
+    bool to_exists = false;
+    if (RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_EMPTY) {
+        if (RedisModule_ModuleTypeGetType(key) != TDigestSketchType) {
+            RedisModule_CloseKey(key);
+            return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+        }
+        tdigestStart = RedisModule_ModuleTypeGetValue(key);
+        to_exists = true;
+    }
+    RedisModule_CloseKey(key);
+
+    double compression = to_exists ? tdigestStart->compression : blob_compression;
+    td_histogram_t *tdigest = NULL;
+    if (td_init(compression, &tdigest) != 0) {
+        return RedisModule_ReplyWithError(ctx, "ERR T-Digest: allocation failed");
+    }
+    if (to_exists && td_merge(tdigest, tdigestStart) != 0) {
+        td_free(tdigest);
+        return RedisModule_ReplyWithError(ctx, "ERR T-Digest: overflow detected");
+    }
+
+    for (uint32_t i = 0; i < n; i++) {
+        double mean = _ExternalMerge_LoadF64LE(means_ptr + (size_t)i * 8u);
+        int64_t weight = _ExternalMerge_LoadI64LE(weights_ptr + (size_t)i * 8u);
+        if (td_add(tdigest, mean, (long long)weight) != 0) {
+            td_free(tdigest);
+            return RedisModule_ReplyWithError(ctx, "ERR T-Digest: overflow detected");
+        }
+    }
+    td_compress(tdigest);
+
+    key = RedisModule_OpenKey(ctx, keyName, REDISMODULE_WRITE);
+    if (RedisModule_ModuleTypeSetValue(key, TDigestSketchType, tdigest) != REDISMODULE_OK) {
+        td_free(tdigest);
+        RedisModule_CloseKey(key);
+        return RedisModule_ReplyWithError(ctx, "ERR T-Digest: error setting value");
+    }
+    RedisModule_CloseKey(key);
+    RedisModule_ReplicateVerbatim(ctx);
+    RedisModule_ReplyWithSimpleString(ctx, "OK");
+    return REDISMODULE_OK;
 }
 
 /**
@@ -875,19 +1133,38 @@ void *TDigestRdbLoad(RedisModuleIO *rdb, int encver) {
     /* Load the network layout. */
     bool err = false;
     const double compression = LoadDouble_IOError(rdb, err, NULL);
+    // Reject before allocating: an unvalidated compression can make td_new() return
+    // NULL (huge/negative value) or allocate an attacker-chosen size independent of
+    // the rest of this session's command-level bounds.
+    if (!isfinite(compression) || compression <= 0.0 || compression > (double)TD_MAX_COMPRESSION) {
+        return NULL;
+    }
     td_histogram_t *tdigest = td_new(compression);
+    if (!tdigest) {
+        return NULL;
+    }
     errdefer(err, td_free(tdigest));
     tdigest->min = LoadDouble_IOError(rdb, err, NULL);
     tdigest->max = LoadDouble_IOError(rdb, err, NULL);
 
-    // cap is the total size of nodes
-    tdigest->cap = LoadSigned_IOError(rdb, err, NULL);
+    // cap is fully determined by compression (see cap_from_compression() in the
+    // t-digest lib, which td_new() already applied above). It is only present on
+    // the wire for format continuity, so it must match exactly: accepting a wire
+    // value that disagrees with the real allocation is what let a crafted
+    // RESTORE/RDB payload decouple cap/merged_nodes/unmerged_nodes from the
+    // actual nodes_mean/nodes_weight buffer sizes and drive an out-of-bounds
+    // read/write on every subsequent command touching the key.
+    const int64_t wire_cap = LoadSigned_IOError(rdb, err, NULL);
+    if (wire_cap != (int64_t)tdigest->cap) {
+        err = true;
+        return NULL;
+    }
 
     // merged_nodes is the number of merged nodes at the front of nodes.
-    tdigest->merged_nodes = LoadSigned_IOError(rdb, err, NULL);
+    const int64_t merged_nodes = LoadSigned_IOError(rdb, err, NULL);
 
     // unmerged_nodes is the number of buffered nodes.
-    tdigest->unmerged_nodes = LoadSigned_IOError(rdb, err, NULL);
+    const int64_t unmerged_nodes = LoadSigned_IOError(rdb, err, NULL);
 
     // we run the merge in reverse every other merge to avoid left-to-right bias in merging
     tdigest->total_compressions = LoadSigned_IOError(rdb, err, NULL);
@@ -895,10 +1172,12 @@ void *TDigestRdbLoad(RedisModuleIO *rdb, int encver) {
     tdigest->merged_weight = LoadDouble_IOError(rdb, err, NULL);
     tdigest->unmerged_weight = LoadDouble_IOError(rdb, err, NULL);
 
-    if (tdigest->merged_nodes < 0 || tdigest->merged_nodes > tdigest->cap) {
+    if (merged_nodes < 0 || unmerged_nodes < 0 || merged_nodes + unmerged_nodes > tdigest->cap) {
         err = true;
         return NULL;
     }
+    tdigest->merged_nodes = (int)merged_nodes;
+    tdigest->unmerged_nodes = (int)unmerged_nodes;
 
     for (size_t i = 0; i < tdigest->merged_nodes; i++) {
         tdigest->nodes_mean[i] = LoadDouble_IOError(rdb, err, NULL);
@@ -954,6 +1233,7 @@ int TDigestModule_onLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     RegisterCommand(ctx, "tdigest.add", TDigestSketch_Add, "write deny-oom", "write");
     RegisterCommand(ctx, "tdigest.reset", TDigestSketch_Reset, "write deny-oom", "write fast");
     RegisterCommand(ctx, "tdigest.merge", TDigestSketch_Merge, "write deny-oom", "write");
+    RegisterCommand(ctx, "tdigest.externalmerge", TDigestSketch_ExternalMerge, "write deny-oom", "write");
     RegisterCommand(ctx, "tdigest.min", TDigestSketch_Min, "readonly", "read fast");
     RegisterCommand(ctx, "tdigest.max", TDigestSketch_Max, "readonly", "read fast");
     RegisterCommand(ctx, "tdigest.quantile", TDigestSketch_Quantile, "readonly", "read fast");

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -5,6 +5,8 @@ import numpy as np
 import redis
 import math
 import random
+import struct
+import zlib
 from random import randint
 
 
@@ -15,6 +17,22 @@ def parse_tdigest_info(array_reply):
         property_value = array_reply[pos + 1]
         reply_dict[property_name] = property_value
     return reply_dict
+
+
+# Build a TDIGEST.EXTERNALMERGE v1 ("TDB1") payload.
+# Mirrors the layout documented in src/rm_tdigest.c. `centroids` is a list of
+# (mean: float, weight: int) pairs, sorted ascending by mean.
+def build_externalmerge(centroids, compression=100.0,
+                    magic=b"TDB1", version=1,
+                    override_num=None, override_crc=None):
+    n = len(centroids) if override_num is None else override_num
+    body = magic + bytes([version]) + struct.pack("<dI", compression, n)
+    for m, _ in centroids:
+        body += struct.pack("<d", m)
+    for _, w in centroids:
+        body += struct.pack("<q", w)
+    crc = zlib.crc32(body) & 0xFFFFFFFF if override_crc is None else override_crc
+    return body + struct.pack("<I", crc)
 
 
 class testTDigest:
@@ -89,6 +107,34 @@ class testTDigest:
         self.assertRaises(
            redis.exceptions.ResponseError, self.cmd, "tdigest.create", "tdigest", "compression", '100000000000000000000'
         )
+
+    def test_tdigest_create_compression_max_bound(self):
+        # TD_MAX_COMPRESSION (src/rm_tdigest.c) bounds CREATE/MERGE's
+        # COMPRESSION keyword the same way EXTERNALMERGE bounds its blob's
+        # declared compression, so no single command can force an
+        # arbitrarily large node-array allocation.
+        self.cmd('FLUSHALL')
+        max_centroids = 100000
+        max_compression = (max_centroids - 10) // 6
+
+        self.assertOk(self.cmd("tdigest.create", "atmax", "compression", max_compression))
+        info = parse_tdigest_info(self.cmd("tdigest.info", "atmax"))
+        self.assertEqual(max_compression, info["Compression"])
+        self.assertEqual(max_centroids, info["Capacity"])
+
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.create", "over",
+            "compression", max_compression + 1
+        )
+        self.assertEqual(0, self.cmd("EXISTS", "over"))
+
+        # Same bound applies to MERGE's explicit COMPRESSION keyword.
+        self.assertOk(self.cmd("tdigest.create", "src", "compression", 100))
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.merge", "dst", 1, "src",
+            "compression", max_compression + 1
+        )
+        self.assertEqual(0, self.cmd("EXISTS", "dst"))
 
     def test_tdigest_reset(self):
         self.cmd('FLUSHALL')
@@ -964,13 +1010,297 @@ class testTDigest:
         self.assertEqual(tdigest_min, self.cmd("tdigest.min", "tdigest"))
         self.assertEqual(tdigest_max, self.cmd("tdigest.max", "tdigest"))
 
+    def test_tdigest_externalmerge_happy_path(self):
+        self.cmd("FLUSHALL")
+        # Sorted, finite means; positive int64 weights.
+        centroids = [(1.0, 5), (2.5, 10), (3.7, 2), (10.0, 1)]
+        blob = build_externalmerge(centroids, compression=100.0)
+        # Create-if-missing: target key does not exist yet.
+        self.assertOk(self.cmd("tdigest.externalmerge", "dst", blob))
+        info = parse_tdigest_info(self.cmd("tdigest.info", "dst"))
+        total_weight = float(info["Merged weight"]) + float(info["Unmerged weight"])
+        self.assertEqual(sum(w for _, w in centroids), total_weight)
+
+        # A second merge accumulates rather than replaces.
+        self.assertOk(self.cmd("tdigest.externalmerge", "dst", blob))
+        info = parse_tdigest_info(self.cmd("tdigest.info", "dst"))
+        total_weight2 = float(info["Merged weight"]) + float(info["Unmerged weight"])
+        self.assertEqual(2 * sum(w for _, w in centroids), total_weight2)
+
+    def test_tdigest_externalmerge_compression_on_create_vs_existing(self):
+        # Creating a new key: the blob's declared compression governs, so a
+        # high-fidelity client-side digest isn't silently downsampled to the
+        # module default on its first flush.
+        self.cmd("FLUSHALL")
+        blob = build_externalmerge([(1.0, 1), (2.0, 1)], compression=250.0)
+        self.assertOk(self.cmd("tdigest.externalmerge", "dst", blob))
+        info = parse_tdigest_info(self.cmd("tdigest.info", "dst"))
+        self.assertEqual(250, info["Compression"])
+
+        # Merging into an existing key: the key's own compression governs,
+        # and the blob's compression field is ignored (same rule as MERGE).
+        self.assertOk(self.cmd("tdigest.create", "existing", "compression", 100))
+        blob2 = build_externalmerge([(1.0, 1), (2.0, 1)], compression=999.0)
+        self.assertOk(self.cmd("tdigest.externalmerge", "existing", blob2))
+        info2 = parse_tdigest_info(self.cmd("tdigest.info", "existing"))
+        self.assertEqual(100, info2["Compression"])
+
+    def test_tdigest_externalmerge_max_compression_bound(self):
+        # EXTERNALMERGE_MAX_COMPRESSION is derived so that the resulting
+        # digest's internal capacity (6*compression+10) never exceeds
+        # EXTERNALMERGE_MAX_CENTROIDS, matching the bound already applied to
+        # the blob's own centroid count.
+        self.cmd("FLUSHALL")
+        # Mirrors TD_MAX_CENTROIDS / TD_MAX_COMPRESSION in src/rm_tdigest.c,
+        # shared by TDIGEST.CREATE, TDIGEST.MERGE, and TDIGEST.EXTERNALMERGE.
+        max_centroids = 100000
+        max_compression = (max_centroids - 10) // 6
+
+        # Exactly at the cap: accepted, and the resulting capacity matches.
+        at_max = build_externalmerge([(1.0, 1), (2.0, 1)], compression=float(max_compression))
+        self.assertOk(self.cmd("tdigest.externalmerge", "atmax", at_max))
+        info = parse_tdigest_info(self.cmd("tdigest.info", "atmax"))
+        self.assertEqual(max_compression, info["Compression"])
+        self.assertEqual(max_centroids, info["Capacity"])
+
+        # One over the cap: rejected, no key created.
+        over = build_externalmerge([(1.0, 1), (2.0, 1)], compression=float(max_compression + 1))
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.externalmerge", "over", over
+        )
+        self.assertEqual(0, self.cmd("EXISTS", "over"))
+
+        # A tiny blob declaring an absurd compression must not be able to
+        # force a huge allocation for a brand-new key.
+        huge = build_externalmerge([(1.0, 1), (2.0, 1)], compression=1e8)
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.externalmerge", "huge", huge
+        )
+        self.assertEqual(0, self.cmd("EXISTS", "huge"))
+
+    def test_tdigest_externalmerge_overflow_leaves_no_partial_state(self):
+        # Two centroids whose weights overflow the running int64 weight
+        # accumulator on the second `td_add`. A rejected blob must fail
+        # atomically: no partially-merged digest, and no orphaned key.
+        self.cmd("FLUSHALL")
+        int64_max = 2**63 - 1
+        bad = build_externalmerge([(1.0, int64_max), (2.0, 1)])
+
+        # Destination key does not exist yet: it must not be created either.
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.externalmerge", "fresh", bad
+        )
+        self.assertEqual(0, self.cmd("EXISTS", "fresh"))
+
+        # Destination key already has data: a failed merge must not mutate it.
+        good = build_externalmerge([(5.0, 3), (6.0, 4)], compression=100.0)
+        self.assertOk(self.cmd("tdigest.externalmerge", "existing", good))
+        info_before = parse_tdigest_info(self.cmd("tdigest.info", "existing"))
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.externalmerge", "existing", bad
+        )
+        info_after = parse_tdigest_info(self.cmd("tdigest.info", "existing"))
+        self.assertEqual(info_before, info_after)
+
+    def test_tdigest_externalmerge_equivalence_to_add(self):
+        # Building a digest from centroids via EXTERNALMERGE should give the same
+        # quantile estimates as inserting weighted samples via TDIGEST.ADD.
+        self.cmd("FLUSHALL")
+        centroids = [(float(x), 100) for x in range(1, 101)]
+        blob = build_externalmerge(centroids, compression=100.0)
+        self.assertOk(self.cmd("tdigest.create", "via_add", "compression", 100))
+        for m, w in centroids:
+            # ADD has no weight knob, so simulate by adding w copies.
+            for _ in range(w):
+                self.cmd("tdigest.add", "via_add", m)
+        self.assertOk(self.cmd("tdigest.externalmerge", "via_blob", blob))
+        for q in (0.1, 0.5, 0.9):
+            a = float(self.cmd("tdigest.quantile", "via_add", q)[0])
+            b = float(self.cmd("tdigest.quantile", "via_blob", q)[0])
+            self.assertAlmostEqual(a, b, 1.0)
+
+    def test_tdigest_externalmerge_wrongtype(self):
+        self.cmd("FLUSHALL")
+        self.cmd("SET", "strkey", "B")
+        blob = build_externalmerge([(1.0, 1)])
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.externalmerge", "strkey", blob
+        )
+
+    def test_tdigest_externalmerge_arity(self):
+        self.cmd("FLUSHALL")
+        self.assertRaises(redis.exceptions.ResponseError, self.cmd, "tdigest.externalmerge")
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, "tdigest.externalmerge", "k"
+        )
+
+    def test_tdigest_externalmerge_rejects_malformed(self):
+        # Every rejection branch in _ExternalMerge_Parse, exercised individually.
+        self.cmd("FLUSHALL")
+        good = [(1.0, 1), (2.0, 2)]
+
+        # Too short.
+        self.env.expect("tdigest.externalmerge", "k", b"\x00" * 8).error()
+
+        # Bad magic.
+        bad = build_externalmerge(good, magic=b"XXXX")
+        self.env.expect("tdigest.externalmerge", "k", bad).error()
+
+        # Bad version.
+        bad = build_externalmerge(good, version=99)
+        self.env.expect("tdigest.externalmerge", "k", bad).error()
+
+        # num_centroids field claims more than the blob actually contains.
+        bad = build_externalmerge(good, override_num=len(good) + 7)
+        self.env.expect("tdigest.externalmerge", "k", bad).error()
+
+        # num_centroids over the cap (we only need the field set; total length
+        # is checked before the cap so build a header-only blob that claims a
+        # huge N — but the cap-check runs first, so length doesn't matter here).
+        header = b"TDB1" + bytes([1]) + struct.pack("<dI", 100.0, (1 << 21))
+        bad = header + b"\x00" * 4
+        self.env.expect("tdigest.externalmerge", "k", bad).error()
+
+        # Invalid compression (NaN).
+        bad = build_externalmerge(good, compression=float("nan"))
+        self.env.expect("tdigest.externalmerge", "k", bad).error()
+
+        # Invalid compression (non-positive).
+        bad = build_externalmerge(good, compression=-1.0)
+        self.env.expect("tdigest.externalmerge", "k", bad).error()
+
+        # Compression too large: a tiny blob must not be able to force a huge
+        # allocation for a brand-new key via an absurd declared compression.
+        bad = build_externalmerge(good, compression=100000000.0)
+        self.env.expect("tdigest.externalmerge", "k", bad).error()
+
+        # Non-finite mean.
+        bad = build_externalmerge([(float("inf"), 1)])
+        self.env.expect("tdigest.externalmerge", "k", bad).error()
+
+        # Non-positive weight.
+        bad = build_externalmerge([(1.0, 0)])
+        self.env.expect("tdigest.externalmerge", "k", bad).error()
+
+        # Unsorted means.
+        bad = build_externalmerge([(2.0, 1), (1.0, 1)])
+        self.env.expect("tdigest.externalmerge", "k", bad).error()
+
+        # CRC mismatch.
+        bad = build_externalmerge(good, override_crc=0xDEADBEEF)
+        self.env.expect("tdigest.externalmerge", "k", bad).error()
+
+        # None of the rejections should have left a key behind.
+        self.assertEqual(0, self.cmd("EXISTS", "k"))
+
+    def test_tdigest_externalmerge_persistence(self):
+        # EXTERNALMERGE-built digest should survive SAVE/restart like any other.
+        self.cmd("FLUSHALL")
+        blob = build_externalmerge([(float(x), 1) for x in range(1, 51)], compression=100.0)
+        self.assertOk(self.cmd("tdigest.externalmerge", "dst", blob))
+        weight_before = float(
+            parse_tdigest_info(self.cmd("tdigest.info", "dst"))["Merged weight"]
+        ) + float(
+            parse_tdigest_info(self.cmd("tdigest.info", "dst"))["Unmerged weight"]
+        )
+        self.assertEqual(True, self.cmd("SAVE"))
+        self.restart_and_reload()
+        self.assertEqual(1, self.cmd("EXISTS", "dst"))
+        weight_after = float(
+            parse_tdigest_info(self.cmd("tdigest.info", "dst"))["Merged weight"]
+        ) + float(
+            parse_tdigest_info(self.cmd("tdigest.info", "dst"))["Unmerged weight"]
+        )
+        self.assertEqual(weight_before, weight_after)
+
     def test_insufficient_memory(self):
         if os.environ.get('SANITIZER') != None:
             self.env.skip()
         self.cmd("FLUSHALL")
-        self.env.expect('tdigest.create', 'k', 'compression', 100000000000000000).error().contains('allocation failed')
+        # Absurdly large compression is now rejected proactively (bounded by
+        # TD_MAX_COMPRESSION) rather than relying on the allocator to fail.
+        self.env.expect('tdigest.create', 'k', 'compression', 100000000000000000).error().contains('exceeds maximum allowed')
 
     def test_rdb_load_oob_guard(self):
         self.cmd('FLUSHALL')
         rdb_payload = b'\x07\x81L2\x12\xf96\x0f\x10\x00\x04\x00\x00\x00\x00\x00\x00(@\x04\x00\x00\x00\x00\x00\x00\xf0?\x04\x00\x00\x00\x00\x00\x00\xf0?\x02\x01\x02@a\x02\x01\x02\x01\x04\x00\x00\x00\x00\x00\x00\xf0?\x04\x00\x00\x00\x00\x00\x00\xf0?\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04CCCCCCCC\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x04AAAAAAAA\x00\xff\x0c\x008\x9c\x969\x91:\xcc5'
         self.env.expect('RESTORE', "key", 0, rdb_payload, 'REPLACE').error().contains('Bad data format')
+
+    def test_rdb_load_cap_compression_consistency(self):
+        # TDigestRdbLoad used to trust `cap`/`merged_nodes`/`unmerged_nodes` from
+        # the wire as-is, decoupled from the buffer sizes td_new(compression)
+        # actually allocates. A crafted RESTORE payload declaring a small
+        # compression (small real buffer) but a large `cap` field passed the old
+        # bounds check (merged_nodes <= cap) while writing far past the real
+        # allocation on subsequent ADDs -- a heap buffer overflow that crashed
+        # the server. Loading must now derive cap from compression and reject
+        # any payload where the two disagree, or where compression itself is
+        # out of bounds.
+        self.cmd('FLUSHALL')
+
+        def crc64_jones(data):
+            poly = 0xad93d23594c935a9
+            rpoly = int(f'{poly:064b}'[::-1], 2)
+            crc = 0
+            for byte in data:
+                crc ^= byte
+                for _ in range(8):
+                    crc = (crc >> 1) ^ rpoly if crc & 1 else crc >> 1
+            return crc & 0xFFFFFFFFFFFFFFFF
+
+        def tamper(dump_bytes, cap_offset=None, fake_cap=None, compression_offset=None,
+                   fake_compression=None):
+            buf = bytearray(dump_bytes)
+            if fake_cap is not None:
+                buf[cap_offset] = 0x40 | (fake_cap >> 8)
+                buf[cap_offset + 1] = fake_cap & 0xFF
+            if fake_compression is not None:
+                buf[compression_offset:compression_offset + 8] = struct.pack('<d', fake_compression)
+            body = bytes(buf[:-8])
+            buf[-8:] = struct.pack('<Q', crc64_jones(body))
+            return bytes(buf)
+
+        # Layout for a freshly-created (empty) tdigest DUMP: 10-byte module
+        # header, opcode+8-byte-double compression at [10:19], min/max doubles,
+        # then opcode+14bit-length cap at [37:40].
+        self.assertOk(self.cmd('tdigest.create', 'src', 'compression', 10))
+        dump = self.cmd('DUMP', 'src')
+
+        # Sanity: the offsets above actually point at compression/cap on this
+        # build's RDB encoding, not unrelated bytes.
+        (orig_compression,) = struct.unpack('<d', dump[11:19])
+        self.assertEqual(10.0, orig_compression)
+        self.assertEqual(70, dump[39])  # cap = 6*10+10 = 70, fits in the low byte
+
+        # cap inflated far past the real 70-element buffer.
+        evil_cap = tamper(dump, cap_offset=38, fake_cap=10000)
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, 'RESTORE', 'evil_cap', 0, evil_cap
+        )
+
+        # compression beyond TD_MAX_COMPRESSION.
+        evil_compression = tamper(dump, compression_offset=11, fake_compression=1e9)
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, 'RESTORE', 'evil_compression', 0,
+            evil_compression
+        )
+
+        # negative compression.
+        evil_negative = tamper(dump, compression_offset=11, fake_compression=-5.0)
+        self.assertRaises(
+            redis.exceptions.ResponseError, self.cmd, 'RESTORE', 'evil_negative', 0, evil_negative
+        )
+
+        # Server must still be alive and the untampered key usable.
+        self.assertOk(self.cmd('tdigest.add', 'src', 1.0))
+        self.assertEqual(0, self.cmd('EXISTS', 'evil_cap'))
+        self.assertEqual(0, self.cmd('EXISTS', 'evil_compression'))
+        self.assertEqual(0, self.cmd('EXISTS', 'evil_negative'))
+
+        # An untampered DUMP must still RESTORE correctly.
+        self.cmd('DEL', 'src2')
+        clean_dump = tamper(dump)  # re-checksum only, no field changes
+        self.assertOk(self.cmd('RESTORE', 'src2', 0, clean_dump))
+        info = parse_tdigest_info(self.cmd('tdigest.info', 'src2'))
+        self.assertEqual(10, info['Compression'])
+        self.assertEqual(70, info['Capacity'])


### PR DESCRIPTION
A new feature that allows user to send an external tdigest made outside redis , to be merged with an existing redis in tdigest

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches memory sizing, untrusted binary input (EXTERNALMERGE blobs), and RDB/RESTORE loading where prior bugs could cause server crashes; behavior changes include rejecting oversized compression and mismatched RDB cap fields.
> 
> **Overview**
> Adds **`TDIGEST.EXTERNALMERGE {key} {blob}`** so client-built t-digests in the **TDB1** wire format (magic, compression, sorted centroids with weights, CRC32) can be merged into a Redis key—creating the key from the blob’s compression when missing, or keeping the existing key’s compression when it already exists. Merges run in a scratch digest and only commit on success so bad blobs never leave partial state.
> 
> Introduces shared **`TD_MAX_COMPRESSION` / `TD_MAX_CENTROIDS`** limits on **`TDIGEST.CREATE`**, **`TDIGEST.MERGE`**, and blob parsing so huge node-array allocations cannot be forced via compression alone.
> 
> **`TDigestRdbLoad`** now rejects out-of-range compression before allocation, requires the on-wire **`cap`** to match what compression actually allocates, and bounds **`merged_nodes` + `unmerged_nodes`** against that cap—closing a crafted **RESTORE**/RDB heap overflow path. Flow tests cover external merge behavior, malformed blobs, and tampered dumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 710128c08145abb770f3416d9f222e5236849926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->