### PR TITLE
MOD-13409 Harden RDB loading (backport to 8.6)

### DIFF
--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -1367,12 +1367,15 @@ static void *CFRdbLoad(RedisModuleIO *io, int encver) {
     bool err = false;
     CuckooFilter *cf = RedisModule_Calloc(1, sizeof(*cf));
     errdefer(err, CuckooFilter_Free(cf));
-    cf->numFilters = LoadUnsigned_IOError(io, err, NULL);
-    cf->numBuckets = LoadUnsigned_IOError(io, err, NULL);
-    if (cf->numFilters == 0 || cf->numBuckets == 0) {
+    const uint64_t numFilters64 = LoadUnsigned_IOError(io, err, NULL);
+    const uint64_t numBuckets64 = LoadUnsigned_IOError(io, err, NULL);
+    if (unlikely(numFilters64 == 0) || unlikely(numFilters64 > UINT16_MAX) ||
+        unlikely(numBuckets64 == 0) || unlikely(numBuckets64 > CF_MAX_NUM_BUCKETS)) {
         err = true;
         return NULL;
     }
+    cf->numFilters = (uint16_t)numFilters64;
+    cf->numBuckets = numBuckets64;
     cf->numItems = LoadUnsigned_IOError(io, err, NULL);
     if (encver < CF_MIN_EXPANSION_VERSION) { // CF_ENCODING_VERSION when added
         cf->numDeletes = 0;                  // Didn't exist earlier. bug fix
@@ -1381,9 +1384,22 @@ static void *CFRdbLoad(RedisModuleIO *io, int encver) {
         cf->expansion = rm_config.cf_expansion_factor.value;
     } else {
         cf->numDeletes = LoadUnsigned_IOError(io, err, NULL);
-        cf->bucketSize = LoadUnsigned_IOError(io, err, NULL);
-        cf->maxIterations = LoadUnsigned_IOError(io, err, NULL);
-        cf->expansion = LoadUnsigned_IOError(io, err, NULL);
+        const uint64_t bucketSize64 = LoadUnsigned_IOError(io, err, NULL);
+        const uint64_t maxIterations64 = LoadUnsigned_IOError(io, err, NULL);
+        const uint64_t expansion64 = LoadUnsigned_IOError(io, err, NULL);
+        if (unlikely(bucketSize64 > UINT16_MAX) || unlikely(maxIterations64 > UINT16_MAX) ||
+            unlikely(expansion64 > UINT16_MAX)) {
+            err = true;
+            return NULL;
+        }
+        cf->bucketSize = (uint16_t)bucketSize64;
+        cf->maxIterations = (uint16_t)maxIterations64;
+        cf->expansion = (uint16_t)expansion64;
+    }
+
+    if (CuckooFilter_ValidateIntegrity(cf) != 0) {
+        err = true;
+        return NULL;
     }
 
     cf->filters = RedisModule_Calloc(cf->numFilters, sizeof *cf->filters);
@@ -1393,13 +1409,33 @@ static void *CFRdbLoad(RedisModuleIO *io, int encver) {
         if (encver < CF_MIN_EXPANSION_VERSION) {
             filter->numBuckets = cf->numBuckets;
         } else {
-            filter->numBuckets = LoadUnsigned_IOError(io, err, NULL);
+            const uint64_t subNumBuckets = LoadUnsigned_IOError(io, err, NULL);
+            // `SubCF::numBuckets` is 56 bits; reject values that would truncate.
+            if (unlikely(subNumBuckets == 0) || unlikely(subNumBuckets > CF_MAX_NUM_BUCKETS) ||
+                unlikely((subNumBuckets & (subNumBuckets - 1)) != 0)) {
+                err = true;
+                return NULL;
+            }
+            filter->numBuckets = subNumBuckets;
         }
 
         size_t len = 0;
         filter->data = (MyCuckooBucket *)LoadStringBuffer_IOError(io, &len, err, NULL);
-        assert(filter->data);
-        assert(len == sizeof *filter->data * filter->bucketSize * filter->numBuckets);
+        if (unlikely(filter->data == NULL)) {
+            err = true;
+            return NULL;
+        }
+        if (unlikely(filter->bucketSize == 0) || unlikely(filter->numBuckets == 0) ||
+            unlikely(filter->bucketSize > SIZE_MAX / (size_t)filter->numBuckets)) {
+            err = true;
+            return NULL;
+        }
+        const size_t expected_len =
+            sizeof *filter->data * (size_t)filter->bucketSize * (size_t)filter->numBuckets;
+        if (unlikely(len != expected_len)) {
+            err = true;
+            return NULL;
+        }
     }
     return cf;
 }

--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -1366,7 +1366,7 @@ static void *CFRdbLoad(RedisModuleIO *io, int encver) {
 
     bool err = false;
     CuckooFilter *cf = RedisModule_Calloc(1, sizeof(*cf));
-    errdefer(err, CuckooFilter_Free(cf));
+    errdefer(err, CFFree(cf));
     const uint64_t numFilters64 = LoadUnsigned_IOError(io, err, NULL);
     const uint64_t numBuckets64 = LoadUnsigned_IOError(io, err, NULL);
     if (unlikely(numFilters64 == 0) || unlikely(numFilters64 > UINT16_MAX) ||

--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -1253,13 +1253,38 @@ static void *BFRdbLoad(RedisModuleIO *io, int encver) {
         }
         size_t sztmp;
         bm->bf = (unsigned char *)LoadStringBuffer_IOError(io, &sztmp, err, NULL);
-        // Validate that the buffer is at least large enough for the number of bits
-        // We need at least ceil(bits/8) bytes
-        if (sztmp < ceil(bm->bits / 8.0)) {
+        if (unlikely(bm->bf == NULL) || unlikely(sztmp == 0) ||
+            unlikely(sztmp > (UINT64_MAX / 8))) {
             err = true;
             return NULL;
         }
         bm->bytes = sztmp;
+        if (encver == 0) {
+            // Validate that the buffer is at least large enough for the number of bits.
+            // We need at least ceil(bits/8) bytes.
+            if (sztmp < ceil(bm->bits / 8.0)) {
+                err = true;
+                return NULL;
+            }
+        } else {
+            const uint64_t buf_bits = (uint64_t)sztmp * 8;
+            if (unlikely(bm->bits != buf_bits)) {
+                err = true;
+                return NULL;
+            }
+        }
+
+        if (unlikely(bm->n2 > 63)) {
+            err = true;
+            return NULL;
+        }
+        if (bm->n2 != 0) {
+            const uint64_t mod_bits = (1ULL << bm->n2);
+            if (unlikely(bm->bits < mod_bits)) {
+                err = true;
+                return NULL;
+            }
+        }
         if (bloom_validate_integrity(bm) != 0) {
             err = true;
             return NULL;

--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -914,7 +914,8 @@ void *TDigestRdbLoad(RedisModuleIO *rdb, int encver) {
 
     if (tdigest->merged_nodes < 0 || tdigest->unmerged_nodes < 0 ||
         tdigest->merged_nodes > allocated_cap || tdigest->unmerged_nodes > allocated_cap ||
-        tdigest->merged_nodes + tdigest->unmerged_nodes > allocated_cap) {
+        (int64_t)tdigest->merged_nodes + (int64_t)tdigest->unmerged_nodes >
+            (int64_t)allocated_cap) {
         err = true;
         return NULL;
     }

--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -17,6 +17,7 @@
 #include "common.h"
 
 #include <math.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <strings.h>
 #include <stdbool.h>
@@ -877,11 +878,27 @@ void *TDigestRdbLoad(RedisModuleIO *rdb, int encver) {
     const double compression = LoadDouble_IOError(rdb, err, NULL);
     td_histogram_t *tdigest = td_new(compression);
     errdefer(err, td_free(tdigest));
+    if (tdigest == NULL) {
+        err = true;
+        return NULL;
+    }
+    const int allocated_cap = tdigest->cap;
     tdigest->min = LoadDouble_IOError(rdb, err, NULL);
     tdigest->max = LoadDouble_IOError(rdb, err, NULL);
 
     // cap is the total size of nodes
-    tdigest->cap = LoadSigned_IOError(rdb, err, NULL);
+    const int64_t loaded_cap64 = LoadSigned_IOError(rdb, err, NULL);
+    if (loaded_cap64 <= 0 || loaded_cap64 > INT_MAX) {
+        err = true;
+        return NULL;
+    }
+    const int loaded_cap = (int)loaded_cap64;
+    // `td_new(compression)` allocates arrays sized to `allocated_cap`. Reject crafted payloads
+    // which attempt to desync `cap` from the allocated arrays.
+    if (loaded_cap != allocated_cap) {
+        err = true;
+        return NULL;
+    }
 
     // merged_nodes is the number of merged nodes at the front of nodes.
     tdigest->merged_nodes = LoadSigned_IOError(rdb, err, NULL);
@@ -895,7 +912,9 @@ void *TDigestRdbLoad(RedisModuleIO *rdb, int encver) {
     tdigest->merged_weight = LoadDouble_IOError(rdb, err, NULL);
     tdigest->unmerged_weight = LoadDouble_IOError(rdb, err, NULL);
 
-    if (tdigest->merged_nodes < 0 || tdigest->merged_nodes > tdigest->cap) {
+    if (tdigest->merged_nodes < 0 || tdigest->unmerged_nodes < 0 ||
+        tdigest->merged_nodes > allocated_cap || tdigest->unmerged_nodes > allocated_cap ||
+        tdigest->merged_nodes + tdigest->unmerged_nodes > allocated_cap) {
         err = true;
         return NULL;
     }

--- a/src/version.h
+++ b/src/version.h
@@ -20,7 +20,7 @@
 #endif
 
 #ifndef REBLOOM_VERSION_PATCH
-#define REBLOOM_VERSION_PATCH 2
+#define REBLOOM_VERSION_PATCH 5
 
 #endif
 

--- a/tests/flow/test_bf_restore_corrupt_rdb.py
+++ b/tests/flow/test_bf_restore_corrupt_rdb.py
@@ -1,0 +1,200 @@
+import struct
+
+from common import *
+
+# RDB module opcodes / encodings (see Redis RDB format)
+RDB_6BITLEN = 0
+RDB_14BITLEN = 1
+RDB_ENC_INT8 = 0
+RDB_ENC_INT16 = 1
+RDB_ENC_INT32 = 2
+RDB_ENC_LZF = 3
+RDB_MODULE_OPCODE_EOF = 0
+RDB_MODULE_OPCODE_UINT = 2
+RDB_MODULE_OPCODE_DOUBLE = 4
+RDB_MODULE_OPCODE_STRING = 5
+
+CRC64_POLY = 0xAD93D23594C935A9
+
+
+def _crc_reflect(data: int, bits: int) -> int:
+    out = 0
+    for i in range(bits):
+        if data & (1 << i):
+            out |= 1 << (bits - 1 - i)
+    return out
+
+
+def _crc64_redis(data: bytes) -> int:
+    crc = 0
+    for b in data:
+        for i in range(8):
+            bit = crc & 0x8000000000000000
+            if b & (1 << i):
+                bit = 0 if bit else 1
+            crc = (crc << 1) & 0xFFFFFFFFFFFFFFFF
+            if bit:
+                crc ^= CRC64_POLY
+    return _crc_reflect(crc, 64) & 0xFFFFFFFFFFFFFFFF
+
+
+def _encode_len(n: int) -> bytes:
+    if n < (1 << 6):
+        return bytes([n & 0x3F])
+    if n < (1 << 14):
+        return bytes([0x40 | ((n >> 8) & 0x3F), n & 0xFF])
+    if n < (1 << 32):
+        return bytes([0x80, (n >> 24) & 0xFF, (n >> 16) & 0xFF, (n >> 8) & 0xFF, n & 0xFF])
+    return bytes([0x81]) + n.to_bytes(8, "big")
+
+
+def _load_len(buf: bytes, pos: int):
+    first = buf[pos]
+    typ = (first & 0xC0) >> 6
+    if typ == RDB_6BITLEN:
+        return first & 0x3F, False, pos + 1, None
+    if typ == RDB_14BITLEN:
+        val = ((first & 0x3F) << 8) | buf[pos + 1]
+        return val, False, pos + 2, None
+    if typ == 2:
+        enc = first & 0x3F
+        if enc == RDB_ENC_INT8:
+            val = int.from_bytes(buf[pos + 1 : pos + 5], "big")
+            return val, False, pos + 5, None
+        if enc == RDB_ENC_INT16:
+            val = int.from_bytes(buf[pos + 1 : pos + 9], "big")
+            return val, False, pos + 9, None
+        return enc, True, pos + 1, enc
+    enc = first & 0x3F
+    return enc, True, pos + 1, enc
+
+
+def _lzf_decompress(data: bytes, out_len: int) -> bytes:
+    i = 0
+    out = bytearray()
+    while i < len(data):
+        ctrl = data[i]
+        i += 1
+        if ctrl < 32:
+            length = ctrl + 1
+            out.extend(data[i : i + length])
+            i += length
+        else:
+            length = ctrl >> 5
+            ref = len(out) - ((ctrl & 0x1F) << 8) - 1
+            if length == 7:
+                length += data[i]
+                i += 1
+            ref -= data[i]
+            i += 1
+            length += 2
+            for _ in range(length):
+                out.append(out[ref])
+                ref += 1
+    if len(out) != out_len:
+        raise RuntimeError(f"LZF output length mismatch (got {len(out)}, expected {out_len})")
+    return bytes(out)
+
+
+def _corrupt_dump_shrink_largest_module_string(dump_payload: bytes) -> bytes:
+    # Redis DUMP value format: [RDB encoded value][2-byte version][8-byte CRC64]
+    if len(dump_payload) < 10:
+        raise RuntimeError("DUMP payload too small")
+    value = dump_payload[:-10]
+    version = dump_payload[-10:-8]
+
+    # The module value begins with a type byte, then a module-id length+value,
+    # followed by a stream of module opcodes.
+    pos = 1
+    _, is_enc, pos, _ = _load_len(value, pos)  # module id
+    if is_enc:
+        raise RuntimeError("Unexpected encoded module-id length")
+
+    strings = []
+    while pos < len(value):
+        opcode, is_enc, pos, _ = _load_len(value, pos)
+        if is_enc:
+            raise RuntimeError(f"Unexpected encoded opcode at pos={pos}")
+        if opcode == RDB_MODULE_OPCODE_EOF:
+            break
+        if opcode == RDB_MODULE_OPCODE_UINT:
+            _, is_enc2, pos, _ = _load_len(value, pos)
+            if is_enc2:
+                raise RuntimeError("Unexpected encoded value in MODULE_OPCODE_UINT")
+            continue
+        if opcode == RDB_MODULE_OPCODE_DOUBLE:
+            pos += 8
+            continue
+        if opcode == RDB_MODULE_OPCODE_STRING:
+            len_start = pos
+            slen_or_enc, is_str_enc, pos, enc = _load_len(value, pos)
+            if not is_str_enc:
+                slen = slen_or_enc
+                data_start = pos
+                data_end = pos + slen
+                if data_end > len(value):
+                    raise RuntimeError("String overruns buffer while parsing")
+                decoded = value[data_start:data_end]
+                old_end = data_end
+                pos = data_end
+                strings.append({"len_start": len_start, "old_end": old_end, "decoded": decoded, "enc": None})
+            else:
+                if enc != RDB_ENC_LZF:
+                    raise RuntimeError(f"Unsupported encoded string type: {enc}")
+                clen, is_enc3, pos, _ = _load_len(value, pos)
+                if is_enc3:
+                    raise RuntimeError("Unexpected encoded compressed length")
+                ulen, is_enc4, pos, _ = _load_len(value, pos)
+                if is_enc4:
+                    raise RuntimeError("Unexpected encoded uncompressed length")
+                comp_start = pos
+                comp_end = pos + clen
+                if comp_end > len(value):
+                    raise RuntimeError("Compressed string overruns buffer while parsing")
+                comp = value[comp_start:comp_end]
+                decoded = _lzf_decompress(comp, ulen)
+                old_end = comp_end
+                pos = comp_end
+                strings.append({"len_start": len_start, "old_end": old_end, "decoded": decoded, "enc": "lzf"})
+            continue
+        raise RuntimeError(f"Unknown module opcode {opcode} at pos={pos}")
+
+    if not strings:
+        raise RuntimeError("No MODULE_OPCODE_STRING entries found; cannot corrupt payload")
+
+    _, max_entry = max(enumerate(strings), key=lambda t: len(t[1]["decoded"]))
+    decoded = max_entry["decoded"]
+    old_len = len(decoded)
+    new_len = max(1, old_len // 4)
+    new_data = decoded[:new_len]
+    len_start = max_entry["len_start"]
+    old_end = max_entry["old_end"]
+
+    new_value = value[:len_start] + _encode_len(new_len) + new_data + value[old_end:]
+    new_crc = _crc64_redis(new_value + version)
+    return new_value + version + struct.pack("<Q", new_crc)
+
+
+class testBFRestoreCorruptRDB():
+    def __init__(self):
+        # We need raw bytes for DUMP/RESTORE payload manipulation
+        self.env = Env(decodeResponses=False)
+
+    def test_restore_rejects_corrupted_bloom_bitset(self):
+        env = self.env
+        env.cmd("FLUSHALL")
+
+        # Use a hash-tag so keys land in same slot on cluster runs
+        key = b"bf_poc{bf}"
+        corrupt_key = b"bf_poc_corrupt{bf}"
+
+        env.cmd("BF.RESERVE", key, 0.01, 1000)
+        dump_payload = env.cmd("DUMP", key)
+        corrupted = _corrupt_dump_shrink_largest_module_string(dump_payload)
+
+        # With the fix, the module should reject the crafted payload during load.
+        with env.assertResponseError():
+            env.cmd("RESTORE", corrupt_key, 0, corrupted)
+
+        # Ensure the server/module remains healthy
+        env.cmd("BF.ADD", key, b"sanity")

--- a/tests/flow/test_bf_restore_corrupt_rdb.py
+++ b/tests/flow/test_bf_restore_corrupt_rdb.py
@@ -96,6 +96,81 @@ def _lzf_decompress(data: bytes, out_len: int) -> bytes:
     return bytes(out)
 
 
+def _zigzag_encode(n: int) -> int:
+    # 64-bit zigzag, compatible with Redis module signed encoding.
+    #  0 -> 0, -1 -> 1, 1 -> 2, -2 -> 3, ...
+    if n >= 0:
+        return n << 1
+    return ((-n) << 1) - 1
+
+
+def _corrupt_dump_set_first_uint_after_3_doubles(dump_payload: bytes, new_value: int) -> bytes:
+    # Redis DUMP value format: [RDB encoded value][2-byte version][8-byte CRC64]
+    if len(dump_payload) < 10:
+        raise RuntimeError("DUMP payload too small")
+    value = dump_payload[:-10]
+    version = dump_payload[-10:-8]
+
+    # The module value begins with a type byte, then a module-id length+value,
+    # followed by a stream of module opcodes.
+    pos = 1
+    _, is_enc, pos, _ = _load_len(value, pos)  # module id
+    if is_enc:
+        raise RuntimeError("Unexpected encoded module-id length")
+
+    doubles_seen = 0
+    patched = False
+
+    while pos < len(value):
+        opcode, is_enc, pos, _ = _load_len(value, pos)
+        if is_enc:
+            raise RuntimeError(f"Unexpected encoded opcode at pos={pos}")
+        if opcode == RDB_MODULE_OPCODE_EOF:
+            break
+        if opcode == RDB_MODULE_OPCODE_UINT:
+            val_start = pos
+            _, is_enc2, pos, _ = _load_len(value, pos)
+            if is_enc2:
+                raise RuntimeError("Unexpected encoded value in MODULE_OPCODE_UINT")
+            val_end = pos
+            if (not patched) and doubles_seen >= 3:
+                encoded = _encode_len(_zigzag_encode(new_value))
+                new_value_bytes = value[:val_start] + encoded + value[val_end:]
+                new_crc = _crc64_redis(new_value_bytes + version)
+                patched = True
+                return new_value_bytes + version + struct.pack("<Q", new_crc)
+            continue
+        if opcode == RDB_MODULE_OPCODE_DOUBLE:
+            pos += 8
+            doubles_seen += 1
+            continue
+        if opcode == RDB_MODULE_OPCODE_STRING:
+            slen_or_enc, is_str_enc, pos, enc = _load_len(value, pos)
+            if not is_str_enc:
+                slen = slen_or_enc
+                pos += slen
+            else:
+                if enc != RDB_ENC_LZF:
+                    raise RuntimeError(f"Unsupported encoded string type: {enc}")
+                clen, is_enc3, pos, _ = _load_len(value, pos)
+                if is_enc3:
+                    raise RuntimeError("Unexpected encoded compressed length")
+                ulen, is_enc4, pos, _ = _load_len(value, pos)
+                if is_enc4:
+                    raise RuntimeError("Unexpected encoded uncompressed length")
+                comp_end = pos + clen
+                if comp_end > len(value):
+                    raise RuntimeError("Compressed string overruns buffer while parsing")
+                comp = value[pos:comp_end]
+                _lzf_decompress(comp, ulen)
+                pos = comp_end
+            continue
+        raise RuntimeError(f"Unknown module opcode {opcode} at pos={pos}")
+
+    if not patched:
+        raise RuntimeError("Did not find target SINT to patch")
+
+
 def _corrupt_dump_shrink_largest_module_string(dump_payload: bytes) -> bytes:
     # Redis DUMP value format: [RDB encoded value][2-byte version][8-byte CRC64]
     if len(dump_payload) < 10:
@@ -198,3 +273,54 @@ class testBFRestoreCorruptRDB():
 
         # Ensure the server/module remains healthy
         env.cmd("BF.ADD", key, b"sanity")
+
+
+class testCFRestoreCorruptRDB():
+    def __init__(self):
+        # We need raw bytes for DUMP/RESTORE payload manipulation
+        self.env = Env(decodeResponses=False)
+
+    def test_restore_rejects_corrupted_cuckoo_filter_buffer(self):
+        env = self.env
+        env.cmd("FLUSHALL")
+
+        # Use a hash-tag so keys land in same slot on cluster runs
+        key = b"cf_poc{cf}"
+        corrupt_key = b"cf_poc_corrupt{cf}"
+
+        env.cmd("CF.RESERVE", key, 1000)
+        dump_payload = env.cmd("DUMP", key)
+        corrupted = _corrupt_dump_shrink_largest_module_string(dump_payload)
+
+        # With the fix, the module should reject the crafted payload during load.
+        with env.assertResponseError():
+            env.cmd("RESTORE", corrupt_key, 0, corrupted)
+
+        # Ensure the server/module remains healthy
+        env.cmd("CF.ADD", key, b"sanity")
+
+
+class testTDigestRestoreCorruptRDB():
+    def __init__(self):
+        # We need raw bytes for DUMP/RESTORE payload manipulation
+        self.env = Env(decodeResponses=False)
+
+    def test_restore_rejects_corrupted_tdigest_cap(self):
+        env = self.env
+        env.cmd("FLUSHALL")
+
+        key = b"td_poc{td}"
+        corrupt_key = b"td_poc_corrupt{td}"
+
+        # Small compression so allocated cap is small; corruption inflates cap.
+        env.cmd("tdigest.create", key, "compression", 10)
+        env.cmd("tdigest.add", key, 1.0)
+
+        dump_payload = env.cmd("DUMP", key)
+        corrupted = _corrupt_dump_set_first_uint_after_3_doubles(dump_payload, 1_000_000)
+
+        with env.assertResponseError():
+            env.cmd("RESTORE", corrupt_key, 0, corrupted)
+
+        # Ensure the server/module remains healthy
+        env.cmd("tdigest.add", key, 2.0)


### PR DESCRIPTION
## Summary
Backport of #1038 to 8.6.

- validate Bloom and Cuckoo RDB metadata and serialized buffer sizes before allocation/copy
- validate TDigest capacity and node counters before loading serialized nodes
- add targeted corrupt-RDB regression coverage

## Testing
- gmake build
- targeted corrupt-RDB suite: 3/3 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes deserialization of untrusted RDB/RESTORE data; failures are safer, but any overly strict check could reject valid snapshots—high impact because bugs here are memory-safety issues.
> 
> **Overview**
> Hardens **RESTORE/RDB load** for Bloom filters, Cuckoo filters, and T-Digest so crafted or truncated module payloads are rejected instead of trusting metadata alone.
> 
> **Bloom** (`BFRdbLoad`): rejects missing/empty/oversized bitset buffers; for newer encodings requires `bits` to match buffer size × 8; validates `n2` and related bit geometry before `bloom_validate_integrity`.
> 
> **Cuckoo** (`CFRdbLoad`): bounds-checks filter/bucket counts and fields that map to `uint16_t`; runs `CuckooFilter_ValidateIntegrity` before sub-filter allocation; validates per-subfilter bucket counts (non-zero, power-of-two, max) and that each serialized bucket blob length matches `bucketSize × numBuckets`; replaces `assert`-only checks with explicit load failures.
> 
> **T-Digest** (`TDigestRdbLoad`): ensures loaded `cap` matches what `td_new(compression)` allocated and tightens checks on merged/unmerged node counts relative to that cap.
> 
> Patch release **8.6.5** and new flow tests corrupt `DUMP` payloads (shrunk bitset/bucket strings, inflated TDigest cap) and assert `RESTORE` errors while the original keys stay usable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5b2409ad07620819174cbe7bd2632c5dee179fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->