### PR TITLE
MOD-16952 - enhance bootstrap (add list and dry-run arg)

### DIFF
--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -53,7 +53,7 @@ fi
 . "$LIB/setup-python.sh"
 
 if [ "${DRY_RUN:-0}" = 1 ]; then
-    _dry_line "==> [redisbloom] dry-run complete — commands above are what bootstrap would run for missing deps (nothing installed)"
+    _dry_head "==> [redisbloom] dry-run complete — commands above are what bootstrap would run for missing deps (nothing installed)"
     exit 0
 fi
 

--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -44,20 +44,13 @@ echo "==> [redisbloom] OSNICK=$OSNICK PM=$PM"
 # Allow git operations on the checked-out source even when its uid doesn't
 # match the current user (common in CI containers). Scoped to this repo
 # (--local), not the host's global git config.
-# Skipped in check-deps and dry-run modes — neither may mutate anything.
-if [ "${CHECK_DEPS:-0}" != 1 ] && [ "${DRY_RUN:-0}" != 1 ] && [ -d "$ROOT/.git" ]; then
+# Skipped in check-deps mode — it may not mutate anything.
+if [ "${CHECK_DEPS:-0}" != 1 ] && [ -d "$ROOT/.git" ]; then
     git -C "$ROOT" config --local --add safe.directory '*' || true
 fi
 
 # shellcheck source=lib/setup-python.sh
 . "$LIB/setup-python.sh"
-
-if [ "${DRY_RUN:-0}" = 1 ]; then
-    echo
-    echo "==> [redisbloom] dry-run complete (OSNICK=$OSNICK, PM=$PM) — nothing was installed"
-    echo "    (lines above are the commands bootstrap would run)"
-    exit 0
-fi
 
 if [ "${CHECK_DEPS:-0}" = 1 ]; then
     n_ok=$(set -- $DEPS_OK; echo $#)

--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -56,6 +56,15 @@ if [ "${CHECK_DEPS:-0}" = 1 ]; then
     n_ok=$(set -- $DEPS_OK; echo $#)
     n_missing=$(set -- $DEPS_MISSING; echo $#)
     total=$((n_ok + n_missing))
+    # Aggregate mode: when the outer bootstrap sets DEPS_REPORT_FILE, don't
+    # print a per-module list — append machine-readable records and let the
+    # caller print one deduped union across all modules.
+    if [ -n "${DEPS_REPORT_FILE:-}" ]; then
+        for _p in $DEPS_OK;      do echo "ok $_p"      >> "$DEPS_REPORT_FILE"; done
+        for _p in $DEPS_MISSING; do echo "missing $_p" >> "$DEPS_REPORT_FILE"; done
+        echo "==> [redisbloom] checked: $n_ok installed, $n_missing missing"
+        exit 0
+    fi
     echo
     echo "==> [redisbloom] dependency check (OSNICK=$OSNICK, PM=$PM) — nothing was installed"
     # Colors on a real terminal; plain text when piped (CI logs) so no

--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -60,8 +60,10 @@ if [ "${CHECK_DEPS:-0}" = 1 ]; then
     # print a per-module list — append machine-readable records and let the
     # caller print one deduped union across all modules.
     if [ -n "${DEPS_REPORT_FILE:-}" ]; then
-        for _p in $DEPS_OK;      do echo "ok $_p"      >> "$DEPS_REPORT_FILE"; done
-        for _p in $DEPS_MISSING; do echo "missing $_p" >> "$DEPS_REPORT_FILE"; done
+        for _p in $DEPS_OK;           do echo "ok $_p"           >> "$DEPS_REPORT_FILE"; done
+        for _p in $DEPS_MISSING;      do echo "missing $_p"      >> "$DEPS_REPORT_FILE"; done
+        for _p in $DEPS_OPT_OK;       do echo "opt_ok $_p"       >> "$DEPS_REPORT_FILE"; done
+        for _p in $DEPS_OPT_MISSING;  do echo "opt_missing $_p"  >> "$DEPS_REPORT_FILE"; done
         echo "==> [redisbloom] checked: $n_ok installed, $n_missing missing"
         exit 0
     fi
@@ -86,7 +88,12 @@ if [ "${CHECK_DEPS:-0}" = 1 ]; then
     else
         echo "${GRN}installed: $n_ok/$total (set VERBOSE=1 to list)${RST}"
     fi
-    # Non-zero exit when anything is missing so CI / callers can gate on it.
+    # Optional (tests/coverage/debug) — reported separately, never fails the check.
+    if [ -n "$DEPS_OPT_MISSING" ]; then
+        echo "optional, not installed (tests/coverage/debug only):"
+        for _p in $DEPS_OPT_MISSING; do echo "    $_p"; done
+    fi
+    # Non-zero exit only when a REQUIRED dep is missing; optional gaps don't fail.
     [ "$n_missing" -eq 0 ] || exit 1
     exit 0
 fi

--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -45,12 +45,17 @@ echo "==> [redisbloom] OSNICK=$OSNICK PM=$PM"
 # match the current user (common in CI containers). Scoped to this repo
 # (--local), not the host's global git config.
 # Skipped in list mode — it may not mutate anything.
-if [ "${CHECK_DEPS:-0}" != 1 ] && [ -d "$ROOT/.git" ]; then
+if [ "${CHECK_DEPS:-0}" != 1 ] && [ "${DRY_RUN:-0}" != 1 ] && [ -d "$ROOT/.git" ]; then
     git -C "$ROOT" config --local --add safe.directory '*' || true
 fi
 
 # shellcheck source=lib/setup-python.sh
 . "$LIB/setup-python.sh"
+
+if [ "${DRY_RUN:-0}" = 1 ]; then
+    _dry_line "==> [redisbloom] dry-run complete — commands above are what bootstrap would run for missing deps (nothing installed)"
+    exit 0
+fi
 
 if [ "${CHECK_DEPS:-0}" = 1 ]; then
     n_ok=$(set -- $DEPS_OK; echo $#)

--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -44,11 +44,49 @@ echo "==> [redisbloom] OSNICK=$OSNICK PM=$PM"
 # Allow git operations on the checked-out source even when its uid doesn't
 # match the current user (common in CI containers). Scoped to this repo
 # (--local), not the host's global git config.
-if [ -d "$ROOT/.git" ]; then
+# Skipped in check-deps and dry-run modes — neither may mutate anything.
+if [ "${CHECK_DEPS:-0}" != 1 ] && [ "${DRY_RUN:-0}" != 1 ] && [ -d "$ROOT/.git" ]; then
     git -C "$ROOT" config --local --add safe.directory '*' || true
 fi
 
 # shellcheck source=lib/setup-python.sh
 . "$LIB/setup-python.sh"
+
+if [ "${DRY_RUN:-0}" = 1 ]; then
+    echo
+    echo "==> [redisbloom] dry-run complete (OSNICK=$OSNICK, PM=$PM) — nothing was installed"
+    echo "    (lines above are the commands bootstrap would run)"
+    exit 0
+fi
+
+if [ "${CHECK_DEPS:-0}" = 1 ]; then
+    n_ok=$(set -- $DEPS_OK; echo $#)
+    n_missing=$(set -- $DEPS_MISSING; echo $#)
+    total=$((n_ok + n_missing))
+    echo
+    echo "==> [redisbloom] dependency check (OSNICK=$OSNICK, PM=$PM) — nothing was installed"
+    # Colors on a real terminal; plain text when piped (CI logs) so no
+    # escape-code noise. RED = missing (the headline), GREEN = installed.
+    if [ -t 1 ]; then RED="$(printf '\033[1;31m')"; GRN="$(printf '\033[1;32m')"; RST="$(printf '\033[0m')"; else RED=""; GRN=""; RST=""; fi
+    # "not installed" is the headline of a check run — print it first, bold red.
+    if [ -n "$DEPS_MISSING" ]; then
+        echo "${RED}NOT INSTALLED ($n_missing):${RST}"
+        for _p in $DEPS_MISSING; do echo "${RED}    $_p${RST}"; done
+    else
+        echo "${GRN}not installed: (none)${RST}"
+    fi
+    # Full satisfied list is reassurance, not action: summarize by count,
+    # print it in full only under VERBOSE=1.
+    if [ "${VERBOSE:-0}" = 1 ]; then
+        echo "${GRN}installed:${RST}"
+        for _p in $DEPS_OK; do echo "${GRN}    $_p${RST}"; done
+        [ -n "$DEPS_OK" ] || echo "    (none)"
+    else
+        echo "${GRN}installed: $n_ok/$total (set VERBOSE=1 to list)${RST}"
+    fi
+    # Non-zero exit when anything is missing so CI / callers can gate on it.
+    [ "$n_missing" -eq 0 ] || exit 1
+    exit 0
+fi
 
 echo "==> [redisbloom] install_script.sh: done"

--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -44,7 +44,7 @@ echo "==> [redisbloom] OSNICK=$OSNICK PM=$PM"
 # Allow git operations on the checked-out source even when its uid doesn't
 # match the current user (common in CI containers). Scoped to this repo
 # (--local), not the host's global git config.
-# Skipped in check-deps mode — it may not mutate anything.
+# Skipped in list mode — it may not mutate anything.
 if [ "${CHECK_DEPS:-0}" != 1 ] && [ -d "$ROOT/.git" ]; then
     git -C "$ROOT" config --local --add safe.directory '*' || true
 fi

--- a/.install/install_script.sh
+++ b/.install/install_script.sh
@@ -75,7 +75,9 @@ if [ "${CHECK_DEPS:-0}" = 1 ]; then
     # "not installed" is the headline of a check run — print it first, bold red.
     if [ -n "$DEPS_MISSING" ]; then
         echo "${RED}NOT INSTALLED ($n_missing):${RST}"
-        for _p in $DEPS_MISSING; do echo "${RED}    $_p${RST}"; done
+        for _p in $DEPS_MISSING; do
+            case "$_p" in *:*) echo "${RED}    ${_p%%:*} (>= ${_p#*:})${RST}" ;; *) echo "${RED}    $_p${RST}" ;; esac
+        done
     else
         echo "${GRN}not installed: (none)${RST}"
     fi

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -36,7 +36,9 @@ install_aws_cli() {
             DEPS_OPT_OK="$DEPS_OPT_OK awscli"
         else
             DEPS_OPT_MISSING="$DEPS_OPT_MISSING awscli"
-            [ "${DRY_RUN:-0}" = 1 ] && _dry_line "curl -fSL <awscli-v2>.zip && unzip && \$SUDO ./aws/install"
+            # dry-run: print the actual (arch-aware) install as one runnable line.
+            # $(uname -m) yields x86_64/aarch64, matching the AWS asset names.
+            [ "${DRY_RUN:-0}" = 1 ] && _dry_line 'curl -fSL --retry 3 "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip && unzip -o /tmp/awscliv2.zip -d /tmp/awscli-install && sudo /tmp/awscli-install/aws/install && rm -rf /tmp/awscliv2.zip /tmp/awscli-install'
         fi
         return 0
     fi

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -79,7 +79,6 @@ RHEL_BASE="
     openssl openssl-devel bzip2-devel libffi-devel zlib-devel
     clang clang-devel
     tcl
-    python3 python3-pip python3-devel python3-numpy
     cmake
     unzip rsync valgrind lcov jq tar which gdb
 "

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -15,7 +15,7 @@
 # Only affects `make bootstrap check-deps` (reported separately, never fails).
 # Shared superset across modules; names this module doesn't install are simply
 # never matched.
-OPTIONAL_PKGS="valgrind gdb lcov tcl jq clang-format py3-numpy python3-numpy py3-psutil python3-psutil py3-cryptography python3-cryptography openssh xsimd openblas-dev curl tar uv"
+OPTIONAL_PKGS="valgrind gdb lcov tcl jq clang-format py3-numpy python3-numpy py3-psutil python3-psutil py3-cryptography python3-cryptography openssh xsimd openblas-dev curl tar uv zlib1g-dev zlib-dev zlib-devel libbz2-dev bzip2-dev bzip2-devel libblocksruntime-dev libev-dev libev-devel libevent-dev libevent-devel"
 
 # Install AWS CLI v2 from the official installer (arch-aware). Skips if
 # already present — handles pre-installed AMIs without failing.

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -15,7 +15,7 @@
 # Only affects `make bootstrap list` (reported separately, never fails).
 # Shared superset across modules; names this module doesn't install are simply
 # never matched.
-OPTIONAL_PKGS="valgrind gdb lcov tcl jq clang-format py3-numpy python3-numpy py3-psutil python3-psutil py3-cryptography python3-cryptography openssh xsimd openblas-dev curl tar uv zlib1g-dev zlib-dev zlib-devel libbz2-dev bzip2-dev bzip2-devel libblocksruntime-dev libev-dev libev-devel libevent-dev libevent-devel"
+OPTIONAL_PKGS="valgrind gdb lcov tcl jq clang-format py3-numpy python3-numpy py3-psutil python3-psutil py3-cryptography python3-cryptography openssh xsimd openblas-dev curl tar uv zlib1g-dev zlib-dev zlib-devel libbz2-dev bzip2-dev bzip2-devel libblocksruntime-dev libev-dev libev-devel libevent-dev libevent-devel awscli"
 
 # MIN_VERSIONS: sparse "pkg:minversion" list — only deps with a real floor a
 # package-manager install can actually satisfy. Everything else is presence-only.
@@ -28,6 +28,18 @@ MIN_VERSIONS=""
 # Install AWS CLI v2 from the official installer (arch-aware). Skips if
 # already present — handles pre-installed AMIs without failing.
 install_aws_cli() {
+    # aws-cli is an optional CI artifact-upload tool, not a build/run dep.
+    # list/dry-run must not mutate: the curl+unzip below hit the network and
+    # write /tmp, so short-circuit before them. list records it as optional.
+    if [ "${CHECK_DEPS:-0}" = 1 ] || [ "${DRY_RUN:-0}" = 1 ]; then
+        if command -v aws >/dev/null 2>&1; then
+            DEPS_OPT_OK="$DEPS_OPT_OK awscli"
+        else
+            DEPS_OPT_MISSING="$DEPS_OPT_MISSING awscli"
+            [ "${DRY_RUN:-0}" = 1 ] && _dry_line "curl -fSL <awscli-v2>.zip && unzip && \$SUDO ./aws/install"
+        fi
+        return 0
+    fi
     if command -v aws &>/dev/null; then
         return 0
     fi

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -12,7 +12,7 @@
 
 # Optional = installed by bootstrap but NOT in the README's minimal build-dep
 # list: tests/coverage/debug and feature libs the core build/run doesn't need.
-# Only affects `make bootstrap check-deps` (reported separately, never fails).
+# Only affects `make bootstrap list` (reported separately, never fails).
 # Shared superset across modules; names this module doesn't install are simply
 # never matched.
 OPTIONAL_PKGS="valgrind gdb lcov tcl jq clang-format py3-numpy python3-numpy py3-psutil python3-psutil py3-cryptography python3-cryptography openssh xsimd openblas-dev curl tar uv zlib1g-dev zlib-dev zlib-devel libbz2-dev bzip2-dev bzip2-devel libblocksruntime-dev libev-dev libev-devel libevent-dev libevent-devel"

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -15,7 +15,7 @@
 # Only affects `make bootstrap check-deps` (reported separately, never fails).
 # Shared superset across modules; names this module doesn't install are simply
 # never matched.
-OPTIONAL_PKGS="valgrind gdb lcov tcl jq py3-numpy py3-psutil py3-cryptography openssh xsimd openblas-dev"
+OPTIONAL_PKGS="valgrind gdb lcov tcl jq clang-format py3-numpy python3-numpy py3-psutil python3-psutil py3-cryptography python3-cryptography openssh xsimd openblas-dev curl tar uv"
 
 # Install AWS CLI v2 from the official installer (arch-aware). Skips if
 # already present — handles pre-installed AMIs without failing.

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -10,6 +10,13 @@
 # Sourced by os/<osnick>.sh after lib/pm.sh. All variables here are plain
 # space-separated strings so callers can splat them with `apt_install $SET`.
 
+# Optional = installed by bootstrap but NOT in the README's minimal build-dep
+# list: tests/coverage/debug and feature libs the core build/run doesn't need.
+# Only affects `make bootstrap check-deps` (reported separately, never fails).
+# Shared superset across modules; names this module doesn't install are simply
+# never matched.
+OPTIONAL_PKGS="valgrind gdb lcov tcl jq py3-numpy py3-psutil py3-cryptography openssh xsimd openblas-dev"
+
 # Install AWS CLI v2 from the official installer (arch-aware). Skips if
 # already present — handles pre-installed AMIs without failing.
 install_aws_cli() {

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -17,6 +17,11 @@
 # never matched.
 OPTIONAL_PKGS="valgrind gdb lcov tcl jq clang-format py3-numpy python3-numpy py3-psutil python3-psutil py3-cryptography python3-cryptography openssh xsimd openblas-dev curl tar uv zlib1g-dev zlib-dev zlib-devel libbz2-dev bzip2-dev bzip2-devel libblocksruntime-dev libev-dev libev-devel libevent-dev libevent-devel"
 
+# MIN_VERSIONS: sparse "pkg:minversion" -- only deps with a real floor; a
+# present-but-older dep is reported as missing, tagged with the version.
+# cmake 3.25 = what install_cmake.sh provisions (apt 3.22 is too old).
+MIN_VERSIONS="cmake:3.25"
+
 # Install AWS CLI v2 from the official installer (arch-aware). Skips if
 # already present — handles pre-installed AMIs without failing.
 install_aws_cli() {

--- a/.install/lib/packages.sh
+++ b/.install/lib/packages.sh
@@ -17,10 +17,13 @@
 # never matched.
 OPTIONAL_PKGS="valgrind gdb lcov tcl jq clang-format py3-numpy python3-numpy py3-psutil python3-psutil py3-cryptography python3-cryptography openssh xsimd openblas-dev curl tar uv zlib1g-dev zlib-dev zlib-devel libbz2-dev bzip2-dev bzip2-devel libblocksruntime-dev libev-dev libev-devel libevent-dev libevent-devel"
 
-# MIN_VERSIONS: sparse "pkg:minversion" -- only deps with a real floor; a
-# present-but-older dep is reported as missing, tagged with the version.
-# cmake 3.25 = what install_cmake.sh provisions (apt 3.22 is too old).
-MIN_VERSIONS="cmake:3.25"
+# MIN_VERSIONS: sparse "pkg:minversion" list — only deps with a real floor a
+# package-manager install can actually satisfy. Everything else is presence-only.
+# (cmake is intentionally NOT here: its >= 3.25 requirement is provisioned by
+# install_cmake.sh during a real `make bootstrap`, not by the distro package, so
+# a version floor here would be unsatisfiable by the apt/dnf `cmake` and would
+# only make `list`/`dry-run` disagree.)
+MIN_VERSIONS=""
 
 # Install AWS CLI v2 from the official installer (arch-aware). Skips if
 # already present — handles pre-installed AMIs without failing.

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -65,7 +65,7 @@ _min_for() { for _e in $MIN_VERSIONS; do case "$_e" in "$1:"*) echo "${_e#*:}"; 
 _get_installed_version() {
     case "$1" in
         gcc|g++) "$1" -dumpversion 2>/dev/null ;;
-        *)       "$1" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 ;;
+        *)       "$1" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 || true ;;
     esac
 }
 

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -35,7 +35,7 @@ else
 fi
 
 # ----------------------------------------------------------------------------
-# check-deps mode: when CHECK_DEPS=1 the install primitives below do NOT
+# list mode: when CHECK_DEPS=1 the install primitives below do NOT
 # install — they query whether each package is already present and record it
 # into DEPS_OK / DEPS_MISSING (printed as a summary by install_script.sh).
 # SUDO is neutralised to a no-op so stray privileged side-commands
@@ -50,7 +50,7 @@ DEPS_OPT_MISSING=""
 
 # Optional deps are marked in lib/packages.sh (OPTIONAL_PKGS); default empty
 # here so a check works even before packages.sh is sourced. Still installed
-# normally — this only splits them into a separate check-deps bucket.
+# normally — this only splits them into a separate list bucket.
 OPTIONAL_PKGS="${OPTIONAL_PKGS:-}"
 _is_optional() { case " $OPTIONAL_PKGS " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
 

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -45,6 +45,14 @@ fi
 CHECK_DEPS="${CHECK_DEPS:-0}"
 DEPS_OK=""
 DEPS_MISSING=""
+DEPS_OPT_OK=""
+DEPS_OPT_MISSING=""
+
+# Optional deps are marked in lib/packages.sh (OPTIONAL_PKGS); default empty
+# here so a check works even before packages.sh is sourced. Still installed
+# normally — this only splits them into a separate check-deps bucket.
+OPTIONAL_PKGS="${OPTIONAL_PKGS:-}"
+_is_optional() { case " $OPTIONAL_PKGS " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
 
 if [ "$CHECK_DEPS" = 1 ]; then
     SUDO=":"                # ':' is the shell no-op builtin; it ignores its arguments
@@ -66,7 +74,11 @@ _pkg_installed() {
 
 _check_pkgs() {
     for _p in "$@"; do
-        if _pkg_installed "$_p"; then DEPS_OK="$DEPS_OK $_p"; else DEPS_MISSING="$DEPS_MISSING $_p"; fi
+        if _is_optional "$_p"; then
+            if _pkg_installed "$_p"; then DEPS_OPT_OK="$DEPS_OPT_OK $_p"; else DEPS_OPT_MISSING="$DEPS_OPT_MISSING $_p"; fi
+        else
+            if _pkg_installed "$_p"; then DEPS_OK="$DEPS_OK $_p"; else DEPS_MISSING="$DEPS_MISSING $_p"; fi
+        fi
     done
 }
 

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -35,6 +35,61 @@ else
 fi
 
 # ----------------------------------------------------------------------------
+# check-deps mode: when CHECK_DEPS=1 the install primitives below do NOT
+# install — they query whether each package is already present and record it
+# into DEPS_OK / DEPS_MISSING (printed as a summary by install_script.sh).
+# SUDO is neutralised to a no-op so stray privileged side-commands
+# (groupinstall, repo enables, ln/cp/update-alternatives) can't mutate the
+# system during a check.
+# ----------------------------------------------------------------------------
+CHECK_DEPS="${CHECK_DEPS:-0}"
+DEPS_OK=""
+DEPS_MISSING=""
+
+# DRY_RUN=1: install nothing — print the package-install command each
+# primitive WOULD run, in a clear, copy-pasteable form. Like check-deps it
+# neutralises SUDO so no privileged side-command mutates the system.
+DRY_RUN="${DRY_RUN:-0}"
+
+if [ "$CHECK_DEPS" = 1 ] || [ "$DRY_RUN" = 1 ]; then
+    _SUDO_DISPLAY="$SUDO"   # remember the intended sudo prefix for dry-run output
+    SUDO=":"                # ':' is the shell no-op builtin; it ignores its arguments
+fi
+
+# Colors for dry-run output: bold blue "DRY-RUN [tag]" headline, blue command.
+# Only on a real terminal (plain text when piped, e.g. CI logs).
+if [ "$DRY_RUN" = 1 ] && [ -t 1 ]; then
+    DRY_HL="$(printf '\033[1;34m')"; DRY_C="$(printf '\033[34m')"; DRY_RST="$(printf '\033[0m')"
+else
+    DRY_HL=""; DRY_C=""; DRY_RST=""
+fi
+
+# _dry_line <tag> <text...> — print one colored dry-run line with a bold
+# headline. _dry uses the active PM as the tag and adds the sudo prefix.
+_dry_line() { _t="$1"; shift; echo "${DRY_HL}DRY-RUN [$_t]${DRY_RST}  ${DRY_C}$*${DRY_RST}"; }
+_dry() { _dry_line "$PM" "${_SUDO_DISPLAY:+$_SUDO_DISPLAY }$*"; }
+
+# Read-only "is this package installed?" probe, per package manager.
+_pkg_installed() {
+    case "$PM" in
+        apt)          dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -q 'ok installed' ;;
+        dnf|yum|tdnf) rpm -q "$1" >/dev/null 2>&1 ;;
+        apk)          apk info -e "$1" >/dev/null 2>&1 ;;
+        # Judge by stdout, not exit code: brew often prints unrelated
+        # warnings to stderr and returns non-zero even when the formula is
+        # installed. A non-empty "<name> <version>" line means installed.
+        brew)         [ -n "$(brew list --versions "$1" 2>/dev/null)" ] ;;
+        *)            return 1 ;;
+    esac
+}
+
+_check_pkgs() {
+    for _p in "$@"; do
+        if _pkg_installed "$_p"; then DEPS_OK="$DEPS_OK $_p"; else DEPS_MISSING="$DEPS_MISSING $_p"; fi
+    done
+}
+
+# ----------------------------------------------------------------------------
 # Per-PM install primitives
 # ----------------------------------------------------------------------------
 
@@ -43,6 +98,12 @@ fi
 _pm_apt_updated=0
 apt_install() {
     [ "$#" -gt 0 ] || return 0
+    if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
+    if [ "$DRY_RUN" = 1 ]; then
+        [ "$_pm_apt_updated" = 0 ] && { _dry "apt-get update"; _pm_apt_updated=1; }
+        _dry "apt-get install -y --no-install-recommends $*"
+        return 0
+    fi
     # Acquire::Retries: ports.ubuntu.com (arm64 mirror) intermittently drops
     # connections mid-build; without retries a single dropped fetch fails the
     # whole docker build (exit 100). Retry each download before giving up.
@@ -63,11 +124,15 @@ apt_install() {
 # preinstalled on amazon linux 2023 / EL10 base images.
 dnf_install() {
     [ "$#" -gt 0 ] || return 0
+    if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
+    if [ "$DRY_RUN" = 1 ]; then _dry "dnf -y install --allowerasing --skip-broken $*"; return 0; fi
     $SUDO dnf -y install --allowerasing --skip-broken "$@"
 }
 
 yum_install() {
     [ "$#" -gt 0 ] || return 0
+    if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
+    if [ "$DRY_RUN" = 1 ]; then _dry "yum -y install --skip-broken $*"; return 0; fi
     $SUDO yum -y install --skip-broken "$@"
 }
 
@@ -77,6 +142,12 @@ yum_install() {
 # becomes a warning rather than a build failure.
 tdnf_install() {
     [ "$#" -gt 0 ] || return 0
+    if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
+    if [ "$DRY_RUN" = 1 ]; then
+        local p
+        for p in "$@"; do _dry "tdnf -y install $p"; done
+        return 0
+    fi
     local pkg
     for pkg in "$@"; do
         if ! $SUDO tdnf -y install "$pkg" >/dev/null 2>&1; then
@@ -87,6 +158,8 @@ tdnf_install() {
 
 apk_install() {
     [ "$#" -gt 0 ] || return 0
+    if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
+    if [ "$DRY_RUN" = 1 ]; then _dry "apk add --no-cache $*"; return 0; fi
     $SUDO apk add --no-cache "$@"
 }
 
@@ -95,6 +168,8 @@ apk_install() {
 # checks (compiler probes, `command -v`, ...).
 brew_install() {
     [ "$#" -gt 0 ] || return 0
+    if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
+    if [ "$DRY_RUN" = 1 ]; then _dry "brew install $*"; return 0; fi
     if ! command -v brew >/dev/null 2>&1; then
         echo "pm.sh: brew not installed; install from https://brew.sh" >&2
         exit 1

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -127,8 +127,15 @@ _check_pkgs() {
             _min=$(_min_for "$_p")
             if ! _pkg_installed "$_p"; then
                 if [ -n "$_min" ]; then DEPS_MISSING="$DEPS_MISSING $_p:$_min"; else DEPS_MISSING="$DEPS_MISSING $_p"; fi
-            elif [ -n "$_min" ] && _have=$(_get_installed_version "$_p") && [ -n "$_have" ] && ! version_ge "$_have" "$_min"; then
-                DEPS_MISSING="$DEPS_MISSING $_p:$_min"
+            elif [ -n "$_min" ]; then
+                # has a floor: treat an unknown/unparseable version as NOT
+                # satisfied (fail-safe) rather than silently recording it OK.
+                _have=$(_get_installed_version "$_p")
+                if [ -z "$_have" ] || ! version_ge "$_have" "$_min"; then
+                    DEPS_MISSING="$DEPS_MISSING $_p:$_min"
+                else
+                    DEPS_OK="$DEPS_OK $_p"
+                fi
             else
                 DEPS_OK="$DEPS_OK $_p"
             fi

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -358,7 +358,7 @@ el8_default_install() {
         _run ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/make /usr/local/bin/make || true
     fi
     # Point python3 at 3.11 — skip once it already is.
-    if ! python3 --version 2>/dev/null | grep -q '3\.11'; then
+    if ! /usr/bin/python3 --version 2>/dev/null | grep -q '3\.11'; then
         _run update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 2000000
         _run update-alternatives --set python3 /usr/bin/python3.11
     fi

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -276,8 +276,8 @@ rhel_default_install() {
         esac
     fi
     case "$PM" in
-        dnf) dnf_install $RHEL_BASE ;;
-        yum) yum_install $RHEL_BASE ;;
+        dnf) dnf_install $RHEL_BASE; dnf_install ${RHEL_PYTHON-python3 python3-pip python3-devel python3-numpy} ;;
+        yum) yum_install $RHEL_BASE; yum_install ${RHEL_PYTHON-python3 python3-pip python3-devel python3-numpy} ;;
     esac
 }
 
@@ -338,6 +338,12 @@ _pm_enable_el8_extras() {
 el8_default_install() {
     rpm -q epel-release >/dev/null 2>&1 || _run dnf -y install epel-release
     _pm_enable_el8_extras
+    # el8's python is python3.11 (installed below). The base `python3` rpm is
+    # named python36, so `rpm -q python3` never matches → list/dry-run would flag
+    # it missing forever and never converge. Tell rhel_default_install to add no
+    # bare python3 here; 3.11 is what el8 actually uses (numpy comes from the
+    # test venv via uv pip, so no system numpy package is needed on el8).
+    local RHEL_PYTHON=""
     rhel_default_install
     dnf_install \
         gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel \

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -242,7 +242,7 @@ apk_install() {
 brew_install() {
     [ "$#" -gt 0 ] || return 0
     if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
-    if [ "$DRY_RUN" = 1 ]; then set -- $(_missing_only "$@"); [ "$#" -gt 0 ] || return 0; _run brew install "$@"; return 0; fi
+    if [ "$DRY_RUN" = 1 ]; then set -- $(_missing_only "$@"); [ "$#" -gt 0 ] || return 0; _run env HOMEBREW_NO_AUTO_UPDATE=1 brew install "$@"; return 0; fi
     if ! command -v brew >/dev/null 2>&1; then
         echo "pm.sh: brew not installed; install from https://brew.sh" >&2
         exit 1

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -34,6 +34,15 @@ else
     exit 1
 fi
 
+# Root container without a real sudo binary (e.g. a slim amazonlinux2 Docker
+# image running install_script.sh directly as root): make `sudo` a transparent
+# pass-through so literal-`sudo` steps in _sh strings (incl. pipes like
+# `| sudo tee` / `| sudo gpg` and `&& sudo make install`) still run. When NOT
+# root, a missing sudo is a genuine error — leave it unmasked.
+if [ "$(id -u)" = 0 ] && ! command -v sudo >/dev/null 2>&1; then
+    sudo() { "$@"; }
+fi
+
 # ----------------------------------------------------------------------------
 # list mode: when CHECK_DEPS=1 the install primitives below do NOT
 # install — they query whether each package is already present and record it

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -96,9 +96,24 @@ _dry_head() { printf '%s%s%s\n' "$_DRY_H" "$*" "$_DRY_R"; }   # a headline (cyan
 
 # _run CMD... — install: execute (real sudo prefix); dry-run: print (blue);
 # list: skip. Callers pre-filter to missing.
+_apt_df_shown=0
 _run() {
     if [ "$CHECK_DEPS" = 1 ]; then return 0
-    elif [ "$DRY_RUN" = 1 ]; then _dry_line "${_SUDO_DISPLAY:+$_SUDO_DISPLAY }$*"
+    elif [ "$DRY_RUN" = 1 ]; then
+        case " $* " in
+            *' apt-get '*|*' dnf '*|*' yum '*|*' tdnf '*|*' apk '*)
+                # First pkg-manager command: on apt, emit the noninteractive
+                # frontend right before it — only when there IS an apt command,
+                # so a box needing no apt install prints no export noise.
+                if [ "$PM" = apt ] && [ "$_apt_df_shown" = 0 ]; then
+                    _dry_line 'export DEBIAN_FRONTEND=noninteractive'; _apt_df_shown=1
+                fi
+                # apt-get/dnf/... read stdin; in a pasted dry-run that stdin IS
+                # the following commands, so the pkg manager swallows the rest of
+                # the paste. Redirect from /dev/null so a paste runs to the end.
+                _dry_line "${_SUDO_DISPLAY:+$_SUDO_DISPLAY }$* < /dev/null" ;;
+            *)  _dry_line "${_SUDO_DISPLAY:+$_SUDO_DISPLAY }$*" ;;
+        esac
     else ${_SUDO_DISPLAY:-$SUDO} "$@"; fi
 }
 

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -348,8 +348,12 @@ el8_default_install() {
     dnf_install \
         gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel \
         python3.11 python3.11-devel python3.11-pip xz
-    # Symlink the toolset compiler into /usr/local/bin — skip once gcc already points there.
-    if [ "$(readlink -f /usr/local/bin/gcc 2>/dev/null)" != /opt/rh/gcc-toolset-11/root/usr/bin/gcc ]; then
+    # gcc-toolset-11 is this module's compiler. Skip when the active gcc/g++ is
+    # already >= 11 — so a higher toolset another module wired up (e.g.
+    # RediSearch's gcc-toolset-13) is ACCEPTED, not downgraded back to 11; only
+    # wire ours when gcc is below it. Re-links the full set if either is stale.
+    if ! version_ge "$(gcc -dumpversion 2>/dev/null || echo 0)" 11 \
+       || ! version_ge "$(g++ -dumpversion 2>/dev/null || echo 0)" 11; then
         _run cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh 2>/dev/null || true
         _run ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/gcc  /usr/local/bin/gcc  || true
         _run ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/g++  /usr/local/bin/g++  || true

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -146,6 +146,7 @@ _pm_apt_updated=0
 apt_install() {
     [ "$#" -gt 0 ] || return 0
     if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
+    if [ "$DRY_RUN" = 1 ]; then set -- $(_missing_only "$@"); [ "$#" -gt 0 ] || return 0; fi
     # Acquire::Retries: ports.ubuntu.com (arm64 mirror) intermittently drops
     # connections mid-build; without retries a single dropped fetch fails the
     # whole docker build (exit 100). Retry each download before giving up.

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -151,9 +151,9 @@ apt_install() {
     # connections mid-build; without retries a single dropped fetch fails the
     # whole docker build (exit 100). Retry each download before giving up.
     local apt_retry="-o Acquire::Retries=5"
-    if [ "$DRY_RUN" != 1 ] && [ "$_pm_apt_updated" = 0 ]; then
+    if [ "$_pm_apt_updated" = 0 ]; then
         export DEBIAN_FRONTEND=noninteractive
-        $SUDO apt-get update -qq $apt_retry
+        _run apt-get update -qq $apt_retry
         _pm_apt_updated=1
     fi
     # env goes THROUGH sudo: sudo's env_reset strips exported variables, so a

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -54,6 +54,28 @@ DEPS_OPT_MISSING=""
 OPTIONAL_PKGS="${OPTIONAL_PKGS:-}"
 _is_optional() { case " $OPTIONAL_PKGS " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
 
+# MIN_VERSIONS (lib/packages.sh): sparse "pkg:minversion" list -- only deps
+# with a real floor. Everything else is presence-only. Default empty.
+MIN_VERSIONS="${MIN_VERSIONS:-}"
+_min_for() { for _e in $MIN_VERSIONS; do case "$_e" in "$1:"*) echo "${_e#*:}"; return ;; esac; done; }
+
+# Read a tool's installed version from the tool itself (not the package DB --
+# e.g. cmake is overlaid into /usr/local by install_cmake.sh, so dpkg would
+# report the stale apt version).
+_get_installed_version() {
+    case "$1" in
+        gcc|g++) "$1" -dumpversion 2>/dev/null ;;
+        *)       "$1" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1 ;;
+    esac
+}
+
+# version_ge HAVE WANT -> 0 if HAVE >= WANT (strips -rev/+build suffixes).
+version_ge() {
+    _have="${1%%[-+]*}"; _want="${2%%[-+]*}"
+    _s=sort; sort -V </dev/null >/dev/null 2>&1 || { command -v gsort >/dev/null 2>&1 && _s=gsort; }
+    [ "$(printf '%s\n%s\n' "$_want" "$_have" | "$_s" -V | head -1)" = "$_want" ]
+}
+
 if [ "$CHECK_DEPS" = 1 ]; then
     SUDO=":"                # ':' is the shell no-op builtin; it ignores its arguments
 fi
@@ -77,7 +99,14 @@ _check_pkgs() {
         if _is_optional "$_p"; then
             if _pkg_installed "$_p"; then DEPS_OPT_OK="$DEPS_OPT_OK $_p"; else DEPS_OPT_MISSING="$DEPS_OPT_MISSING $_p"; fi
         else
-            if _pkg_installed "$_p"; then DEPS_OK="$DEPS_OK $_p"; else DEPS_MISSING="$DEPS_MISSING $_p"; fi
+            _min=$(_min_for "$_p")
+            if ! _pkg_installed "$_p"; then
+                if [ -n "$_min" ]; then DEPS_MISSING="$DEPS_MISSING $_p:$_min"; else DEPS_MISSING="$DEPS_MISSING $_p"; fi
+            elif [ -n "$_min" ] && _have=$(_get_installed_version "$_p") && [ -n "$_have" ] && ! version_ge "$_have" "$_min"; then
+                DEPS_MISSING="$DEPS_MISSING $_p:$_min"
+            else
+                DEPS_OK="$DEPS_OK $_p"
+            fi
         fi
     done
 }

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -135,7 +135,7 @@ _missing_only() { for _p in "$@"; do _pkg_installed "$_p" || printf '%s ' "$_p";
 _pkg_installed() {
     case "$PM" in
         apt)          dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -q 'ok installed' ;;
-        dnf|yum|tdnf) rpm -q "$1" >/dev/null 2>&1 ;;
+        dnf|yum|tdnf) rpm -q "$1" >/dev/null 2>&1 || rpm -q "$1-minimal" >/dev/null 2>&1 ;;  # RHEL ships curl-minimal, which provides curl
         apk)          apk info -e "$1" >/dev/null 2>&1 ;;
         # Judge by stdout, not exit code: brew often prints unrelated
         # warnings to stderr and returns non-zero even when the formula is

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -46,28 +46,9 @@ CHECK_DEPS="${CHECK_DEPS:-0}"
 DEPS_OK=""
 DEPS_MISSING=""
 
-# DRY_RUN=1: install nothing — print the package-install command each
-# primitive WOULD run, in a clear, copy-pasteable form. Like check-deps it
-# neutralises SUDO so no privileged side-command mutates the system.
-DRY_RUN="${DRY_RUN:-0}"
-
-if [ "$CHECK_DEPS" = 1 ] || [ "$DRY_RUN" = 1 ]; then
-    _SUDO_DISPLAY="$SUDO"   # remember the intended sudo prefix for dry-run output
+if [ "$CHECK_DEPS" = 1 ]; then
     SUDO=":"                # ':' is the shell no-op builtin; it ignores its arguments
 fi
-
-# Colors for dry-run output: bold blue "DRY-RUN [tag]" headline, blue command.
-# Only on a real terminal (plain text when piped, e.g. CI logs).
-if [ "$DRY_RUN" = 1 ] && [ -t 1 ]; then
-    DRY_HL="$(printf '\033[1;34m')"; DRY_C="$(printf '\033[34m')"; DRY_RST="$(printf '\033[0m')"
-else
-    DRY_HL=""; DRY_C=""; DRY_RST=""
-fi
-
-# _dry_line <tag> <text...> — print one colored dry-run line with a bold
-# headline. _dry uses the active PM as the tag and adds the sudo prefix.
-_dry_line() { _t="$1"; shift; echo "${DRY_HL}DRY-RUN [$_t]${DRY_RST}  ${DRY_C}$*${DRY_RST}"; }
-_dry() { _dry_line "$PM" "${_SUDO_DISPLAY:+$_SUDO_DISPLAY }$*"; }
 
 # Read-only "is this package installed?" probe, per package manager.
 _pkg_installed() {
@@ -99,11 +80,6 @@ _pm_apt_updated=0
 apt_install() {
     [ "$#" -gt 0 ] || return 0
     if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
-    if [ "$DRY_RUN" = 1 ]; then
-        [ "$_pm_apt_updated" = 0 ] && { _dry "apt-get update"; _pm_apt_updated=1; }
-        _dry "apt-get install -y --no-install-recommends $*"
-        return 0
-    fi
     # Acquire::Retries: ports.ubuntu.com (arm64 mirror) intermittently drops
     # connections mid-build; without retries a single dropped fetch fails the
     # whole docker build (exit 100). Retry each download before giving up.
@@ -125,14 +101,12 @@ apt_install() {
 dnf_install() {
     [ "$#" -gt 0 ] || return 0
     if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
-    if [ "$DRY_RUN" = 1 ]; then _dry "dnf -y install --allowerasing --skip-broken $*"; return 0; fi
     $SUDO dnf -y install --allowerasing --skip-broken "$@"
 }
 
 yum_install() {
     [ "$#" -gt 0 ] || return 0
     if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
-    if [ "$DRY_RUN" = 1 ]; then _dry "yum -y install --skip-broken $*"; return 0; fi
     $SUDO yum -y install --skip-broken "$@"
 }
 
@@ -143,11 +117,6 @@ yum_install() {
 tdnf_install() {
     [ "$#" -gt 0 ] || return 0
     if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
-    if [ "$DRY_RUN" = 1 ]; then
-        local p
-        for p in "$@"; do _dry "tdnf -y install $p"; done
-        return 0
-    fi
     local pkg
     for pkg in "$@"; do
         if ! $SUDO tdnf -y install "$pkg" >/dev/null 2>&1; then
@@ -159,7 +128,6 @@ tdnf_install() {
 apk_install() {
     [ "$#" -gt 0 ] || return 0
     if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
-    if [ "$DRY_RUN" = 1 ]; then _dry "apk add --no-cache $*"; return 0; fi
     $SUDO apk add --no-cache "$@"
 }
 
@@ -169,7 +137,6 @@ apk_install() {
 brew_install() {
     [ "$#" -gt 0 ] || return 0
     if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
-    if [ "$DRY_RUN" = 1 ]; then _dry "brew install $*"; return 0; fi
     if ! command -v brew >/dev/null 2>&1; then
         echo "pm.sh: brew not installed; install from https://brew.sh" >&2
         exit 1

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -76,9 +76,34 @@ version_ge() {
     [ "$(printf '%s\n%s\n' "$_want" "$_have" | "$_s" -V | head -1)" = "$_want" ]
 }
 
-if [ "$CHECK_DEPS" = 1 ]; then
-    SUDO=":"                # ':' is the shell no-op builtin; it ignores its arguments
+# DRY_RUN=1: run the bootstrap flow but install nothing — for each MISSING
+# package, print the exact install command that WOULD run (the same single
+# line the primitive executes normally, via _run — no duplicated command).
+DRY_RUN="${DRY_RUN:-0}"
+
+if [ "$CHECK_DEPS" = 1 ] || [ "$DRY_RUN" = 1 ]; then
+    _SUDO_DISPLAY="$SUDO"   # remember the real sudo prefix for dry-run printing
+    SUDO=":"                # neutralize privileged side-commands (no mutation)
 fi
+
+# dry-run output is blue on a real terminal, plain when piped (CI logs).
+if [ "$DRY_RUN" = 1 ] && [ -t 1 ]; then _DRY_C="$(printf '\033[1;34m')"; _DRY_R="$(printf '\033[0m')"; else _DRY_C=""; _DRY_R=""; fi
+_dry_line() { printf '%s%s%s\n' "$_DRY_C" "$*" "$_DRY_R"; }
+
+# _run CMD... — one wrapper for every "would-install" command, so callers
+# never branch on the mode:
+#   install  -> execute it (with the real sudo prefix)
+#   dry-run  -> print it (blue), don't execute
+#   list     -> skip it (a check neither installs nor prints)
+# The printed and the executed command are literally the same line.
+_run() {
+    if [ "$CHECK_DEPS" = 1 ]; then return 0
+    elif [ "$DRY_RUN" = 1 ]; then _dry_line "${_SUDO_DISPLAY:+$_SUDO_DISPLAY }$*"
+    else ${_SUDO_DISPLAY:-$SUDO} "$@"; fi
+}
+
+# Echo (space-separated) only the packages from "$@" that are NOT installed.
+_missing_only() { for _p in "$@"; do _pkg_installed "$_p" || printf '%s ' "$_p"; done; }
 
 # Read-only "is this package installed?" probe, per package manager.
 _pkg_installed() {
@@ -121,20 +146,21 @@ _pm_apt_updated=0
 apt_install() {
     [ "$#" -gt 0 ] || return 0
     if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
+    if [ "$DRY_RUN" = 1 ]; then set -- $(_missing_only "$@"); [ "$#" -gt 0 ] || return 0; fi
     # Acquire::Retries: ports.ubuntu.com (arm64 mirror) intermittently drops
     # connections mid-build; without retries a single dropped fetch fails the
     # whole docker build (exit 100). Retry each download before giving up.
     local apt_retry="-o Acquire::Retries=5"
-    if [ "$_pm_apt_updated" = 0 ]; then
+    if [ "$DRY_RUN" != 1 ] && [ "$_pm_apt_updated" = 0 ]; then
         export DEBIAN_FRONTEND=noninteractive
         $SUDO apt-get update -qq $apt_retry
         _pm_apt_updated=1
     fi
-    # env goes THROUGH $SUDO: sudo's env_reset strips exported variables, so a
+    # env goes THROUGH sudo: sudo's env_reset strips exported variables, so a
     # plain export upstream never reaches dpkg — debconf (e.g. tzdata on focal,
     # which the base image doesn't preinstall) then blocks on an interactive
     # prompt and the bootstrap hangs.
-    $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends $apt_retry "$@"
+    _run env DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends $apt_retry "$@"
 }
 
 # `--allowerasing` lets dnf pick our `curl` over the slimmer `curl-minimal`
@@ -142,13 +168,15 @@ apt_install() {
 dnf_install() {
     [ "$#" -gt 0 ] || return 0
     if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
-    $SUDO dnf -y install --allowerasing --skip-broken "$@"
+    if [ "$DRY_RUN" = 1 ]; then set -- $(_missing_only "$@"); [ "$#" -gt 0 ] || return 0; fi
+    _run dnf -y install --allowerasing --skip-broken "$@"
 }
 
 yum_install() {
     [ "$#" -gt 0 ] || return 0
     if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
-    $SUDO yum -y install --skip-broken "$@"
+    if [ "$DRY_RUN" = 1 ]; then set -- $(_missing_only "$@"); [ "$#" -gt 0 ] || return 0; fi
+    _run yum -y install --skip-broken "$@"
 }
 
 # tdnf has no --skip-broken and aborts the whole transaction if any single
@@ -158,8 +186,10 @@ yum_install() {
 tdnf_install() {
     [ "$#" -gt 0 ] || return 0
     if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
+    if [ "$DRY_RUN" = 1 ]; then set -- $(_missing_only "$@"); fi
     local pkg
     for pkg in "$@"; do
+        if [ "$DRY_RUN" = 1 ]; then _run tdnf -y install "$pkg"; continue; fi
         if ! $SUDO tdnf -y install "$pkg" >/dev/null 2>&1; then
             echo "pm.sh: tdnf skipped unavailable package '$pkg'"
         fi
@@ -169,7 +199,8 @@ tdnf_install() {
 apk_install() {
     [ "$#" -gt 0 ] || return 0
     if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
-    $SUDO apk add --no-cache "$@"
+    if [ "$DRY_RUN" = 1 ]; then set -- $(_missing_only "$@"); [ "$#" -gt 0 ] || return 0; fi
+    _run apk add --no-cache "$@"
 }
 
 # brew exits non-zero when a formula is already installed/linked. We tolerate
@@ -178,6 +209,7 @@ apk_install() {
 brew_install() {
     [ "$#" -gt 0 ] || return 0
     if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
+    if [ "$DRY_RUN" = 1 ]; then set -- $(_missing_only "$@"); [ "$#" -gt 0 ] || return 0; _run brew install "$@"; return 0; fi
     if ! command -v brew >/dev/null 2>&1; then
         echo "pm.sh: brew not installed; install from https://brew.sh" >&2
         exit 1

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -102,6 +102,17 @@ _run() {
     else ${_SUDO_DISPLAY:-$SUDO} "$@"; fi
 }
 
+# _sh 'RAW SHELL' — a mutating step that doesn't fit _run (pipes, redirects,
+# cd/&&-chains, source builds). dry-run: print it verbatim so the output stays a
+# copy-pasteable script; list: skip; else: execute via eval. Write the string
+# with a literal `sudo` (these raw steps are Linux-only, where bootstrap ensures
+# sudo) so the printed line runs as-is.
+_sh() {
+    if [ "$DRY_RUN" = 1 ]; then _dry_line "$1"
+    elif [ "$CHECK_DEPS" = 1 ]; then return 0
+    else eval "$1"; fi
+}
+
 # Echo (space-separated) only the packages from "$@" that are NOT installed.
 _missing_only() { for _p in "$@"; do _pkg_installed "$_p" || printf '%s ' "$_p"; done; }
 
@@ -241,10 +252,14 @@ debian_default_install() {
 }
 
 rhel_default_install() {
-    case "$PM" in
-        dnf) $SUDO dnf -y groupinstall "Development Tools" || true ;;
-        yum) $SUDO yum -y groupinstall "Development Tools" || true ;;
-    esac
+    # "Development Tools" is a large meta-group; skip it once the core compiler
+    # trio is present so re-runs / dry-run don't keep re-listing it.
+    if ! rpm -q gcc gcc-c++ make >/dev/null 2>&1; then
+        case "$PM" in
+            dnf) _sh 'sudo dnf -y groupinstall "Development Tools" || true' ;;
+            yum) _sh 'sudo yum -y groupinstall "Development Tools" || true' ;;
+        esac
+    fi
     case "$PM" in
         dnf) dnf_install $RHEL_BASE ;;
         yum) yum_install $RHEL_BASE ;;
@@ -271,14 +286,20 @@ _pm_enable_el8_extras() {
         # shellcheck disable=SC1091
         . /etc/os-release
         if [ "${ID:-}" = "rhel" ] && [ "${VERSION_ID%%.*}" = "8" ]; then
-            local rid
-            rid=$(dnf repolist --all 2>/dev/null \
+            # `local rid=$(...)` (single line) is intentional: the `local`
+            # builtin returns its own exit status (always 0), which masks
+            # the pipeline's pipefail-propagated grep exit when no repo
+            # matches. Splitting into `local rid; rid=$(...)` makes the
+            # assignment a simple command and set -e aborts install_script.sh
+            # before the diagnostic below can run.
+            local rid=$(dnf repolist --all 2>/dev/null \
                 | grep -i 'codeready-builder-for-rhel-8' \
                 | grep -vi source \
                 | head -1 \
                 | awk '{print $1}')
             if [ -n "$rid" ]; then
-                $SUDO dnf config-manager --set-enabled "$rid"
+                dnf repolist --enabled 2>/dev/null | grep -q "$rid" \
+                    || _run dnf config-manager --set-enabled "$rid"
                 return 0
             fi
             echo "pm.sh: RHEL 8 needs CodeReady Builder; no codeready-builder-for-rhel-8 repo found." >&2
@@ -286,9 +307,9 @@ _pm_enable_el8_extras() {
             return 1
         fi
     fi
-    $SUDO dnf config-manager --set-enabled powertools 2>/dev/null \
-        || $SUDO dnf config-manager --set-enabled crb 2>/dev/null \
-        || true
+    # Skip if a secondary repo (powertools/crb/codeready) is already enabled.
+    dnf repolist --enabled 2>/dev/null | grep -qiE 'powertools|crb|codeready' \
+        || _sh 'sudo dnf config-manager --set-enabled powertools 2>/dev/null || sudo dnf config-manager --set-enabled crb 2>/dev/null || true'
 }
 
 # EL8 (Alma 8, Rocky 8, RHEL 8): base-RHEL gcc is 8.5; we layer gcc-toolset-11
@@ -300,23 +321,26 @@ _pm_enable_el8_extras() {
 # download its own 3.12, then psutil's wheel-less aarch64 source build would
 # fail looking for Python.h that matches the wrong interpreter.
 el8_default_install() {
-    $SUDO dnf -y install epel-release
-    # Hard-fail: without codeready-builder, libatomic-devel (and other -devel
-    # pkgs) won't resolve in the dnf_install below, leaving a half-installed
-    # toolchain and a confusing "no package" error several steps later.
-    _pm_enable_el8_extras || exit 1
+    rpm -q epel-release >/dev/null 2>&1 || _run dnf -y install epel-release
+    _pm_enable_el8_extras
     rhel_default_install
     dnf_install \
         gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ gcc-toolset-11-libatomic-devel \
         python3.11 python3.11-devel python3.11-pip xz
-    $SUDO cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh 2>/dev/null || true
-    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/gcc  /usr/local/bin/gcc  || true
-    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/g++  /usr/local/bin/g++  || true
-    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/cc   /usr/local/bin/cc   || true
-    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/as   /usr/local/bin/as   || true
-    $SUDO ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/make /usr/local/bin/make || true
-    $SUDO update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 2000000
-    $SUDO update-alternatives --set python3 /usr/bin/python3.11
+    # Symlink the toolset compiler into /usr/local/bin — skip once gcc already points there.
+    if [ "$(readlink -f /usr/local/bin/gcc 2>/dev/null)" != /opt/rh/gcc-toolset-11/root/usr/bin/gcc ]; then
+        _run cp /opt/rh/gcc-toolset-11/enable /etc/profile.d/gcc-toolset-11.sh 2>/dev/null || true
+        _run ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/gcc  /usr/local/bin/gcc  || true
+        _run ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/g++  /usr/local/bin/g++  || true
+        _run ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/cc   /usr/local/bin/cc   || true
+        _run ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/as   /usr/local/bin/as   || true
+        _run ln -sf /opt/rh/gcc-toolset-11/root/usr/bin/make /usr/local/bin/make || true
+    fi
+    # Point python3 at 3.11 — skip once it already is.
+    if ! python3 --version 2>/dev/null | grep -q '3\.11'; then
+        _run update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 2000000
+        _run update-alternatives --set python3 /usr/bin/python3.11
+    fi
     export SETUP_PYTHON_VERSION="${SETUP_PYTHON_VERSION:-3.11}"
 }
 
@@ -326,10 +350,13 @@ el9_default_install() {
     rhel_default_install
     dnf_install \
         gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ gcc-toolset-13-libatomic-devel
-    $SUDO cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh 2>/dev/null || true
-    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/gcc  /usr/local/bin/gcc  || true
-    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/g++  /usr/local/bin/g++  || true
-    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/cc   /usr/local/bin/cc   || true
-    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/as   /usr/local/bin/as   || true
-    $SUDO ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/make /usr/local/bin/make || true
+    # Symlink the toolset compiler into /usr/local/bin — skip once gcc already points there.
+    if [ "$(readlink -f /usr/local/bin/gcc 2>/dev/null)" != /opt/rh/gcc-toolset-13/root/usr/bin/gcc ]; then
+        _run cp /opt/rh/gcc-toolset-13/enable /etc/profile.d/gcc-toolset-13.sh 2>/dev/null || true
+        _run ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/gcc  /usr/local/bin/gcc  || true
+        _run ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/g++  /usr/local/bin/g++  || true
+        _run ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/cc   /usr/local/bin/cc   || true
+        _run ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/as   /usr/local/bin/as   || true
+        _run ln -sf /opt/rh/gcc-toolset-13/root/usr/bin/make /usr/local/bin/make || true
+    fi
 }

--- a/.install/lib/pm.sh
+++ b/.install/lib/pm.sh
@@ -86,16 +86,16 @@ if [ "$CHECK_DEPS" = 1 ] || [ "$DRY_RUN" = 1 ]; then
     SUDO=":"                # neutralize privileged side-commands (no mutation)
 fi
 
-# dry-run output is blue on a real terminal, plain when piped (CI logs).
-if [ "$DRY_RUN" = 1 ] && [ -t 1 ]; then _DRY_C="$(printf '\033[1;34m')"; _DRY_R="$(printf '\033[0m')"; else _DRY_C=""; _DRY_R=""; fi
-_dry_line() { printf '%s%s%s\n' "$_DRY_C" "$*" "$_DRY_R"; }
+# dry-run colors (on a real terminal; plain when piped, e.g. CI logs):
+#   commands  -> blue     headlines (==> lines) -> cyan, so they're distinct.
+if [ "$DRY_RUN" = 1 ] && [ -t 1 ]; then
+    _DRY_C="$(printf '\033[0;34m')"; _DRY_H="$(printf '\033[1;36m')"; _DRY_R="$(printf '\033[0m')"
+else _DRY_C=""; _DRY_H=""; _DRY_R=""; fi
+_dry_line() { printf '%s%s%s\n' "$_DRY_C" "$*" "$_DRY_R"; }   # a command  (blue)
+_dry_head() { printf '%s%s%s\n' "$_DRY_H" "$*" "$_DRY_R"; }   # a headline (cyan)
 
-# _run CMD... — one wrapper for every "would-install" command, so callers
-# never branch on the mode:
-#   install  -> execute it (with the real sudo prefix)
-#   dry-run  -> print it (blue), don't execute
-#   list     -> skip it (a check neither installs nor prints)
-# The printed and the executed command are literally the same line.
+# _run CMD... — install: execute (real sudo prefix); dry-run: print (blue);
+# list: skip. Callers pre-filter to missing.
 _run() {
     if [ "$CHECK_DEPS" = 1 ]; then return 0
     elif [ "$DRY_RUN" = 1 ]; then _dry_line "${_SUDO_DISPLAY:+$_SUDO_DISPLAY }$*"
@@ -146,7 +146,6 @@ _pm_apt_updated=0
 apt_install() {
     [ "$#" -gt 0 ] || return 0
     if [ "$CHECK_DEPS" = 1 ]; then _check_pkgs "$@"; return 0; fi
-    if [ "$DRY_RUN" = 1 ]; then set -- $(_missing_only "$@"); [ "$#" -gt 0 ] || return 0; fi
     # Acquire::Retries: ports.ubuntu.com (arm64 mirror) intermittently drops
     # connections mid-build; without retries a single dropped fetch fails the
     # whole docker build (exit 100). Retry each download before giving up.

--- a/.install/lib/setup-python.sh
+++ b/.install/lib/setup-python.sh
@@ -32,6 +32,13 @@ if [ "${CHECK_DEPS:-0}" = 1 ]; then
     return 0 2>/dev/null || exit 0
 fi
 
+# dry-run: print the uv install command only if uv is missing; never touch the
+# venv/pip (creating it would be a real mutation).
+if [ "${DRY_RUN:-0}" = 1 ]; then
+    command -v uv >/dev/null 2>&1 || _dry_line "curl -LsSf https://astral.sh/uv/install.sh | sh   # uv (then: uv venv + uv pip install -r ...)"
+    return 0 2>/dev/null || exit 0
+fi
+
 if ! command -v uv >/dev/null 2>&1; then
     echo "==> [redisbloom] installing uv"
     curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/.install/lib/setup-python.sh
+++ b/.install/lib/setup-python.sh
@@ -15,16 +15,14 @@
 # Python.h against the wrong interpreter. Set this yourself before sourcing
 # the script if you need a non-default interpreter on another OS.
 
-# Required by callers — set by install_script.sh. Fail fast if absent rather
-# than producing a confusing `uv venv ""` failure later.
-: "${ROOT:?setup-python.sh: ROOT not set (must be sourced by install_script.sh)}"
-: "${HERE:?setup-python.sh: HERE not set (must be sourced by install_script.sh)}"
-
 # list mode: record uv presence like any other dep, install nothing.
 # uv installs to ~/.local/bin (or ~/.cargo/bin), which is not on PATH in the
 # non-login bootstrap subshell — detect it there too, not just via PATH.
 _have_uv() { command -v uv >/dev/null 2>&1 || [ -x "$HOME/.local/bin/uv" ] || [ -x "$HOME/.cargo/bin/uv" ]; }
 
+# list / dry-run are read-only dependency reports — they must run in EVERY
+# environment, so handle them BEFORE the ROOT/HERE asserts below (which only
+# guard the real venv+pip work).
 if [ "${CHECK_DEPS:-0}" = 1 ]; then
     # uv presence, routed through OPTIONAL_PKGS like any other dep.
     if _have_uv; then _uv=ok; else _uv=missing; fi
@@ -36,12 +34,30 @@ if [ "${CHECK_DEPS:-0}" = 1 ]; then
     return 0 2>/dev/null || exit 0
 fi
 
-# dry-run: print the uv install command only if uv is missing; never touch the
-# venv/pip (creating it would be a real mutation).
 if [ "${DRY_RUN:-0}" = 1 ]; then
-    _have_uv || _dry_line "curl -LsSf https://astral.sh/uv/install.sh | sh   # uv (then: uv venv + uv pip install -r ...)"
+    # Print the exact uv + venv + pip sequence bootstrap would run (nothing is
+    # executed) so dry-run output is a copy-pasteable script. Guarded on what's
+    # already present so a provisioned host prints only the gaps: uv install
+    # only if uv is missing; venv + pip only if the venv doesn't exist yet
+    # (mirrors the real `[ ! -d venv ]` guard below).
+    if [ ! -d "$ROOT/venv" ]; then
+        _have_uv || _dry_line "curl -LsSf https://astral.sh/uv/install.sh | sh"
+        # uv installs to ~/.local/bin (or ~/.cargo/bin), which may not be on
+        # PATH — export it so the uv commands below resolve when pasted, exactly
+        # as bootstrap does after installing uv.
+        _dry_line 'export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"'
+        _dry_line "uv venv \"$ROOT/venv\" --python \"${SETUP_PYTHON_VERSION:-3.12}\""
+        _dry_line "uv pip install --python \"$ROOT/venv/bin/python\" --upgrade pip wheel \"setuptools<81\""
+        _dry_line "uv pip install --python \"$ROOT/venv/bin/python\" -r \"$HERE/build_package_requirements.txt\""
+        [ -f "$ROOT/tests/flow/requirements.txt" ] && _dry_line "uv pip install --python \"$ROOT/venv/bin/python\" -r \"$ROOT/tests/flow/requirements.txt\""
+    fi
     return 0 2>/dev/null || exit 0
 fi
+
+# Required by callers — set by install_script.sh. Fail fast if absent rather
+# than producing a confusing `uv venv ""` failure later.
+: "${ROOT:?setup-python.sh: ROOT not set (must be sourced by install_script.sh)}"
+: "${HERE:?setup-python.sh: HERE not set (must be sourced by install_script.sh)}"
 
 if ! command -v uv >/dev/null 2>&1; then
     echo "==> [redisbloom] installing uv"

--- a/.install/lib/setup-python.sh
+++ b/.install/lib/setup-python.sh
@@ -20,6 +20,22 @@
 : "${ROOT:?setup-python.sh: ROOT not set (must be sourced by install_script.sh)}"
 : "${HERE:?setup-python.sh: HERE not set (must be sourced by install_script.sh)}"
 
+# check-deps mode: record uv presence like any other dep, install nothing.
+if [ "${CHECK_DEPS:-0}" = 1 ]; then
+    if command -v uv >/dev/null 2>&1; then DEPS_OK="$DEPS_OK uv"; else DEPS_MISSING="$DEPS_MISSING uv"; fi
+    return 0 2>/dev/null || exit 0
+fi
+
+# dry-run mode: print the python provisioning commands, install nothing.
+if [ "${DRY_RUN:-0}" = 1 ]; then
+    _dry_line python "curl -LsSf https://astral.sh/uv/install.sh | sh   # if uv is missing"
+    _dry_line python "uv venv $ROOT/venv --python \${SETUP_PYTHON_VERSION:-3.12}"
+    _dry_line python "uv pip install --upgrade pip wheel 'setuptools<81'"
+    _dry_line python "uv pip install -r $HERE/build_package_requirements.txt"
+    _dry_line python "uv pip install -r $ROOT/tests/flow/requirements.txt   # if present"
+    return 0 2>/dev/null || exit 0
+fi
+
 if ! command -v uv >/dev/null 2>&1; then
     echo "==> [redisbloom] installing uv"
     curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/.install/lib/setup-python.sh
+++ b/.install/lib/setup-python.sh
@@ -21,9 +21,13 @@
 : "${HERE:?setup-python.sh: HERE not set (must be sourced by install_script.sh)}"
 
 # list mode: record uv presence like any other dep, install nothing.
+# uv installs to ~/.local/bin (or ~/.cargo/bin), which is not on PATH in the
+# non-login bootstrap subshell — detect it there too, not just via PATH.
+_have_uv() { command -v uv >/dev/null 2>&1 || [ -x "$HOME/.local/bin/uv" ] || [ -x "$HOME/.cargo/bin/uv" ]; }
+
 if [ "${CHECK_DEPS:-0}" = 1 ]; then
     # uv presence, routed through OPTIONAL_PKGS like any other dep.
-    if command -v uv >/dev/null 2>&1; then _uv=ok; else _uv=missing; fi
+    if _have_uv; then _uv=ok; else _uv=missing; fi
     if _is_optional uv; then
         [ "$_uv" = ok ] && DEPS_OPT_OK="$DEPS_OPT_OK uv" || DEPS_OPT_MISSING="$DEPS_OPT_MISSING uv"
     else
@@ -35,7 +39,7 @@ fi
 # dry-run: print the uv install command only if uv is missing; never touch the
 # venv/pip (creating it would be a real mutation).
 if [ "${DRY_RUN:-0}" = 1 ]; then
-    command -v uv >/dev/null 2>&1 || _dry_line "curl -LsSf https://astral.sh/uv/install.sh | sh   # uv (then: uv venv + uv pip install -r ...)"
+    _have_uv || _dry_line "curl -LsSf https://astral.sh/uv/install.sh | sh   # uv (then: uv venv + uv pip install -r ...)"
     return 0 2>/dev/null || exit 0
 fi
 

--- a/.install/lib/setup-python.sh
+++ b/.install/lib/setup-python.sh
@@ -22,7 +22,13 @@
 
 # check-deps mode: record uv presence like any other dep, install nothing.
 if [ "${CHECK_DEPS:-0}" = 1 ]; then
-    if command -v uv >/dev/null 2>&1; then DEPS_OK="$DEPS_OK uv"; else DEPS_MISSING="$DEPS_MISSING uv"; fi
+    # uv presence, routed through OPTIONAL_PKGS like any other dep.
+    if command -v uv >/dev/null 2>&1; then _uv=ok; else _uv=missing; fi
+    if _is_optional uv; then
+        [ "$_uv" = ok ] && DEPS_OPT_OK="$DEPS_OPT_OK uv" || DEPS_OPT_MISSING="$DEPS_OPT_MISSING uv"
+    else
+        [ "$_uv" = ok ] && DEPS_OK="$DEPS_OK uv" || DEPS_MISSING="$DEPS_MISSING uv"
+    fi
     return 0 2>/dev/null || exit 0
 fi
 

--- a/.install/lib/setup-python.sh
+++ b/.install/lib/setup-python.sh
@@ -20,7 +20,7 @@
 : "${ROOT:?setup-python.sh: ROOT not set (must be sourced by install_script.sh)}"
 : "${HERE:?setup-python.sh: HERE not set (must be sourced by install_script.sh)}"
 
-# check-deps mode: record uv presence like any other dep, install nothing.
+# list mode: record uv presence like any other dep, install nothing.
 if [ "${CHECK_DEPS:-0}" = 1 ]; then
     # uv presence, routed through OPTIONAL_PKGS like any other dep.
     if command -v uv >/dev/null 2>&1; then _uv=ok; else _uv=missing; fi

--- a/.install/lib/setup-python.sh
+++ b/.install/lib/setup-python.sh
@@ -26,16 +26,6 @@ if [ "${CHECK_DEPS:-0}" = 1 ]; then
     return 0 2>/dev/null || exit 0
 fi
 
-# dry-run mode: print the python provisioning commands, install nothing.
-if [ "${DRY_RUN:-0}" = 1 ]; then
-    _dry_line python "curl -LsSf https://astral.sh/uv/install.sh | sh   # if uv is missing"
-    _dry_line python "uv venv $ROOT/venv --python \${SETUP_PYTHON_VERSION:-3.12}"
-    _dry_line python "uv pip install --upgrade pip wheel 'setuptools<81'"
-    _dry_line python "uv pip install -r $HERE/build_package_requirements.txt"
-    _dry_line python "uv pip install -r $ROOT/tests/flow/requirements.txt   # if present"
-    return 0 2>/dev/null || exit 0
-fi
-
 if ! command -v uv >/dev/null 2>&1; then
     echo "==> [redisbloom] installing uv"
     curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/.install/os/amazonlinux2.sh
+++ b/.install/os/amazonlinux2.sh
@@ -14,21 +14,34 @@
 # shellcheck source=../lib/packages.sh
 . "$LIB/packages.sh"
 
-$SUDO amazon-linux-extras install epel -y
-$SUDO yum -y install epel-release yum-utils
-$SUDO yum-config-manager --add-repo http://vault.centos.org/centos/7/sclo/x86_64/rh/
+# EPEL (jq, lcov, …) — enable only if epel-release isn't already installed.
+rpm -q epel-release >/dev/null 2>&1 || _run amazon-linux-extras install epel -y
+yum_install epel-release yum-utils
+# autogen + cmake3 are arch-independent (base / EPEL, incl. aarch64).
+yum_install autogen cmake3
 
-yum_install autogen centos-release-scl scl-utils cmake3
-$SUDO yum -y install --nogpgcheck --skip-broken \
-    devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make || true
+# SCL / devtoolset-11 provide a modern gcc — but the CentOS Vault SCL repo is
+# x86_64-only, so on aarch64 there is no devtoolset (the base gcc is used).
+# Gate the whole SCL path on x86_64 so it isn't listed as a forever-unresolvable
+# step on arm (where centos-release-scl / devtoolset-11 can never install).
+if [ "$(uname -m)" = "x86_64" ]; then
+    ls /etc/yum.repos.d/*sclo*.repo >/dev/null 2>&1 || _run yum-config-manager --add-repo http://vault.centos.org/centos/7/sclo/x86_64/rh/
+    yum_install centos-release-scl scl-utils
+    [ -d /opt/rh/devtoolset-11 ] || _run yum -y install --nogpgcheck --skip-broken \
+        devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make || true
+fi
 
 rhel_default_install
-$SUDO ln -sf "$(command -v cmake3)" /usr/bin/cmake
-if [ -f /opt/rh/devtoolset-11/root/usr/bin/gcc ]; then
-    $SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/make /usr/local/bin/make
-    $SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/gcc /usr/local/bin/gcc
-    $SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/g++ /usr/local/bin/g++
-    $SUDO ln -sf /opt/rh/devtoolset-11/root/usr/bin/cc /usr/local/bin/cc
+# Point /usr/bin/cmake at cmake3 (EPEL) unless cmake is already >= 3. The path
+# is resolved at run time, so print the literal $(command -v …) via _sh.
+cmake --version 2>/dev/null | grep -qE 'version 3\.' || _sh 'sudo ln -sf "$(command -v cmake3)" /usr/bin/cmake'
+# devtoolset present but not yet symlinked into /usr/local/bin — skip once done.
+if [ -f /opt/rh/devtoolset-11/root/usr/bin/gcc ] && \
+   [ "$(readlink -f /usr/local/bin/gcc 2>/dev/null)" != /opt/rh/devtoolset-11/root/usr/bin/gcc ]; then
+    _run ln -sf /opt/rh/devtoolset-11/root/usr/bin/make /usr/local/bin/make
+    _run ln -sf /opt/rh/devtoolset-11/root/usr/bin/gcc /usr/local/bin/gcc
+    _run ln -sf /opt/rh/devtoolset-11/root/usr/bin/g++ /usr/local/bin/g++
+    _run ln -sf /opt/rh/devtoolset-11/root/usr/bin/cc /usr/local/bin/cc
 fi
 
 # Install aws-cli for uploading artifacts to s3

--- a/.install/os/amazonlinux2.sh
+++ b/.install/os/amazonlinux2.sh
@@ -26,7 +26,11 @@ yum_install autogen cmake3
 # step on arm (where centos-release-scl / devtoolset-11 can never install).
 if [ "$(uname -m)" = "x86_64" ]; then
     ls /etc/yum.repos.d/*sclo*.repo >/dev/null 2>&1 || _run yum-config-manager --add-repo http://vault.centos.org/centos/7/sclo/x86_64/rh/
-    yum_install centos-release-scl scl-utils
+    # centos-release-scl is a CentOS package (absent from Amazon Linux 2 repos,
+    # and CentOS 7's SCL vault is EOL) — and redundant here: the SCL repo is
+    # added directly above and devtoolset installs with --nogpgcheck. Only
+    # scl-utils is needed (present in amzn2 base).
+    yum_install scl-utils
     [ -d /opt/rh/devtoolset-11 ] || _run yum -y install --nogpgcheck --skip-broken \
         devtoolset-11-gcc devtoolset-11-gcc-c++ devtoolset-11-make || true
 fi

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -43,9 +43,9 @@ fi
 # cmake 3.28 from source (apt ships 3.10) — only when the installed cmake is
 # older. Each step prints in dry-run; skipped entirely once cmake is new enough.
 if ! cmake --version 2>/dev/null | grep -qE 'cmake version 3\.(2[89]|[3-9][0-9])'; then
-    _sh 'cd /tmp && wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz && tar -xzf cmake-3.28.0.tar.gz'
-    _sh 'cd /tmp/cmake-3.28.0 && ./configure && make -j"$(nproc)" && sudo make install'
-    _sh 'cd / && rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz && sudo ln -sf /usr/local/bin/cmake /usr/bin/cmake'
+    _sh '(cd /tmp && wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz && tar -xzf cmake-3.28.0.tar.gz)'
+    _sh '(cd /tmp/cmake-3.28.0 && ./configure && make -j"$(nproc)" && sudo make install)'
+    _sh 'rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz && sudo ln -sf /usr/local/bin/cmake /usr/bin/cmake'
 fi
 # dataclasses backport (Python 3.6 lacks it) — skip if already importable.
 if ! python3 -c 'import dataclasses' >/dev/null 2>&1; then

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -56,6 +56,8 @@ if [ "$CHECK_DEPS" != 1 ] && [ "$DRY_RUN" != 1 ]; then
     fi
     pip3 install dataclasses
 elif [ "$DRY_RUN" = 1 ]; then
-    _dry_line "build cmake 3.28 from source (if cmake < 3.28), then \$SUDO make install"
+    if ! cmake --version 2>/dev/null | grep -qE 'cmake version 3\.(2[89]|[3-9][0-9])'; then
+        _dry_line "build cmake 3.28 from source, then \$SUDO make install"
+    fi
     _dry_line "pip3 install dataclasses"
 fi

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -1,26 +1,27 @@
 #!/usr/bin/env bash
 # Ubuntu 18.04 (bionic). cmake 3.28 built from source — apt cmake is 3.10.
-# gcc-10 via toolchain-r PPA; || true so launchpad failures are non-fatal
-# (ESM repos already carry gcc-10 on Ubuntu Pro machines).
+# gcc-10 via toolchain-r PPA. Every step is guarded on what's already present,
+# so `make bootstrap` is idempotent (a second run is a near-no-op) and `dry-run`
+# prints only the commands still needed — never a step whose target exists.
 
 # shellcheck source=../lib/packages.sh
 . "$LIB/packages.sh"
 
 export DEBIAN_FRONTEND=noninteractive
+# debconf pre-seed (suppresses tzdata prompts). Idempotent apt prep, not a dep —
+# apt_install also carries DEBIAN_FRONTEND=noninteractive, so keep it silent.
 echo 'debconf debconf/frontend select Noninteractive' | $SUDO debconf-set-selections 2>/dev/null || true
 echo 'tzdata tzdata/Areas select Etc' | $SUDO debconf-set-selections 2>/dev/null || true
 echo 'tzdata tzdata/Zones/Etc select UTC' | $SUDO debconf-set-selections 2>/dev/null || true
-# apt_install (not a raw apt-get call) so this runs apt-get update first —
-# on a fresh base image with no apt index yet, a raw "apt-get install"
-# here can fail silently and leave gnupg/wget missing for the next step.
 apt_install gnupg wget curl ca-certificates
-# keyserver fetches are raw network — skip during a check/dry-run.
-if [ "$CHECK_DEPS" != 1 ] && [ "$DRY_RUN" != 1 ]; then
-    wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg || true
-    wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r-2.gpg || true
+# gcc-10 comes from the ubuntu-toolchain-r PPA. Only add the PPA when gcc-10
+# isn't installed yet — so a re-run / dry-run on a provisioned host skips it.
+if ! dpkg-query -W -f='${Status}' gcc-10 2>/dev/null | grep -q 'ok installed'; then
+    _sh 'wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | sudo gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg || true'
+    _sh 'wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5" | sudo gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r-2.gpg || true'
+    _sh 'echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | sudo tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list'
+    _run apt-get update -qq
 fi
-echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list
-$SUDO apt-get update -qq
 apt_install software-properties-common lsb-core binfmt-support cargo zlib1g-dev
 debian_default_install
 apt_install gcc-10 g++-10
@@ -31,33 +32,22 @@ if [ "$_cur" -lt 10 ]; then
     # cc/gcc/g++ are each registered as their own independent master by
     # debian_default_install, not slaves of each other — --slave-grouping
     # would conflict with that.
-    $SUDO update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 60
-    $SUDO update-alternatives --set     cc  /usr/bin/gcc-10
-    $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
-    $SUDO update-alternatives --set     gcc /usr/bin/gcc-10
-    $SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60
-    $SUDO update-alternatives --set     g++ /usr/bin/g++-10
+    _run update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 60
+    _run update-alternatives --set     cc  /usr/bin/gcc-10
+    _run update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
+    _run update-alternatives --set     gcc /usr/bin/gcc-10
+    _run update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60
+    _run update-alternatives --set     g++ /usr/bin/g++-10
 fi
 
-# cmake-from-source + pip3 are raw (bypass the *_install primitives) — they'd
-# compile/install for real under list/dry-run, so gate them. dry-run prints them.
-if [ "$CHECK_DEPS" != 1 ] && [ "$DRY_RUN" != 1 ]; then
-    if ! cmake --version 2>/dev/null | grep -qE 'cmake version 3\.(2[89]|[3-9][0-9])'; then
-        cd /tmp
-        wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
-        tar -xzf cmake-3.28.0.tar.gz
-        cd cmake-3.28.0
-        ./configure
-        make -j"$(nproc)"
-        $SUDO make install
-        cd /
-        rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz
-        $SUDO ln -sf /usr/local/bin/cmake /usr/bin/cmake
-    fi
-    pip3 install dataclasses
-elif [ "$DRY_RUN" = 1 ]; then
-    if ! cmake --version 2>/dev/null | grep -qE 'cmake version 3\.(2[89]|[3-9][0-9])'; then
-        _dry_line "build cmake 3.28 from source, then \$SUDO make install"
-    fi
-    _dry_line "pip3 install dataclasses"
+# cmake 3.28 from source (apt ships 3.10) — only when the installed cmake is
+# older. Each step prints in dry-run; skipped entirely once cmake is new enough.
+if ! cmake --version 2>/dev/null | grep -qE 'cmake version 3\.(2[89]|[3-9][0-9])'; then
+    _sh 'cd /tmp && wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz && tar -xzf cmake-3.28.0.tar.gz'
+    _sh 'cd /tmp/cmake-3.28.0 && ./configure && make -j"$(nproc)" && sudo make install'
+    _sh 'cd / && rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz && sudo ln -sf /usr/local/bin/cmake /usr/bin/cmake'
+fi
+# dataclasses backport (Python 3.6 lacks it) — skip if already importable.
+if ! python3 -c 'import dataclasses' >/dev/null 2>&1; then
+    _sh 'pip3 install dataclasses'
 fi

--- a/.install/os/bionic.sh
+++ b/.install/os/bionic.sh
@@ -14,8 +14,11 @@ echo 'tzdata tzdata/Zones/Etc select UTC' | $SUDO debconf-set-selections 2>/dev/
 # on a fresh base image with no apt index yet, a raw "apt-get install"
 # here can fail silently and leave gnupg/wget missing for the next step.
 apt_install gnupg wget curl ca-certificates
-wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg || true
-wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r-2.gpg || true
+# keyserver fetches are raw network — skip during a check/dry-run.
+if [ "$CHECK_DEPS" != 1 ] && [ "$DRY_RUN" != 1 ]; then
+    wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x1E9377A2BA9EF27F" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r.gpg || true
+    wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2C277A0A352154E5" | $SUDO gpg --batch --no-tty --yes --dearmor -o /etc/apt/trusted.gpg.d/ubuntu-toolchain-r-2.gpg || true
+fi
 echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main" | $SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list
 $SUDO apt-get update -qq
 apt_install software-properties-common lsb-core binfmt-support cargo zlib1g-dev
@@ -23,7 +26,7 @@ debian_default_install
 apt_install gcc-10 g++-10
 # Only move the active compiler up, never down — another module's bootstrap
 # may have already pinned something newer in this shared build container.
-_cur=$(gcc -dumpversion | cut -d. -f1)
+_cur=$(gcc -dumpversion 2>/dev/null | cut -d. -f1 || echo 0)
 if [ "$_cur" -lt 10 ]; then
     # cc/gcc/g++ are each registered as their own independent master by
     # debian_default_install, not slaves of each other — --slave-grouping
@@ -36,17 +39,23 @@ if [ "$_cur" -lt 10 ]; then
     $SUDO update-alternatives --set     g++ /usr/bin/g++-10
 fi
 
-if ! cmake --version 2>/dev/null | grep -qE 'cmake version 3\.(2[89]|[3-9][0-9])'; then
-    cd /tmp
-    wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
-    tar -xzf cmake-3.28.0.tar.gz
-    cd cmake-3.28.0
-    ./configure
-    make -j"$(nproc)"
-    $SUDO make install
-    cd /
-    rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz
-    $SUDO ln -sf /usr/local/bin/cmake /usr/bin/cmake
+# cmake-from-source + pip3 are raw (bypass the *_install primitives) — they'd
+# compile/install for real under list/dry-run, so gate them. dry-run prints them.
+if [ "$CHECK_DEPS" != 1 ] && [ "$DRY_RUN" != 1 ]; then
+    if ! cmake --version 2>/dev/null | grep -qE 'cmake version 3\.(2[89]|[3-9][0-9])'; then
+        cd /tmp
+        wget -q https://cmake.org/files/v3.28/cmake-3.28.0.tar.gz
+        tar -xzf cmake-3.28.0.tar.gz
+        cd cmake-3.28.0
+        ./configure
+        make -j"$(nproc)"
+        $SUDO make install
+        cd /
+        rm -rf /tmp/cmake-3.28.0 /tmp/cmake-3.28.0.tar.gz
+        $SUDO ln -sf /usr/local/bin/cmake /usr/bin/cmake
+    fi
+    pip3 install dataclasses
+elif [ "$DRY_RUN" = 1 ]; then
+    _dry_line "build cmake 3.28 from source (if cmake < 3.28), then \$SUDO make install"
+    _dry_line "pip3 install dataclasses"
 fi
-
-pip3 install dataclasses

--- a/.install/os/bullseye.sh
+++ b/.install/os/bullseye.sh
@@ -12,9 +12,12 @@ debian_default_install
 # default (gcc-10 is bullseye's system gcc) — a fixed target, so every
 # module's bootstrap converges on the same state regardless of order or of
 # whatever newer side-by-side gcc another checkout installed.
-$SUDO update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 100
-$SUDO update-alternatives --set     cc  /usr/bin/gcc-10
-$SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
-$SUDO update-alternatives --set     gcc /usr/bin/gcc-10
-$SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
-$SUDO update-alternatives --set     g++ /usr/bin/g++-10
+# Skip once cc already resolves to gcc-10 (idempotent re-runs / dry-run).
+if [ "$(readlink -f /usr/bin/cc 2>/dev/null)" != /usr/bin/gcc-10 ]; then
+    _run update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 100
+    _run update-alternatives --set     cc  /usr/bin/gcc-10
+    _run update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
+    _run update-alternatives --set     gcc /usr/bin/gcc-10
+    _run update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
+    _run update-alternatives --set     g++ /usr/bin/g++-10
+fi

--- a/.install/os/focal.sh
+++ b/.install/os/focal.sh
@@ -11,10 +11,10 @@ apt_install gcc-10 g++-10
 # may have already pinned something newer in this shared build container.
 _cur=$(gcc -dumpversion 2>/dev/null | cut -d. -f1 || echo 0)
 if [ "$_cur" -lt 10 ]; then
-    $SUDO update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 60
-    $SUDO update-alternatives --set     cc  /usr/bin/gcc-10
-    $SUDO update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
-    $SUDO update-alternatives --set     gcc /usr/bin/gcc-10
-    $SUDO update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60
-    $SUDO update-alternatives --set     g++ /usr/bin/g++-10
+    _run update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 60
+    _run update-alternatives --set     cc  /usr/bin/gcc-10
+    _run update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
+    _run update-alternatives --set     gcc /usr/bin/gcc-10
+    _run update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 60
+    _run update-alternatives --set     g++ /usr/bin/g++-10
 fi

--- a/.install/os/focal.sh
+++ b/.install/os/focal.sh
@@ -9,7 +9,7 @@ debian_default_install
 apt_install gcc-10 g++-10
 # Only move the active compiler up, never down — another module's bootstrap
 # may have already pinned something newer in this shared build container.
-_cur=$(gcc -dumpversion | cut -d. -f1)
+_cur=$(gcc -dumpversion 2>/dev/null | cut -d. -f1 || echo 0)
 if [ "$_cur" -lt 10 ]; then
     $SUDO update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-10 60
     $SUDO update-alternatives --set     cc  /usr/bin/gcc-10

--- a/.install/os/macos.sh
+++ b/.install/os/macos.sh
@@ -26,12 +26,10 @@ fi
 
 brew_default_install
 
-# python@3.11 only when the host has no python3 (see header). Honor the
-# non-installing modes: print under dry-run, skip under check-deps.
+# python@3.11 only when the host has no python3 (see header). Skip under
+# check-deps.
 if ! command -v python3 >/dev/null 2>&1; then
-    if [ "${DRY_RUN:-0}" = 1 ]; then
-        _dry "brew install python@3.11"
-    elif [ "${CHECK_DEPS:-0}" != 1 ]; then
+    if [ "${CHECK_DEPS:-0}" != 1 ]; then
         echo "==> [redisbloom] python3 not on PATH; installing brew python@3.11"
         HOMEBREW_NO_AUTO_UPDATE=1 brew install python@3.11
     fi
@@ -54,11 +52,9 @@ update_profile() {
 }
 
 # PATH munging writes to the user's shell profiles — a mutation. It must NOT
-# run in check-deps mode, and must only be PRINTED (not run) under dry-run.
+# run in check-deps mode.
 if [ "${CHECK_DEPS:-0}" = 1 ]; then
     :   # read-only check: leave shell profiles untouched
-elif [ "${DRY_RUN:-0}" = 1 ]; then
-    _dry_line macos "append to ~/.bash_profile and ~/.zshrc:  $NEWPATH"
 else
     [ -f "$HOME/.bash_profile" ] && update_profile "$HOME/.bash_profile"
     [ -f "$HOME/.zshrc" ]        && update_profile "$HOME/.zshrc"

--- a/.install/os/macos.sh
+++ b/.install/os/macos.sh
@@ -26,9 +26,15 @@ fi
 
 brew_default_install
 
+# python@3.11 only when the host has no python3 (see header). Honor the
+# non-installing modes: print under dry-run, skip under check-deps.
 if ! command -v python3 >/dev/null 2>&1; then
-    echo "==> [redisbloom] python3 not on PATH; installing brew python@3.11"
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install python@3.11
+    if [ "${DRY_RUN:-0}" = 1 ]; then
+        _dry "brew install python@3.11"
+    elif [ "${CHECK_DEPS:-0}" != 1 ]; then
+        echo "==> [redisbloom] python3 not on PATH; installing brew python@3.11"
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install python@3.11
+    fi
 fi
 
 LLVM_VERSION="18"
@@ -36,17 +42,25 @@ BREW_PREFIX="$(brew --prefix)"
 GNUBIN="$BREW_PREFIX/opt/make/libexec/gnubin"
 LLVM="$BREW_PREFIX/opt/llvm@$LLVM_VERSION/bin"
 COREUTILS="$BREW_PREFIX/opt/coreutils/libexec/gnubin"
+NEWPATH="export PATH=$COREUTILS:$LLVM:$GNUBIN:\$PATH"
 
 update_profile() {
     local profile_path=$1
-    local newpath="export PATH=$COREUTILS:$LLVM:$GNUBIN:\$PATH"
-    grep -qxF "$newpath" "$profile_path" 2>/dev/null \
-        || printf '%s\n' "$newpath" >> "$profile_path"
+    grep -qxF "$NEWPATH" "$profile_path" 2>/dev/null \
+        || printf '%s\n' "$NEWPATH" >> "$profile_path"
     if [ -n "${GITHUB_PATH:-}" ]; then
-        printf '%s\n' "$newpath" >> "$GITHUB_PATH"
+        printf '%s\n' "$NEWPATH" >> "$GITHUB_PATH"
     fi
 }
 
-[ -f "$HOME/.bash_profile" ] && update_profile "$HOME/.bash_profile"
-[ -f "$HOME/.zshrc" ]        && update_profile "$HOME/.zshrc"
+# PATH munging writes to the user's shell profiles — a mutation. It must NOT
+# run in check-deps mode, and must only be PRINTED (not run) under dry-run.
+if [ "${CHECK_DEPS:-0}" = 1 ]; then
+    :   # read-only check: leave shell profiles untouched
+elif [ "${DRY_RUN:-0}" = 1 ]; then
+    _dry_line macos "append to ~/.bash_profile and ~/.zshrc:  $NEWPATH"
+else
+    [ -f "$HOME/.bash_profile" ] && update_profile "$HOME/.bash_profile"
+    [ -f "$HOME/.zshrc" ]        && update_profile "$HOME/.zshrc"
+fi
 true

--- a/.install/os/macos.sh
+++ b/.install/os/macos.sh
@@ -37,7 +37,7 @@ elif [ "${CHECK_DEPS:-0}" = 1 ]; then
 elif [ "${DRY_RUN:-0}" = 1 ]; then
     _dry_line "HOMEBREW_NO_AUTO_UPDATE=1 brew install python@3.11"
 else
-    HOMEBREW_NO_AUTO_UPDATE=1 _run brew install python@3.11
+    _run env HOMEBREW_NO_AUTO_UPDATE=1 brew install python@3.11
 fi
 
 LLVM_VERSION="18"

--- a/.install/os/macos.sh
+++ b/.install/os/macos.sh
@@ -27,7 +27,7 @@ fi
 brew_default_install
 
 # python@3.11 only when the host has no python3 (see header). Skip under
-# check-deps.
+# list.
 if ! command -v python3 >/dev/null 2>&1; then
     if [ "${CHECK_DEPS:-0}" != 1 ]; then
         echo "==> [redisbloom] python3 not on PATH; installing brew python@3.11"
@@ -52,7 +52,7 @@ update_profile() {
 }
 
 # PATH munging writes to the user's shell profiles — a mutation. It must NOT
-# run in check-deps mode.
+# run in list mode.
 if [ "${CHECK_DEPS:-0}" = 1 ]; then
     :   # read-only check: leave shell profiles untouched
 else

--- a/.install/os/macos.sh
+++ b/.install/os/macos.sh
@@ -26,13 +26,10 @@ fi
 
 brew_default_install
 
-# python@3.11 only when the host has no python3 (see header). Skip under
-# list.
+# python@3.11 only when the host has no python3 (see header). Skip under list;
+# print (don't run) under dry-run.
 if ! command -v python3 >/dev/null 2>&1; then
-    if [ "${CHECK_DEPS:-0}" != 1 ]; then
-        echo "==> [redisbloom] python3 not on PATH; installing brew python@3.11"
-        HOMEBREW_NO_AUTO_UPDATE=1 brew install python@3.11
-    fi
+    HOMEBREW_NO_AUTO_UPDATE=1 _run brew install python@3.11
 fi
 
 LLVM_VERSION="18"
@@ -51,11 +48,9 @@ update_profile() {
     fi
 }
 
-# PATH munging writes to the user's shell profiles — a mutation. It must NOT
-# run in list mode.
-if [ "${CHECK_DEPS:-0}" = 1 ]; then
-    :   # read-only check: leave shell profiles untouched
-else
+# PATH munging writes to the user's shell profiles — a mutation. Skip it in
+# list/dry-run mode.
+if [ "${CHECK_DEPS:-0}" != 1 ] && [ "${DRY_RUN:-0}" != 1 ]; then
     [ -f "$HOME/.bash_profile" ] && update_profile "$HOME/.bash_profile"
     [ -f "$HOME/.zshrc" ]        && update_profile "$HOME/.zshrc"
 fi

--- a/.install/os/macos.sh
+++ b/.install/os/macos.sh
@@ -45,21 +45,24 @@ BREW_PREFIX="$(brew --prefix)"
 GNUBIN="$BREW_PREFIX/opt/make/libexec/gnubin"
 LLVM="$BREW_PREFIX/opt/llvm@$LLVM_VERSION/bin"
 COREUTILS="$BREW_PREFIX/opt/coreutils/libexec/gnubin"
-NEWPATH="export PATH=$COREUTILS:$LLVM:$GNUBIN:\$PATH"
-
 update_profile() {
     local profile_path=$1
-    grep -qxF "$NEWPATH" "$profile_path" 2>/dev/null \
-        || printf '%s\n' "$NEWPATH" >> "$profile_path"
-    if [ -n "${GITHUB_PATH:-}" ]; then
-        printf '%s\n' "$NEWPATH" >> "$GITHUB_PATH"
-    fi
+    local newpath="export PATH=$COREUTILS:$LLVM:$GNUBIN:\$PATH"
+    grep -qxF "$newpath" "$profile_path" 2>/dev/null \
+        || printf '%s\n' "$newpath" >> "$profile_path"
 }
 
-# PATH munging writes to the user's shell profiles — a mutation. Skip it in
-# list/dry-run mode.
+# PATH munging writes to the user's shell profiles / $GITHUB_PATH — mutations.
+# Skip entirely in list/dry-run mode: neither may modify anything.
 if [ "${CHECK_DEPS:-0}" != 1 ] && [ "${DRY_RUN:-0}" != 1 ]; then
     [ -f "$HOME/.bash_profile" ] && update_profile "$HOME/.bash_profile"
     [ -f "$HOME/.zshrc" ]        && update_profile "$HOME/.zshrc"
+
+    # GitHub Actions: $GITHUB_PATH expects one directory per line (not an export
+    # statement). Writing the full `export PATH=...` line would add a single
+    # garbage entry to PATH instead of prepending the three directories.
+    if [ -n "${GITHUB_PATH:-}" ]; then
+        printf '%s\n%s\n%s\n' "$COREUTILS" "$LLVM" "$GNUBIN" >> "$GITHUB_PATH"
+    fi
 fi
 true

--- a/.install/os/macos.sh
+++ b/.install/os/macos.sh
@@ -28,7 +28,15 @@ brew_default_install
 
 # python@3.11 only when the host has no python3 (see header). Skip under list;
 # print (don't run) under dry-run.
-if ! command -v python3 >/dev/null 2>&1; then
+if command -v python3 >/dev/null 2>&1; then
+    # present — record for the list count (macOS python isn't in BREW_BASE)
+    if [ "${CHECK_DEPS:-0}" = 1 ]; then DEPS_OK="$DEPS_OK python@3.11"; fi
+elif [ "${CHECK_DEPS:-0}" = 1 ]; then
+    # list: record as missing so it matches dry-run and a real install
+    DEPS_MISSING="$DEPS_MISSING python@3.11"
+elif [ "${DRY_RUN:-0}" = 1 ]; then
+    _dry_line "HOMEBREW_NO_AUTO_UPDATE=1 brew install python@3.11"
+else
     HOMEBREW_NO_AUTO_UPDATE=1 _run brew install python@3.11
 fi
 

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,17 @@ INSTALL_SCRIPT_MODE ?= $(if $(filter Linux,$(shell uname -s)),sudo,)
 bootstrap:
 ifeq ($(filter list,$(MAKECMDGOALS)),list)
 	@cd $(ROOT)/.install && CHECK_DEPS=1 ./install_script.sh $(INSTALL_SCRIPT_MODE)
+else ifeq ($(filter dry-run,$(MAKECMDGOALS)),dry-run)
+	@cd $(ROOT)/.install && DRY_RUN=1 ./install_script.sh $(INSTALL_SCRIPT_MODE)
 else
 	@rm -rf $(ROOT)/venv
 	cd $(ROOT)/.install && ./install_script.sh $(INSTALL_SCRIPT_MODE)
 endif
 
 list: ; @:
+dry-run: ; @:
 
-.PHONY: bootstrap list
+.PHONY: bootstrap list dry-run
 
 else
 

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,6 @@ INSTALL_SCRIPT_MODE ?= $(if $(filter Linux,$(shell uname -s)),sudo,)
 bootstrap:
 ifeq ($(CHECK_DEPS),1)
 	@cd $(ROOT)/.install && CHECK_DEPS=1 ./install_script.sh $(INSTALL_SCRIPT_MODE)
-else ifeq ($(DRY_RUN),1)
-	@cd $(ROOT)/.install && DRY_RUN=1 ./install_script.sh $(INSTALL_SCRIPT_MODE)
 else
 	@rm -rf $(ROOT)/venv
 	cd $(ROOT)/.install && ./install_script.sh $(INSTALL_SCRIPT_MODE)

--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,16 @@ override ROOT:=$(shell cd $(ROOT) && pwd)
 INSTALL_SCRIPT_MODE ?= $(if $(filter Linux,$(shell uname -s)),sudo,)
 
 bootstrap:
-ifeq ($(CHECK_DEPS),1)
+ifeq ($(filter list,$(MAKECMDGOALS)),list)
 	@cd $(ROOT)/.install && CHECK_DEPS=1 ./install_script.sh $(INSTALL_SCRIPT_MODE)
 else
 	@rm -rf $(ROOT)/venv
 	cd $(ROOT)/.install && ./install_script.sh $(INSTALL_SCRIPT_MODE)
 endif
 
-.PHONY: bootstrap
+list: ; @:
+
+.PHONY: bootstrap list
 
 else
 

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,14 @@ override ROOT:=$(shell cd $(ROOT) && pwd)
 INSTALL_SCRIPT_MODE ?= $(if $(filter Linux,$(shell uname -s)),sudo,)
 
 bootstrap:
+ifeq ($(CHECK_DEPS),1)
+	@cd $(ROOT)/.install && CHECK_DEPS=1 ./install_script.sh $(INSTALL_SCRIPT_MODE)
+else ifeq ($(DRY_RUN),1)
+	@cd $(ROOT)/.install && DRY_RUN=1 ./install_script.sh $(INSTALL_SCRIPT_MODE)
+else
 	@rm -rf $(ROOT)/venv
 	cd $(ROOT)/.install && ./install_script.sh $(INSTALL_SCRIPT_MODE)
+endif
 
 .PHONY: bootstrap
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches all OS bootstrap paths and privileged install/repo/compiler wiring; mistakes could break fresh installs or mis-report deps, though list/dry-run are additive and normal `make bootstrap` behavior is intended to stay the same with safer re-runs.
> 
> **Overview**
> Adds **`make bootstrap list`** and **`make bootstrap dry-run`** so developers and CI can inspect bootstrap without installing packages or recreating `venv`.
> 
> **List mode** (`CHECK_DEPS=1`) probes installed packages per PM, splits **required** vs **optional** deps (`OPTIONAL_PKGS`), supports optional version floors (`MIN_VERSIONS`), and can append machine-readable lines to `DEPS_REPORT_FILE` for multi-module aggregation. It exits non-zero only when required deps are missing.
> 
> **Dry-run** prints copy-pasteable install commands for gaps only (via `_run` / `_sh`), including apt `DEBIAN_FRONTEND` and stdin redirects for pkg managers. **Real bootstrap** is unchanged except OS scripts are more **idempotent** (skip PPA/repo/toolset/symlink steps when already satisfied) and EL8 avoids false `python3` missing checks via `RHEL_PYTHON`.
> 
> Also: root containers without `sudo` get a pass-through `sudo` function; `install_aws_cli` and macOS profile/`GITHUB_PATH` updates are suppressed in list/dry-run; gcc toolset wiring won’t downgrade a newer compiler another module installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d052e343b132ae465398863dbc5843d374a8b434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->