### PR TITLE
MOD-16871: replicate in `cfInsertCommon` after `cfCreate` in case of errors

### DIFF
--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -664,6 +664,7 @@ static int cfInsertCommon(RedisModuleCtx *ctx, RedisModuleString *keystr, RedisM
             }
             return REDISMODULE_OK;
         }
+        RedisModule_ReplicateVerbatim(ctx);
     } else if (status != SB_OK) {
         return RedisModule_ReplyWithError(ctx, statusStrerror(status));
     }

--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -651,6 +651,7 @@ static int cfInsertCommon(RedisModuleCtx *ctx, RedisModuleString *keystr, RedisM
     RedisModuleKey *key = RedisModule_OpenKey(ctx, keystr, REDISMODULE_READ | REDISMODULE_WRITE);
     CuckooFilter *cf = NULL;
     int status = cfGetFilter(key, &cf);
+    bool autocreated = false;
 
     if (status == SB_EMPTY && options->autocreate) {
         int err = CUCKOO_OK;
@@ -664,7 +665,7 @@ static int cfInsertCommon(RedisModuleCtx *ctx, RedisModuleString *keystr, RedisM
             }
             return REDISMODULE_OK;
         }
-        RedisModule_ReplicateVerbatim(ctx);
+        autocreated = true;
     } else if (status != SB_OK) {
         return RedisModule_ReplyWithError(ctx, statusStrerror(status));
     }
@@ -673,6 +674,12 @@ static int cfInsertCommon(RedisModuleCtx *ctx, RedisModuleString *keystr, RedisM
         // Ensure that adding new elements does not cause heavy expansion.
         // We might want to find a way to better distinguish legitimate from malicious
         // additions.
+        // The autocreate above is a real keyspace mutation; replicate it even though
+        // this guard stops us short of the ReplicateVerbatim() call at the end of
+        // this function.
+        if (autocreated) {
+            RedisModule_ReplicateVerbatim(ctx);
+        }
         return RedisModule_ReplyWithError(ctx, "Maximum expansions reached");
     }
 
@@ -712,6 +719,9 @@ static int cfInsertCommon(RedisModuleCtx *ctx, RedisModuleString *keystr, RedisM
             break;
         case CuckooInsert_NoSpace:
             if (!options->is_multi) {
+                if (autocreated) {
+                    RedisModule_ReplicateVerbatim(ctx);
+                }
                 return RedisModule_ReplyWithError(ctx, "Filter is full");
             } else {
                 if (_is_resp3(ctx) && !options->is_nx) {
@@ -725,6 +735,9 @@ static int cfInsertCommon(RedisModuleCtx *ctx, RedisModuleString *keystr, RedisM
             break;
         case CuckooInsert_MemAllocFailed:
             if (!options->is_multi) {
+                if (autocreated) {
+                    RedisModule_ReplicateVerbatim(ctx);
+                }
                 return RedisModule_ReplyWithError(ctx, "ERR Insufficient memory");
             } else {
                 if (_is_resp3(ctx) && !options->is_nx) {

--- a/tests/flow/test_cuckoo.py
+++ b/tests/flow/test_cuckoo.py
@@ -745,3 +745,52 @@ def test_cf_loadchunk_replicates_to_replica():
                if slave.execute_command('CF.EXISTS', 'cf', 'item%d' % i) != 1]
     env.assertEqual(missing, [],
                     message='%d/%d items missing on replica after CF.LOADCHUNK' % (len(missing), n))
+
+
+def test_cf_add_autocreate_expansion_limit_replicates_to_replica():
+    # cfInsertCommon() autocreates the filter (RedisModule_ModuleTypeSetValue,
+    # a real keyspace mutation) *before* it checks cf->numFilters against
+    # cf-max-expansions. When that guard trips on a brand-new key, the
+    # function returns an error without ever reaching the single
+    # RedisModule_ReplicateVerbatim() call at the end of cfInsertCommon. So a
+    # CF.ADD that both creates the key and immediately hits the expansion
+    # limit is never replicated, even though the key now exists on the
+    # master. Master and replica must never disagree on whether a key exists.
+    # freshEnv=True forces a dedicated master+replica env, so this test is not
+    # affected by env reuse from preceding (non-replicated) tests.
+    env = Env(useSlaves=True, decodeResponses=True, freshEnv=True)
+    if env.isCluster():
+        env.skip()
+
+    master = env.getConnection()
+    slave = env.getSlaveConnection()
+
+    # A freshly created cuckoo filter has numFilters == 1 (CuckooFilter_Init
+    # grows once), so cf-max-expansions=1 makes the very first insert into a
+    # new key trip the "Maximum expansions reached" guard.
+    master.execute_command('CONFIG', 'SET', 'cf-max-expansions', '1')
+
+    # 'newkey' does not exist yet; CF.ADD's autocreate path should create it
+    # and then immediately fail the expansion-limit check.
+    env.assertFalse(master.execute_command('EXISTS', 'newkey'))
+    with env.assertResponseError(contained='Maximum expansions reached'):
+        master.execute_command('CF.ADD', 'newkey', 'x')
+
+    existsOnMaster = bool(master.execute_command('EXISTS', 'newkey'))
+
+    # The replica must be caught up to the master's replication offset. Poll
+    # WAIT to tolerate the replica still connecting/doing its initial sync.
+    acked = 0
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        acked = master.execute_command('WAIT', 1, 1000)
+        if acked >= 1:
+            break
+    env.assertEqual(acked, 1)
+
+    existsOnSlave = bool(slave.execute_command('EXISTS', 'newkey'))
+
+    # Master and replica must agree on whether 'newkey' exists.
+    env.assertEqual(existsOnMaster, existsOnSlave,
+                    message='newkey existence diverged: master=%s replica=%s' %
+                            (existsOnMaster, existsOnSlave))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches replication for write paths on autocreate + error; scope is narrow but incorrect replication can cause failover/key-existence bugs.
> 
> **Overview**
> **Fixes master/replica divergence** when `CF.ADD` / `CF.INSERT` autocreates a cuckoo filter and then errors before the normal end-of-command replication.
> 
> `cfInsertCommon` can call `cfCreate` (a real keyspace write) and still return early on **Maximum expansions reached**, **Filter is full**, or **Insufficient memory** without reaching the single `RedisModule_ReplicateVerbatim()` at the bottom. The change tracks whether the filter was **autocreated** and calls **`RedisModule_ReplicateVerbatim`** on those early exits so replicas see the same key existence as the master.
> 
> Adds **`test_cf_add_autocreate_expansion_limit_replicates_to_replica`**: `cf-max-expansions=1`, `CF.ADD` on a new key, assert master and replica agree on `EXISTS` after replication catches up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a90e67faf0364ae93d03226f97692a89738e7d52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->