### PR TITLE
MOD-16050: backport CF.LOADCHUNK replication fix to 8.8

### DIFF
--- a/src/rebloom.c
+++ b/src/rebloom.c
@@ -1010,6 +1010,7 @@ static int CFLoadChunk_RedisCommand(RedisModuleCtx *ctx, RedisModuleString **arg
     if (CF_LoadEncodedChunk(cf, pos, blob, bloblen) != REDISMODULE_OK) {
         return RedisModule_ReplyWithError(ctx, "Couldn't load chunk!");
     }
+    RedisModule_ReplicateVerbatim(ctx);
     return RedisModule_ReplyWithSimpleString(ctx, "OK");
 }
 

--- a/tests/flow/test_cuckoo.py
+++ b/tests/flow/test_cuckoo.py
@@ -1,4 +1,5 @@
 import random
+import time
 
 from common import *
 
@@ -688,3 +689,56 @@ class testCuckooNoCodec():
         self.cmd('FLUSHALL')
         rdb_payload = b'\x07\x810\x16\xe5\xa2\x89\x82\x14\x04\x02\x00\x02\x08\x02\x01\x02\x00\x02\x01\x02\x01\x02\x01\x00\xff\x0c\x00`\x07q:\xe0pL\r'
         self.env.expect('RESTORE', "hax", 0, rdb_payload, 'REPLACE').error().contains('Bad data format')
+
+
+def test_cf_loadchunk_replicates_to_replica():
+    # MOD-16050: CF.LOADCHUNK must replicate its data chunks, not only the header.
+    # Otherwise a replica of a CF.LOADCHUNK-restored filter has the correct
+    # metadata (CF.INFO reports the full item count) but empty buckets, and a
+    # failover silently loses all the data.
+    # freshEnv=True forces a dedicated master+replica env, so this test is not
+    # affected by env reuse from preceding (non-replicated) tests.
+    env = Env(useSlaves=True, decodeResponses=False, freshEnv=True)
+    if env.isCluster():
+        env.skip()
+
+    master = env.getConnection()
+    slave = env.getSlaveConnection()
+
+    n = 2000
+    # Build a source filter that spans several sub-filters (expansion), then
+    # serialize it with CF.SCANDUMP.
+    master.execute_command('CF.RESERVE', 'src', 100, 'EXPANSION', 2)
+    for i in range(n):
+        master.execute_command('CF.ADD', 'src', 'item%d' % i)
+
+    chunks = []
+    pos = 0
+    while True:
+        pos, data = master.execute_command('CF.SCANDUMP', 'src', pos)
+        if pos == 0:
+            break
+        chunks.append((pos, data))
+    # Must have data chunks beyond the header, otherwise this would not exercise
+    # the data-chunk replication path.
+    env.assertGreater(len(chunks), 1)
+
+    # Restore into a fresh key via CF.LOADCHUNK on the master.
+    for pos, data in chunks:
+        master.execute_command('CF.LOADCHUNK', 'cf', pos, data)
+
+    # The replica must be caught up to the master's replication offset. Poll WAIT
+    # to tolerate the replica still connecting/doing its initial sync.
+    acked = 0
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        acked = master.execute_command('WAIT', 1, 1000)
+        if acked >= 1:
+            break
+    env.assertEqual(acked, 1)
+
+    # ...and must hold the actual filter data, not just the header metadata.
+    missing = [i for i in range(n)
+               if slave.execute_command('CF.EXISTS', 'cf', 'item%d' % i) != 1]
+    env.assertEqual(missing, [],
+                    message='%d/%d items missing on replica after CF.LOADCHUNK' % (len(missing), n))


### PR DESCRIPTION
## Summary

- Cherry-picks the MOD-16050 fix from #1014 onto the public `8.8` branch.
- Replicates successful `CF.LOADCHUNK` data chunks to replicas and AOF, not only the header chunk.
- Restores the primary/replica regression test that verifies all restored Cuckoo Filter items reach the replica.

## Context

The private `v8.8.1` history contained this fix, but public `origin/8.8` was not descended from that commit. Consequently, public `v8.8.2` was released without MOD-16050. This PR prepares the fix for the next public 8.8 release; it intentionally does not bump or tag a version.

Jira: [MOD-16050](https://redislabs.atlassian.net/browse/MOD-16050)
Original public fix: #1014 (`a8d0991f5a26d6be382e39ed4f73a9f8cf42bd77`)

## Validation

- [x] Cherry-picked patch has the same stable patch ID as the original fix.
- [x] `gmake build`
- [x] `python3 -m py_compile tests/flow/test_cuckoo.py`
- [x] `gmake flow-tests GEN=0 SLAVES=1 AOF=0 OSS_CLUSTER=0 TEST="test_cuckoo.py:test_cf_loadchunk_replicates_to_replica"` — 1 passed, 0 failed on the replica topology; cluster variant skipped as intended.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replication behavior for CF.LOADCHUNK changes in production restore/migration paths; incorrect replication could still cause silent data loss on failover, but the change aligns with the header path and BF.LOADCHUNK.
> 
> **Overview**
> Fixes **MOD-16050** by replicating successful **`CF.LOADCHUNK`** data chunks (not only the header at position 1). After **`RedisModule_ReplicateVerbatim`** on the data path in `CFLoadChunk_RedisCommand`, replicas and AOF receive the same chunk commands as the master—closing the case where **`CF.INFO`** looked correct but buckets were empty and failover could drop restored items.
> 
> Adds a master/replica flow test that **`CF.SCANDUMP`**s an expanded filter, restores via **`CF.LOADCHUNK`** on the master, waits for replication, and asserts all items exist on the replica.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9da6670541f1576cb5b1893ee7246dd8a2ce3893. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[MOD-16050]: https://redislabs.atlassian.net/browse/MOD-16050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ