### PR TITLE
Fix TDIGEST returning nan for a sketch with a single observation

### DIFF
--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -227,7 +227,7 @@ jobs:
             bash -c "git config --global --add safe.directory /workspace && make pack BRANCH=${{ env.TAG_OR_BRANCH }} SHOW=1"
 
       - name: Upload artifacts to S3
-        if: ${{ !inputs.run_valgrind && !inputs.run_sanitizer }}
+        if: ${{ !inputs.run_valgrind && !inputs.run_sanitizer && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
         env:
           BETA_VERSION: ${{ inputs.beta-version }}
         run: |

--- a/.github/workflows/flow-macos.yml
+++ b/.github/workflows/flow-macos.yml
@@ -169,6 +169,7 @@ jobs:
           use-venv: '1'
           beta-version: ${{ inputs.beta-version }}
       - name: Upload artifacts to S3
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -533,6 +533,24 @@ class testTDigest:
                 expected[i], float(res[i]), 0.01
             )
 
+    def test_tdigest_single_observation(self):
+        # https://github.com/RedisBloom/RedisBloom/issues/870
+        # a sketch holding a single observation replied nan to
+        # TDIGEST.QUANTILE, TDIGEST.CDF and TDIGEST.TRIMMED_MEAN
+        self.cmd('FLUSHALL')
+        self.assertOk(self.cmd("tdigest.create", "tdigest"))
+        self.assertOk(self.cmd("tdigest.add", "tdigest", 123))
+        for q in ["0", "0.5", "0.9", "1"]:
+            self.assertEqual(
+                123.0, float(self.cmd("tdigest.quantile", "tdigest", q)[0])
+            )
+        self.assertEqual(0.0, float(self.cmd("tdigest.cdf", "tdigest", 100)[0]))
+        self.assertEqual(0.5, float(self.cmd("tdigest.cdf", "tdigest", 123)[0]))
+        self.assertEqual(1.0, float(self.cmd("tdigest.cdf", "tdigest", 200)[0]))
+        self.assertEqual(
+            123.0, float(self.cmd("tdigest.trimmed_mean", "tdigest", 0.1, 0.9))
+        )
+
     def test_negative_tdigest_quantile(self):
         self.cmd('FLUSHALL')
         self.cmd("SET", "tdigest", "B")


### PR DESCRIPTION
Fixes #870

## Problem

A t-digest sketch holding exactly one weight-1 observation replies `nan` on every query command:

```
> TDIGEST.CREATE foo
OK
> TDIGEST.ADD foo 123
OK
> TDIGEST.QUANTILE foo 0.9
1) "nan"
```

`TDIGEST.CDF` and `TDIGEST.TRIMMED_MEAN` are affected the same way. The behavior is inconsistent rather than intentional: adding the same value twice, or a single observation with weight 2, returns the correct result — only the single weight-1 sample case fails.

## Root cause

In `deps/t-digest-c`, `td_compress()` has an early return `if (total_weight <= 1)` (introduced upstream in `43fe4be` to guard the `log(total_weight)` denominator against division by zero). It returns before promoting the unmerged node to a merged centroid, so `merged_nodes` stays 0 and every query path takes its "empty histogram → nan" branch. The library's dedicated single-centroid handling in `td_quantile`/`td_quantiles` ("with one data point, all quantiles lead to Rome") was unreachable for this case.

This was fixed upstream in RedisBloom/t-digest-c@50edef3 (MOD-13821), but the submodule here is still pinned one commit behind (`5b89d70`), so the module still ships the bug.

## Fix

- Bump the `deps/t-digest-c` submodule from `5b89d70` to `50edef3` (single-commit bump; the only change is the `td_compress` fix).
- Add a flow regression test (`test_tdigest_single_observation`) covering `TDIGEST.QUANTILE`, `TDIGEST.CDF`, and `TDIGEST.TRIMMED_MEAN` on a single-observation sketch, since the upstream fix landed without test coverage.

## Testing

Built the module and ran the full tdigest flow suite locally (macOS arm64, Redis 8):

```
Total Tests Run: 35, Total Tests Failed: 0, Total Tests Passed: 35
```

Verified the exact repro from #870 now returns the observation value:

```
> TDIGEST.QUANTILE foo 0 0.5 0.9 1   →  123 123 123 123
> TDIGEST.CDF foo 100 123 200        →  0  0.5  1
> TDIGEST.TRIMMED_MEAN foo 0.1 0.9   →  123
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to the edge case of one observation in t-digest queries; CI change only gates S3 uploads on fork PRs.
> 
> **Overview**
> Fixes **TDIGEST** returning `nan` when a sketch has exactly one weight-1 observation (issue #870), by picking up the upstream **`deps/t-digest-c`** fix where `td_compress()` no longer bails out before promoting that lone point into a merged centroid.
> 
> Adds flow regression **`test_tdigest_single_observation`**, asserting **`TDIGEST.QUANTILE`**, **`TDIGEST.CDF`**, and **`TDIGEST.TRIMMED_MEAN`** all return sensible values for a single added value.
> 
> **CI:** Linux and macOS flow workflows now **skip S3 artifact upload** on pull requests from forks (`github.event.pull_request.head.repo.fork`), so untrusted PRs do not run steps that use AWS credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b522bfe0068ac8c5b65878f196c45a6f4890a4be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->