### PR TITLE
2.6 ci: fix nightly sanitizer and valgrind jobs

### DIFF
--- a/sbin/memcheck-summary
+++ b/sbin/memcheck-summary
@@ -56,13 +56,14 @@ sanitizer_check() {
 
 sanitizer_summary() {
 	local logdir="$ROOT/tests/$DIR/logs"
-	if ! TYPE="leaks" sanitizer_check "Direct leak"; then
-		TYPE="leaks" sanitizer_check "detected memory leaks"
-	fi
-	TYPE="buffer overflow" sanitizer_check "dynamic-stack-buffer-overflow"
-	TYPE="memory errors" sanitizer_check "memcpy-param-overlap"
-	TYPE="stack use after scope" sanitizer_check "stack-use-after-scope"
-	TYPE="use after free" sanitizer_check "heap-use-after-free"
+	# Every sanitizer report is headed by "<ERROR|WARNING>: <Tool>Sanitizer: <what>", so one
+	# pattern covers all of them. The previous explicit list missed heap-buffer-overflow,
+	# global-buffer-overflow, stack-buffer-overflow, use-after-poison and alloc-dealloc-mismatch
+	# -- and since the module is built with -fsanitize-recover=all and tests.sh sets
+	# halt_on_error=0, this summary is the only thing that fails the job on those.
+	# The trailing ": " matters: it keeps out "WARNING: AddressSanitizer failed to allocate",
+	# which the oversized-allocation hardening tests provoke on purpose.
+	TYPE="errors" sanitizer_check ": [A-Za-z]*Sanitizer: "
 }
 
 #----------------------------------------------------------------------------------------------

--- a/sbin/memcheck-summary
+++ b/sbin/memcheck-summary
@@ -74,7 +74,7 @@ DIRS=
 #	DIRS+=" ctests cpptests"
 #fi
 if [[ $FLOW == 1 ]]; then
-	DIRS+=" pytests"
+	DIRS+=" flow"
 fi
 
 if [[ $VG == 1 ]]; then

--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -76,19 +76,6 @@ double _halfRoundDown(double f) {
     return int_part >= 0.0 ? int_part + 1.0 : int_part - 1.0;
 }
 
-// Counterpart of _halfRoundDown. Not expressed with round(), whose tie behaviour is
-// libc/platform dependent -- under Valgrind on aarch64 an exact .5 rounds to even
-// instead of away from zero, which silently shifts TDIGEST.REVRANK results.
-double _halfRoundUp(double f) {
-    double int_part;
-    double frac_part = modf(f, &int_part);
-
-    if (fabs(frac_part) < 0.5)
-        return int_part;
-
-    return int_part >= 0.0 ? int_part + 1.0 : int_part - 1.0;
-}
-
 /**
  * Command: TDIGEST.CREATE {key} [{compression}]
  *
@@ -492,7 +479,7 @@ static int _TDigest_Rank(RedisModuleCtx *ctx, RedisModuleString *const *argv, in
             const double cdf_val = td_cdf(tdigest, vals[i]);
             const double cdf_val_prior_round = cdf_val * size;
             const double cdf_to_absolute =
-                reverse ? _halfRoundUp(cdf_val_prior_round) : _halfRoundDown(cdf_val_prior_round);
+                reverse ? round(cdf_val_prior_round) : _halfRoundDown(cdf_val_prior_round);
             ranks[i] = reverse ? round(size - cdf_to_absolute) : cdf_to_absolute;
         }
     }

--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -76,6 +76,19 @@ double _halfRoundDown(double f) {
     return int_part >= 0.0 ? int_part + 1.0 : int_part - 1.0;
 }
 
+// Counterpart of _halfRoundDown. Not expressed with round(), whose tie behaviour is
+// libc/platform dependent -- under Valgrind on aarch64 an exact .5 rounds to even
+// instead of away from zero, which silently shifts TDIGEST.REVRANK results.
+double _halfRoundUp(double f) {
+    double int_part;
+    double frac_part = modf(f, &int_part);
+
+    if (fabs(frac_part) < 0.5)
+        return int_part;
+
+    return int_part >= 0.0 ? int_part + 1.0 : int_part - 1.0;
+}
+
 /**
  * Command: TDIGEST.CREATE {key} [{compression}]
  *
@@ -479,7 +492,7 @@ static int _TDigest_Rank(RedisModuleCtx *ctx, RedisModuleString *const *argv, in
             const double cdf_val = td_cdf(tdigest, vals[i]);
             const double cdf_val_prior_round = cdf_val * size;
             const double cdf_to_absolute =
-                reverse ? round(cdf_val_prior_round) : _halfRoundDown(cdf_val_prior_round);
+                reverse ? _halfRoundUp(cdf_val_prior_round) : _halfRoundDown(cdf_val_prior_round);
             ranks[i] = reverse ? round(size - cdf_to_absolute) : cdf_to_absolute;
         }
     }

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -8,9 +8,6 @@ READIES=$ROOT/deps/readies
 
 export PYTHONUNBUFFERED=1
 
-VALGRIND_REDIS_VER=6.2
-SAN_REDIS_VER=6.2
-
 cd $HERE
 
 #----------------------------------------------------------------------------------------------
@@ -159,42 +156,14 @@ setup_rltest() {
 
 #----------------------------------------------------------------------------------------------
 
-setup_clang_sanitizer() {
-	local ignorelist=$ROOT/tests/memcheck/redis.san-ignorelist
-	if ! grep THPIsEnabled $ignorelist &> /dev/null; then
-		echo "fun:THPIsEnabled" >> $ignorelist
-	fi
-
-	# for RediSearch module
-	export RS_GLOBAL_DTORS=1
-
+setup_sanitizer() {
 	# for RLTest
 	export SANITIZER="$SAN"
 	export SHORT_READ_BYTES_DELTA=512
-	
+
+	export ASAN_OPTIONS="detect_odr_violation=0:halt_on_error=0:detect_leaks=1:allocator_may_return_null=1"
 	# --no-output-catch --exit-on-failure --check-exitcode
 	RLTEST_SAN_ARGS="--sanitizer $SAN"
-
-	if [[ $SAN == addr || $SAN == address ]]; then
-		REDIS_SERVER=${REDIS_SERVER:-redis-server-asan-$SAN_REDIS_VER}
-		if ! command -v $REDIS_SERVER > /dev/null; then
-			echo Building Redis for clang-asan ...
-			$READIES/bin/getredis --force -v $SAN_REDIS_VER --own-openssl --no-run \
-				--suffix asan --clang-asan --clang-san-blacklist $ignorelist
-		fi
-
-		export ASAN_OPTIONS="detect_odr_violation=0:halt_on_error=0:detect_leaks=1"
-		export LSAN_OPTIONS="suppressions=$ROOT/tests/memcheck/asan.supp"
-
-	elif [[ $SAN == mem || $SAN == memory ]]; then
-		REDIS_SERVER=${REDIS_SERVER:-redis-server-msan-$SAN_REDIS_VER}
-		if ! command -v $REDIS_SERVER > /dev/null; then
-			echo Building Redis for clang-msan ...
-			$READIES/bin/getredis --force -v $SAN_REDIS_VER  --no-run --own-openssl \
-				--suffix msan --clang-msan --llvm-dir /opt/llvm-project/build-msan \
-				--clang-san-blacklist $ignorelist
-		fi
-	fi
 }
 
 #----------------------------------------------------------------------------------------------
@@ -211,12 +180,6 @@ setup_redis_server() {
 #----------------------------------------------------------------------------------------------
 
 setup_valgrind() {
-	REDIS_SERVER=${REDIS_SERVER:-redis-server-vg}
-	if ! is_command $REDIS_SERVER; then
-		echo Building Redis for Valgrind ...
-		$READIES/bin/getredis -v $VALGRIND_REDIS_VER --valgrind --suffix vg
-	fi
-
 	if [[ $VG_LEAKS == 0 ]]; then
 		VG_LEAK_CHECK=no
 		RLTEST_VG_NOLEAKS="--vg-no-leakcheck"
@@ -232,7 +195,7 @@ setup_valgrind() {
 		--track-origins=yes \
 		--show-possibly-lost=no"
 
-	VALGRIND_SUPRESSIONS=$ROOT/tests/memcheck/valgrind.supp
+	VALGRIND_SUPRESSIONS=$ROOT/tests/memcheck/redis_valgrind.sup
 
 	RLTEST_VG_ARGS+="\
 		--use-valgrind \
@@ -526,7 +489,7 @@ fi
 setup_rltest
 
 if [[ -n $SAN ]]; then
-	setup_clang_sanitizer
+	setup_sanitizer
 fi
 
 if [[ $VG == 1 ]]; then
@@ -565,7 +528,7 @@ if [[ $NO_SUMMARY == 1 ]]; then
 	exit 0
 fi
 
-if [[ $NOP != 1 && -n $SAN ]]; then
+if [[ $NOP != 1 ]]; then
 	if [[ -n $SAN || $VG == 1 ]]; then
 		{ FLOW=1 $ROOT/sbin/memcheck-summary; (( E |= $? )); } || true
 	fi

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -161,6 +161,8 @@ setup_sanitizer() {
 	export SANITIZER="$SAN"
 	export SHORT_READ_BYTES_DELTA=512
 
+	# halt_on_error=0 keeps the run going past the first report so every finding lands in
+	# logs/*.asan.log; sbin/memcheck-summary then scans them and fails the job.
 	export ASAN_OPTIONS="detect_odr_violation=0:halt_on_error=0:detect_leaks=1:allocator_may_return_null=1"
 	# --no-output-catch --exit-on-failure --check-exitcode
 	RLTEST_SAN_ARGS="--sanitizer $SAN"
@@ -364,16 +366,17 @@ OS=$($READIES/bin/platform --os)
 
 #---------------------------------------------------------------------------------- Tests scope
 
+# the Makefile exports OSS_CLUSTER, not CLUSTER, so accept both names
 if [[ $QUICK == 1 ]]; then
 	GEN=${GEN:-1}
 	SLAVES=${SLAVES:-0}
 	AOF=${AOF:-0}
-	CLUSTER=${CLUSTER:-0}
+	CLUSTER=${CLUSTER:-${OSS_CLUSTER:-0}}
 else
 	GEN=${GEN:-1}
 	SLAVES=${SLAVES:-1}
 	AOF=${AOF:-1}
-	CLUSTER=${CLUSTER:-1}
+	CLUSTER=${CLUSTER:-${OSS_CLUSTER:-1}}
 fi
 
 RLEC=${RLEC:-0}


### PR DESCRIPTION
The `linux-sanitizer` and `linux-valgrind` nightly jobs have both been failing on
this branch for a while ([sanitizer](https://github.com/RedisBloom/RedisBloom/actions/runs/30031487748/job/89288909563),
[valgrind](https://github.com/RedisBloom/RedisBloom/actions/runs/30031487748/job/89288920103)).
Neither failure was a module bug — `tests/flow/tests.sh` had drifted from 8.4/master,
which already solved both. `flow-linux.yml` and `.install/install_redis.sh` are
byte-identical to 8.4, so only `tests.sh` needed to change.

## Sanitizer

Aborted with `Cannot find redis-server-asan-6.2`. `setup_clang_sanitizer` looked for
`redis-server-asan-$SAN_REDIS_VER`, but `getredis --suffix asan` installs the binary as
plain `redis-server-asan`, so the name never matched and `setup_redis_server` bailed out.

The Docker image already builds redis with `SANITIZER=address`, so rebuilding redis here
was both redundant and broken. Dropped, as on 8.4 — `redis-server` from `PATH` is already
instrumented. This also drops `LSAN_OPTIONS`, which pointed at `tests/memcheck/asan.supp`,
a file that does not exist on this branch, and adds `allocator_may_return_null=1` so the
oversized-allocation hardening tests do not abort the run.

## Valgrind

Every server died at startup with:

```
==2079== FATAL: can't open suppressions file "/workspace/tests/memcheck/valgrind.supp"
```

The file is named `tests/memcheck/redis_valgrind.sup`. Because no server started, every
test class errored in `__init__`. Also dropped the `getredis --valgrind` build for the same
reason as above.

Separately, the valgrind leak summary was guarded by `if [[ $NOP != 1 && -n $SAN ]]`, so it
never ran for valgrind-only builds even though the inner condition tested for `$VG`.

## Verification

Ran in the `jammy` container locally. Sanitizer suite green across all four topologies:

| topology | result |
|---|---|
| general | 141 run / 0 failed |
| `--use-slaves` | 141 run / 0 failed |
| `--use-aof` | 141 run / 0 failed |
| `--env oss-cluster` | 141 run / 0 failed |

The local valgrind run is **not** a clean pass — see the note below.

## Open item for CI

Local valgrind runs (on **arm64**, whereas CI is x64) hit `TDIGEST.REVRANK` off-by-one
assertion failures in `test_tdigest_revrank` and `test_tdigest_rank_and_revrank`, e.g.
`[15, 14, 13, 10, 7, 2, -1]` vs `[15, 15, 13, 11, 7, 3, -1]`. These are numeric, not memory
errors. I could not attribute them confidently: `VG=1` also implies `DEBUG=1` and adds
`-D_VALGRIND`, and valgrind's FP emulation differs by architecture. The x64 valgrind job on
this PR should settle whether it is real or an arm64 artifact.

## Review follow-ups

- `sbin/memcheck-summary` matched five specific ASan error names, so `heap-buffer-overflow`,
  `global-buffer-overflow`, `stack-buffer-overflow`, `use-after-poison` and
  `alloc-dealloc-mismatch` went unreported — and with `-fsanitize-recover=all` on the module
  plus `halt_on_error=0`, this summary is the only thing that can fail the job on those. Now
  matches the report header, `": [A-Za-z]*Sanitizer: "`. The trailing `": "` keeps out
  `WARNING: AddressSanitizer failed to allocate`, which the oversized-allocation hardening
  tests provoke on purpose. Checked against 609 real `*.asan.log*` files from local runs.
- `tests.sh` read `$CLUSTER`/`$QUICK`, but the Makefile exports `OSS_CLUSTER`, so
  `make flow-tests OSS_CLUSTER=0` still ran the oss-cluster variant. Both branches now fall
  back to `OSS_CLUSTER`. No change for the nightly, which leaves it at the default of 1.
- The `_halfRoundUp` attempt at the `TDIGEST.REVRANK` divergence has been **reverted** — over
  the reachable domain it is bit-for-bit `round()`, so it could not have changed the result,
  and its `int_part >= 0.0` guard was wrong for `(-1, 0)` where `modf` yields `-0.0`. `src/` is
  now byte-identical to `2.6`; the REVRANK item below stays open and belongs in its own PR.
- The gcc-vs-clang ASan concern raised in review does not apply: `master` builds redis with the
  image's gcc under `SANITIZER=address` and pairs it with the same clang-built module, and its
  `linux-sanitizer / x64-jammy` job is green (run 31906795267 and the three nightlies before
  it). No `CC=clang` needed here.

Pre-existing, not touched here: `master`'s own `sbin/memcheck-summary` has a broken
invocation — `grep -q -e "runtime error" -e "Sanitizer" -v "failed to allocate" "$file"` parses
the pattern as a *filename*, visible as 16 × `grep: failed to allocate: No such file or
directory` in the nightly log. Needs its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test harness scripts and log aggregation; no module runtime or security-sensitive production paths.
> 
> **Overview**
> **Aligns flow memcheck with 8.4/master** so nightly `linux-sanitizer` and `linux-valgrind` jobs can start Redis and fail correctly on log findings.
> 
> **Sanitizer:** `tests/flow/tests.sh` no longer builds or looks for `redis-server-asan-*` / MSAN variants via `getredis`; it uses `redis-server` from `PATH` (already instrumented in CI). `setup_sanitizer` sets `ASAN_OPTIONS` with `halt_on_error=0` and `allocator_may_return_null=1`, and drops `LSAN_OPTIONS` pointing at a missing suppressions file.
> 
> **Valgrind:** Drops the redundant `getredis --valgrind` path and points suppressions at `tests/memcheck/redis_valgrind.sup` instead of the non-existent `valgrind.supp`.
> 
> **Post-run summary:** `sbin/memcheck-summary` scans `tests/flow/logs` (not `pytests`) and uses one grep for `: *Sanitizer: ` so heap/global/stack buffer overflows and similar reports are not missed when the run continues past errors. Flow tests now invoke that summary for Valgrind-only runs as well as sanitizer runs.
> 
> **Topology:** `CLUSTER` defaults honor `OSS_CLUSTER` from the Makefile when `CLUSTER` is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2634ae5374f70785162171745cd78ff14c9ae47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
