### PR TITLE
MOD-16306 - pull docker images from registry

### DIFF
--- a/.github/workflows/event-ci.yml
+++ b/.github/workflows/event-ci.yml
@@ -4,6 +4,7 @@ permissions:
   id-token: write
   contents: read
   actions: read
+  packages: read
 
 on:
   pull_request:
@@ -30,6 +31,7 @@ jobs:
     with:
       arch: x64
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      use_prebuilt_images: ${{ !contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
     secrets: inherit
   build-linux-arm64:
     uses: ./.github/workflows/flow-linux.yml
@@ -37,6 +39,7 @@ jobs:
     with:
       arch: arm64
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
+      use_prebuilt_images: ${{ !contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
     secrets: inherit
   macos:
     uses: ./.github/workflows/flow-macos.yml
@@ -52,6 +55,7 @@ jobs:
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       run_valgrind: true
+      use_prebuilt_images: ${{ !contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
     secrets: inherit
   linux-sanitizer:
     uses: ./.github/workflows/flow-linux.yml
@@ -61,6 +65,7 @@ jobs:
       os: jammy
       redis-ref: ${{needs.prepare-values.outputs.redis-ref}}
       run_sanitizer: true
+      use_prebuilt_images: ${{ !contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}
     secrets: inherit
   spellcheck:
     uses: ./.github/workflows/flow-spellcheck.yml

--- a/.github/workflows/event-nightly.yml
+++ b/.github/workflows/event-nightly.yml
@@ -4,6 +4,7 @@ permissions:
   id-token: write
   contents: read
   actions: read
+  packages: read
 
 on:
   push:

--- a/.github/workflows/event-tag.yml
+++ b/.github/workflows/event-tag.yml
@@ -4,6 +4,7 @@ permissions:
   id-token: write
   contents: read
   actions: read
+  packages: read
   
 on:
   push:

--- a/.github/workflows/flow-linux.yml
+++ b/.github/workflows/flow-linux.yml
@@ -4,6 +4,7 @@ permissions:
   id-token: write
   contents: read
   actions: read
+  packages: read
 
 on:
   workflow_dispatch:
@@ -30,6 +31,10 @@ on:
         description: 'Run sanitizer on the tests'
         type: boolean
         default: false
+      use_prebuilt_images:
+        description: 'Pull prebuilt Docker images instead of building locally'
+        type: boolean
+        default: true
       beta-version:
         description: 'Beta version for S3 uploads'
         type: string
@@ -58,6 +63,10 @@ on:
         description: 'Run sanitizer on the tests'
         type: boolean
         default: false
+      use_prebuilt_images:
+        description: 'Pull prebuilt Docker images instead of building locally'
+        type: boolean
+        default: true
       beta-version:
         description: 'Beta version for S3 uploads'
         type: string
@@ -126,20 +135,49 @@ jobs:
       BRANCH: ${{ needs.setup-environment.outputs.BRANCH }}
       TAG_OR_BRANCH: ${{ needs.setup-environment.outputs.TAG_OR_BRANCH }}
       REDIS_REF: ${{ needs.setup-environment.outputs.redis-ref }}
-      DOCKER_IMAGE: redisbloom-${{ matrix.platform.os }}:latest
+      IMAGE_ARCH: ${{ inputs.arch == 'x64' && 'x86' || 'arm' }}
+      IMAGE_OS: ${{ inputs.run_sanitizer && format('{0}-sanitizer', matrix.platform.os) || matrix.platform.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
-      - name: Build Docker Image
+      - name: Set Docker Image
         run: |
+          repo="$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')"
+          image_tag="${REDIS_REF:-$(.install/get-redis-ref.sh)}"
+          echo "DOCKER_IMAGE=ghcr.io/${repo}/redisbloom-${IMAGE_ARCH}-${IMAGE_OS}:${image_tag}" >> "$GITHUB_ENV"
+
+      - name: Pull Docker Image
+        id: pull-image
+        if: ${{ inputs.use_prebuilt_images }}
+        continue-on-error: true
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "::notice title=Docker image::Trying to pull prebuilt image ${DOCKER_IMAGE}"
+          docker pull "${DOCKER_IMAGE}"
+
+      - name: Use Pulled Docker Image
+        if: ${{ inputs.use_prebuilt_images && steps.pull-image.outcome == 'success' }}
+        run: |
+          echo "::notice title=Docker image::Using pulled prebuilt image ${DOCKER_IMAGE}"
+
+      - name: Build Docker Image
+        if: ${{ !inputs.use_prebuilt_images || steps.pull-image.outcome == 'failure' }}
+        run: |
+          if [ "${{ steps.pull-image.outcome }}" = "failure" ]; then
+            echo "::notice title=Docker image::Prebuilt image pull failed; building locally: ${DOCKER_IMAGE}"
+          else
+            echo "::notice title=Docker image::Building image locally because prebuilt images are disabled: ${DOCKER_IMAGE}"
+          fi
           docker build \
             -f Dockerfile.${{ matrix.platform.os }} \
             --build-arg REDIS_REF=${{ env.REDIS_REF }} \
             --build-arg SANITIZER=${{ inputs.run_sanitizer && 'address' || '' }} \
-            -t ${{ env.DOCKER_IMAGE }} \
+            -t "${DOCKER_IMAGE}" \
             .
 
       - name: Build module
@@ -148,7 +186,7 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace \
             -e SAN=${{ inputs.run_sanitizer && 'addr' || '' }} \
-            ${{ env.DOCKER_IMAGE }} \
+            "${DOCKER_IMAGE}" \
             make build SAN=${{ inputs.run_sanitizer && 'addr' || '' }}
 
       - name: Run tests
@@ -159,7 +197,7 @@ jobs:
             --cap-add=SYS_PTRACE \
             --security-opt seccomp=unconfined \
             -e SAN=${{ inputs.run_sanitizer && 'addr' || '' }} \
-            ${{ env.DOCKER_IMAGE }} \
+            "${DOCKER_IMAGE}" \
             make test \
               VG=${{ inputs.run_valgrind && '1' || '0' }} \
               SAN=${{ inputs.run_sanitizer && 'addr' || '' }}
@@ -185,7 +223,7 @@ jobs:
             -e VERSION=${{ env.VERSION }} \
             -e TAGGED=${{ env.TAGGED }} \
             -e BETA_VERSION="${BETA_VERSION}" \
-            ${{ env.DOCKER_IMAGE }} \
+            "${DOCKER_IMAGE}" \
             bash -c "git config --global --add safe.directory /workspace && make pack BRANCH=${{ env.TAG_OR_BRANCH }} SHOW=1"
 
       - name: Upload artifacts to S3
@@ -200,5 +238,5 @@ jobs:
             -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
             -e GITHUB_REF=${{ github.ref }} \
             -e BETA_VERSION="${BETA_VERSION}" \
-            ${{ env.DOCKER_IMAGE }} \
+            "${DOCKER_IMAGE}" \
             bash -c "git config --global --add safe.directory /workspace && ./sbin/upload-artifacts-s3"

--- a/.github/workflows/flow-random-traffic.yml
+++ b/.github/workflows/flow-random-traffic.yml
@@ -12,6 +12,10 @@ on:
       os:
         description: 'OS to run on (leave empty for random)'
         default: ''
+      use_prebuilt_images:
+        description: 'Pull prebuilt Docker images instead of building locally'
+        type: boolean
+        default: true
   workflow_call:
     inputs:
       redis-ref:
@@ -30,6 +34,10 @@ on:
         description: 'OS to run on (leave empty for random)'
         type: string
         default: ''
+      use_prebuilt_images:
+        description: 'Pull prebuilt Docker images instead of building locally'
+        type: boolean
+        default: true
 
 jobs:
   pick-os:
@@ -57,13 +65,15 @@ jobs:
     name: random-traffic (${{ matrix.generator }}, ${{ needs.pick-os.outputs.os }})
     needs: pick-os
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     timeout-minutes: ${{ fromJSON(inputs.timeout-minutes || '30') }}
     strategy:
       fail-fast: false
       matrix:
         generator: [BloomGen, CuckooGen, CmsGen, TopKGen, TDigestGen]
     env:
-      DOCKER_IMAGE: redisbloom-${{ needs.pick-os.outputs.os }}:latest
       REDIS_REF: ${{ inputs.redis-ref || 'unstable' }}
     steps:
       - name: Checkout
@@ -71,10 +81,40 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Build Docker Image
+      - name: Set Docker Image
         env:
           SELECTED_OS: ${{ needs.pick-os.outputs.os }}
         run: |
+          repo="$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')"
+          image_tag="${REDIS_REF:-$(.install/get-redis-ref.sh)}"
+          echo "DOCKER_IMAGE=ghcr.io/${repo}/redisbloom-x86-${SELECTED_OS}:${image_tag}" >> "$GITHUB_ENV"
+
+      - name: Pull Docker Image
+        id: pull-image
+        if: ${{ inputs.use_prebuilt_images }}
+        continue-on-error: true
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "::notice title=Docker image::Trying to pull prebuilt image ${DOCKER_IMAGE}"
+          docker pull "${DOCKER_IMAGE}"
+
+      - name: Use Pulled Docker Image
+        if: ${{ inputs.use_prebuilt_images && steps.pull-image.outcome == 'success' }}
+        run: |
+          echo "::notice title=Docker image::Using pulled prebuilt image ${DOCKER_IMAGE}"
+
+      - name: Build Docker Image
+        if: ${{ !inputs.use_prebuilt_images || steps.pull-image.outcome == 'failure' }}
+        env:
+          SELECTED_OS: ${{ needs.pick-os.outputs.os }}
+        run: |
+          if [ "${{ inputs.use_prebuilt_images }}" = "true" ]; then
+            echo "::notice title=Docker image::Prebuilt image pull failed; building locally: ${DOCKER_IMAGE}"
+          else
+            echo "::notice title=Docker image::Building image locally because prebuilt images are disabled: ${DOCKER_IMAGE}"
+          fi
           docker build \
             -f "Dockerfile.${SELECTED_OS}" \
             --build-arg REDIS_REF="${REDIS_REF}" \

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -137,6 +137,11 @@ jobs:
       packages: write
     strategy:
       fail-fast: false
+      # Throttle the fan-out: ~36 images build at once otherwise, and the arm64
+      # subset all pull from ports.ubuntu.com (no CDN) in one synchronized burst,
+      # causing "connection timed out" during apt-get update. Cap concurrency so
+      # we trickle rather than slam the mirror. See MOD-16306.
+      max-parallel: 8
       matrix:
         image: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     env:
@@ -198,21 +203,21 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build Docker Image
+      - name: Build and Push Docker Image
         if: ${{ steps.check-image.outputs.exists != 'true' }}
         run: |
-          echo "Building ${DOCKER_IMAGE}"
+          echo "Building and pushing ${DOCKER_IMAGE}"
+          # Push straight from buildx (--push) instead of --load + `docker push`.
+          # The load→push round-trip through the docker daemon store intermittently
+          # fails with "unknown blob" (the loaded image references a config/layer
+          # blob the classic pusher can't find). buildx uploads a correct manifest
+          # directly to GHCR. --provenance=false keeps it a plain single-arch image.
           docker buildx build \
             --platform "${DOCKER_PLATFORM}" \
             -f "Dockerfile.${OS}" \
             --build-arg REDIS_REF="${REDIS_REF}" \
             --build-arg SANITIZER=${{ matrix.image.variant == 'sanitizer' && 'address' || '' }} \
             -t "${DOCKER_IMAGE}" \
-            --load \
+            --provenance=false \
+            --push \
             .
-
-      - name: Push Docker Image
-        if: ${{ steps.check-image.outputs.exists != 'true' }}
-        run: |
-          echo "Pushing ${DOCKER_IMAGE}"
-          docker push "${DOCKER_IMAGE}"

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -1,0 +1,218 @@
+name: Push Docker Images
+
+# Rollout notes:
+# - `.install/get-redis-ref.sh` is the source of truth for CI image tags.
+# - `docker-image-changes` forces PR CI to build locally and merged PR image
+#   publishing to rebuild/push the tag.
+# - Linux CI pulls prebuilt images first and falls back to building locally when
+#   an image is missing.
+
+on:
+  schedule:
+    - cron: '20 19 * * *' # 19:20 UTC, one hour before Event Nightly
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+      - master
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+'
+      - 'release/**'
+  push:
+    branches:
+      - main
+      - master
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+'
+      - 'release/**'
+    paths:
+      - 'pack/ramp.yml'
+  workflow_dispatch:
+    inputs:
+      architecture:
+        description: 'Architecture images to build'
+        type: choice
+        required: true
+        default: 'all'
+        options:
+          - all
+          - x86
+          - arm
+      force:
+        description: 'Rebuild and push images even if the tag already exists'
+        type: boolean
+        default: false
+
+jobs:
+  should-run:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Checkout
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
+
+      - name: Check Docker image version change
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "::notice title=Docker image::Scheduled image publish before nightly"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ github.event.pull_request.merged }}" = "true" ]; then
+              echo "::notice title=Docker image::Merged PR; checking/pushing missing or forced images"
+              echo "run=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "::notice title=Docker image::PR was closed without merge; skipping image push"
+              echo "run=false" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+
+          if git diff --unified=0 HEAD^ HEAD -- pack/ramp.yml | grep -Eq '^[+-]compatible_redis_version:'; then
+            echo "::notice title=Docker image::compatible_redis_version changed; checking/pushing images"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice title=Docker image::compatible_redis_version did not change; skipping image push"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  setup-matrix:
+    if: ${{ needs.should-run.outputs.run == 'true' }}
+    needs: should-run
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set matrix
+        id: set-matrix
+        env:
+          ARCHITECTURE: ${{ inputs.architecture || 'all' }}
+        run: |
+          X86_OS="focal jammy rocky8 rocky9 bullseye amazonlinux2 amazonlinux2023 mariner2 azurelinux3 alpine noble resolute rocky10 alma8 alma9 alma10 bookworm trixie"
+          ARM_OS="focal jammy rocky9 azurelinux3 amazonlinux2023 alpine noble resolute rocky8 rocky10 alma8 alma9 alma10 bullseye bookworm trixie mariner2"
+          MATRIX="["
+          add_platform() {
+            local arch="$1"
+            local image_arch="$2"
+            local runner="$3"
+            local platform="$4"
+            local os_list="$5"
+            for os in $os_list; do
+              MATRIX="${MATRIX}{\"arch\":\"${arch}\",\"image_arch\":\"${image_arch}\",\"runner\":\"${runner}\",\"platform\":\"${platform}\",\"os\":\"${os}\",\"variant\":\"\"},"
+            done
+          }
+          if [ "$ARCHITECTURE" = "all" ] || [ "$ARCHITECTURE" = "x86" ]; then
+            add_platform "x64" "x86" "ubuntu-22.04" "linux/amd64" "$X86_OS"
+            MATRIX="${MATRIX}{\"arch\":\"x64\",\"image_arch\":\"x86\",\"runner\":\"ubuntu-22.04\",\"platform\":\"linux/amd64\",\"os\":\"jammy\",\"variant\":\"sanitizer\"},"
+          fi
+          if [ "$ARCHITECTURE" = "all" ] || [ "$ARCHITECTURE" = "arm" ]; then
+            add_platform "arm64" "arm" "ubuntu24-arm64-4-16" "linux/arm64" "$ARM_OS"
+          fi
+          MATRIX="${MATRIX%,}]"
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+          echo "Generated matrix: ${MATRIX}"
+
+  push-images:
+    name: ${{ matrix.image.os }}-${{ matrix.image.image_arch }}${{ matrix.image.variant && format('-{0}', matrix.image.variant) || '' }}
+    needs: setup-matrix
+    runs-on: ${{ matrix.image.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+    env:
+      OS: ${{ matrix.image.os }}
+      IMAGE_ARCH: ${{ matrix.image.image_arch }}
+      DOCKER_PLATFORM: ${{ matrix.image.platform }}
+      VARIANT: ${{ matrix.image.variant }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: 'recursive'
+
+      - name: Login to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Set Redis ref
+        run: |
+          echo "REDIS_REF=$(.install/get-redis-ref.sh)" >> "$GITHUB_ENV"
+
+      - name: Set Docker Image
+        run: |
+          repo="$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')"
+          image_tag="$(.install/get-redis-ref.sh)"
+          image_os="$OS"
+          if [ -n "$VARIANT" ]; then
+            image_os="${image_os}-${VARIANT}"
+          fi
+          echo "DOCKER_IMAGE=ghcr.io/${repo}/redisbloom-${IMAGE_ARCH}-${image_os}:${image_tag}" >> "$GITHUB_ENV"
+
+      - name: Check Docker Image
+        id: check-image
+        run: |
+          image_tag="$(.install/get-redis-ref.sh)"
+          force_rebuild=false
+          if [ "${{ inputs.force || false }}" = "true" ]; then
+            force_rebuild=true
+          fi
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ contains(github.event.pull_request.labels.*.name, 'docker-image-changes') }}" = "true" ]; then
+            force_rebuild=true
+          fi
+          if [ "${{ github.event_name }}" = "schedule" ] && [ "$image_tag" = "unstable" ]; then
+            force_rebuild=true
+          fi
+
+          if [ "$force_rebuild" = "true" ]; then
+            echo "::notice title=Docker image::Force rebuild requested; rebuilding existing tag if present: ${DOCKER_IMAGE}"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if docker buildx imagetools inspect "${DOCKER_IMAGE}" >/dev/null 2>&1; then
+            echo "::notice title=Docker image::Image already exists, skipping build: ${DOCKER_IMAGE}"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice title=Docker image::Image is missing, building: ${DOCKER_IMAGE}"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build Docker Image
+        if: ${{ steps.check-image.outputs.exists != 'true' }}
+        run: |
+          echo "Building ${DOCKER_IMAGE}"
+          docker buildx build \
+            --platform "${DOCKER_PLATFORM}" \
+            -f "Dockerfile.${OS}" \
+            --build-arg REDIS_REF="${REDIS_REF}" \
+            --build-arg SANITIZER=${{ matrix.image.variant == 'sanitizer' && 'address' || '' }} \
+            -t "${DOCKER_IMAGE}" \
+            --load \
+            .
+
+      - name: Push Docker Image
+        if: ${{ steps.check-image.outputs.exists != 'true' }}
+        run: |
+          echo "Pushing ${DOCKER_IMAGE}"
+          docker push "${DOCKER_IMAGE}"

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -43,16 +43,20 @@ fi
 _pm_apt_updated=0
 apt_install() {
     [ "$#" -gt 0 ] || return 0
+    # Acquire::Retries: ports.ubuntu.com (arm64 mirror) intermittently drops
+    # connections mid-build; without retries a single dropped fetch fails the
+    # whole docker build (exit 100). Retry each download before giving up.
+    local apt_retry="-o Acquire::Retries=5"
     if [ "$_pm_apt_updated" = 0 ]; then
         export DEBIAN_FRONTEND=noninteractive
-        $SUDO apt-get update -qq
+        $SUDO apt-get update -qq $apt_retry
         _pm_apt_updated=1
     fi
     # env goes THROUGH $SUDO: sudo's env_reset strips exported variables, so a
     # plain export upstream never reaches dpkg — debconf (e.g. tzdata on focal,
     # which the base image doesn't preinstall) then blocks on an interactive
     # prompt and the bootstrap hangs.
-    $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends "$@"
+    $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends $apt_retry "$@"
 }
 
 # `--allowerasing` lets dnf pick our `curl` over the slimmer `curl-minimal`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core Linux CI and introduces GHCR publishing; behavior relies on pull-then-fallback and correct image tags, but does not change application runtime code.
> 
> **Overview**
> **Linux CI now prefers prebuilt Docker images from GHCR** instead of building on every job. Images are named `ghcr.io/{repo}/redisbloom-{x86|arm}-{os}[:-sanitizer]:{redis-ref}` using `.install/get-redis-ref.sh` as the tag. Jobs log in to GHCR, pull when enabled, and **fall back to a local `docker build`** if the pull fails or prebuilts are turned off.
> 
> A new **`Push Docker Images`** workflow builds and pushes the full OS/arch matrix (including a jammy sanitizer variant), skips tags that already exist unless forced, caps parallel builds at 8, and uses **buildx `--push`** to avoid intermittent GHCR blob errors. It runs on a nightly schedule (before Event Nightly), when `pack/ramp.yml`’s `compatible_redis_version` changes, on merged PRs to main/release branches, and via manual dispatch.
> 
> **PR CI** passes `use_prebuilt_images: false` when the PR has the **`docker-image-changes`** label so Dockerfile/bootstrap changes are validated locally; merged PRs with that label can force image rebuilds. **`flow-random-traffic`** gets the same pull-or-build path and `packages: read` where needed. **`apt_install`** in `.install/lib/pm.sh` adds **`Acquire::Retries=5`** to reduce flaky `apt-get` failures during image builds (especially arm64 mirrors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2ae9028e55a6af08d6e01a9dbe469417b96c25a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->