### PR TITLE
Sanitizer fix 2.6

### DIFF
--- a/.install/install_redis.sh
+++ b/.install/install_redis.sh
@@ -17,7 +17,15 @@ cd redis
 git fetch origin ${REDIS_REF}
 git checkout ${REDIS_REF}
 git submodule update --init --recursive
-make SANITIZER=${SANITIZER:-} -j$(nproc)
+if [ -n "${SANITIZER}" ]; then
+    echo "Building Redis with SANITIZER=${SANITIZER} (manual flags for Redis < 7.0)"
+    make MALLOC=libc \
+         CFLAGS="-fsanitize=${SANITIZER} -fno-omit-frame-pointer -fno-sanitize-recover=all" \
+         LDFLAGS="-fsanitize=${SANITIZER}" \
+         -j"$(nproc)"
+else
+    make -j"$(nproc)"
+fi
 make install
 cd ..
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only changes the Redis install/build script used in Docker/CI; no runtime application or security logic is modified.
> 
> **Overview**
> Fixes sanitizer-enabled Redis installs when pinning **older Redis refs** that do not honor `make SANITIZER=...` (that target is effectively **Redis 7.0+**).
> 
> When `SANITIZER` is set, `install_redis.sh` now builds with **`MALLOC=libc`** and explicit **`CFLAGS`/`LDFLAGS`** (`-fsanitize=…`, `-fno-omit-frame-pointer`, `-fno-sanitize-recover=all`) instead of passing `SANITIZER` into `make`. Non-sanitizer installs still use a plain parallel `make`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b667b6bc34499fd6d48b8e1f026d3bb155371829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->