### PR TITLE
2.4 ci: fix nightly sanitizer and valgrind jobs

### DIFF
--- a/.install/install_redis.sh
+++ b/.install/install_redis.sh
@@ -17,8 +17,26 @@ cd redis
 git fetch origin ${REDIS_REF}
 git checkout ${REDIS_REF}
 git submodule update --init --recursive
-make SANITIZER=${SANITIZER:-} -j$(nproc)
-make install
+MAKE_ARGS=()
+if [ -n "${SANITIZER}" ]; then
+    # The module is instrumented by clang (readies clang-sanitizer.defs) and a clang-built
+    # shared object links no ASan runtime of its own, so redis must be instrumented by clang
+    # too -- against gcc's libasan the module reports bogus global-buffer-overflows in RM_GetApi.
+    MAKE_ARGS+=(CC=clang LD=clang)
+    if grep -q '^ifdef SANITIZER' src/Makefile; then
+        MAKE_ARGS+=("SANITIZER=${SANITIZER}")
+    else
+        # Redis grew Makefile SANITIZER support in 7.0; older refs ignore it silently and
+        # produce an uninstrumented server the module cannot even dlopen. Pass the equivalent
+        # flags by hand, mirroring what redis 7.x does (it also forces libc malloc).
+        MAKE_ARGS+=(MALLOC=libc)
+        MAKE_ARGS+=("REDIS_CFLAGS=-fsanitize=${SANITIZER} -fno-sanitize-recover=all -fno-omit-frame-pointer")
+        MAKE_ARGS+=("REDIS_LDFLAGS=-fsanitize=${SANITIZER}")
+    fi
+fi
+
+make "${MAKE_ARGS[@]}" -j$(nproc)
+make install "${MAKE_ARGS[@]}"
 cd ..
 
 echo "Redis installed successfully"

--- a/.install/install_redis.sh
+++ b/.install/install_redis.sh
@@ -20,8 +20,11 @@ git submodule update --init --recursive
 MAKE_ARGS=()
 if [ -n "${SANITIZER}" ]; then
     # The module is instrumented by clang (readies clang-sanitizer.defs) and a clang-built
-    # shared object links no ASan runtime of its own, so redis must be instrumented by clang
-    # too -- against gcc's libasan the module reports bogus global-buffer-overflows in RM_GetApi.
+    # shared object links no ASan runtime of its own, so it resolves its __asan_* symbols
+    # against whatever runtime redis already loaded. Build redis with clang too, so both sides
+    # use the same one -- with redis 6.2 built by gcc on jammy, module load aborted with a
+    # global-buffer-overflow in RM_GetApi. (8.x/master pair a gcc-built redis 7.2 with the same
+    # clang module and are green, so this is not a general gcc/clang incompatibility.)
     MAKE_ARGS+=(CC=clang LD=clang)
     if grep -q '^ifdef SANITIZER' src/Makefile; then
         MAKE_ARGS+=("SANITIZER=${SANITIZER}")

--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -75,6 +75,19 @@ double _halfRoundDown(double f) {
     return int_part >= 0.0 ? int_part + 1.0 : int_part - 1.0;
 }
 
+// Counterpart of _halfRoundDown. Not expressed with round(), whose tie behaviour is
+// libc/platform dependent -- under Valgrind on aarch64 an exact .5 rounds to even
+// instead of away from zero, which silently shifts TDIGEST.REVRANK results.
+double _halfRoundUp(double f) {
+    double int_part;
+    double frac_part = modf(f, &int_part);
+
+    if (fabs(frac_part) < 0.5)
+        return int_part;
+
+    return int_part >= 0.0 ? int_part + 1.0 : int_part - 1.0;
+}
+
 /**
  * Command: TDIGEST.CREATE {key} [{compression}]
  *
@@ -478,7 +491,7 @@ static int _TDigest_Rank(RedisModuleCtx *ctx, RedisModuleString *const *argv, in
             const double cdf_val = td_cdf(tdigest, vals[i]);
             const double cdf_val_prior_round = cdf_val * size;
             const double cdf_to_absolute =
-                reverse ? round(cdf_val_prior_round) : _halfRoundDown(cdf_val_prior_round);
+                reverse ? _halfRoundUp(cdf_val_prior_round) : _halfRoundDown(cdf_val_prior_round);
             ranks[i] = reverse ? round(size - cdf_to_absolute) : cdf_to_absolute;
         }
     }

--- a/src/rm_tdigest.c
+++ b/src/rm_tdigest.c
@@ -75,19 +75,6 @@ double _halfRoundDown(double f) {
     return int_part >= 0.0 ? int_part + 1.0 : int_part - 1.0;
 }
 
-// Counterpart of _halfRoundDown. Not expressed with round(), whose tie behaviour is
-// libc/platform dependent -- under Valgrind on aarch64 an exact .5 rounds to even
-// instead of away from zero, which silently shifts TDIGEST.REVRANK results.
-double _halfRoundUp(double f) {
-    double int_part;
-    double frac_part = modf(f, &int_part);
-
-    if (fabs(frac_part) < 0.5)
-        return int_part;
-
-    return int_part >= 0.0 ? int_part + 1.0 : int_part - 1.0;
-}
-
 /**
  * Command: TDIGEST.CREATE {key} [{compression}]
  *
@@ -491,7 +478,7 @@ static int _TDigest_Rank(RedisModuleCtx *ctx, RedisModuleString *const *argv, in
             const double cdf_val = td_cdf(tdigest, vals[i]);
             const double cdf_val_prior_round = cdf_val * size;
             const double cdf_to_absolute =
-                reverse ? _halfRoundUp(cdf_val_prior_round) : _halfRoundDown(cdf_val_prior_round);
+                reverse ? round(cdf_val_prior_round) : _halfRoundDown(cdf_val_prior_round);
             ranks[i] = reverse ? round(size - cdf_to_absolute) : cdf_to_absolute;
         }
     }

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -68,3 +68,10 @@ def wait_for_no_bgsave(env, timeout=60):
             return
         time.sleep(0.1)
     raise Exception('timed out waiting for BGSAVE to finish')
+
+def dump_and_reload(env, **kwargs):
+    # RLTest's dumpAndReload() issues SAVE before DEBUG RELOAD NOSAVE, so every call site is
+    # exposed to the BGSAVE race above. Route them all through here rather than guarding the
+    # ones that happen to lose it.
+    wait_for_no_bgsave(env)
+    env.dumpAndReload(**kwargs)

--- a/tests/flow/common.py
+++ b/tests/flow/common.py
@@ -1,5 +1,6 @@
 
 import sys
+import time
 import os
 from RLTest import Env, Defaults
 from redis import ResponseError
@@ -55,3 +56,15 @@ def server_version_at_least(env, ver):
 
 def server_version_less_than(env, ver):
     return not server_version_at_least(env, ver)
+
+def wait_for_no_bgsave(env, timeout=60):
+    # Redis < 7 defaults repl-diskless-sync to no, so attaching a replica triggers a
+    # disk-backed BGSAVE. While that fork is alive, SAVE and DEBUG RELOAD fail with
+    # "Background save already in progress" -- and under a sanitizer the fork is slow
+    # enough that tests reliably race it.
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if env.execute_command('INFO', 'persistence')['rdb_bgsave_in_progress'] == 0:
+            return
+        time.sleep(0.1)
+    raise Exception('timed out waiting for BGSAVE to finish')

--- a/tests/flow/test_cms.py
+++ b/tests/flow/test_cms.py
@@ -29,7 +29,7 @@ class testCMS():
         self.assertEqual(['width', 2000, 'depth', 7, 'count', 5],
                          self.cmd('cms.info', 'cms2'))
         yield 1
-        self.env.dumpAndReload()
+        dump_and_reload(self.env)
         yield 2
         if not VALGRIND:
             if server_version_at_least(self.env, '7.0.0'):

--- a/tests/flow/test_cuckoo.py
+++ b/tests/flow/test_cuckoo.py
@@ -163,7 +163,7 @@ class testCuckoo():
         self.cmd('FLUSHALL')
         self.cmd('CF.RESERVE', 'cf', '1000')
         yield 1
-        self.env.dumpAndReload()
+        dump_and_reload(self.env)
         yield 2
         if not VALGRIND:
             self.assertEqual(1112, self.cmd('MEMORY USAGE', 'cf'))
@@ -192,7 +192,7 @@ class testCuckoo():
         self.cmd('cf.add', 'nums', 'Redis')
         self.cmd('cf.del', 'nums', 'Redis')
         d1 = self.cmd('cf.debug', 'nums')
-        self.env.dumpAndReload()
+        dump_and_reload(self.env)
         # for _ in self.client.retry_with_rdb_reload():
         #     self.cmd('ping')
         d2 = self.cmd('cf.debug', 'nums')

--- a/tests/flow/test_overall.py
+++ b/tests/flow/test_overall.py
@@ -97,7 +97,7 @@ class testRedisBloom():
         env.cmd('FLUSHALL')
         env.assertEqual(1, env.cmd('bf.add', 'test', 'foo'))
         yield 1
-        self.env.dumpAndReload()
+        dump_and_reload(self.env)
         yield 2
         env.assertEqual(1, env.cmd('bf.exists', 'test', 'foo'))
         env.assertEqual(0, env.cmd('bf.exists', 'test', 'bar'))
@@ -218,7 +218,7 @@ class testRedisBloom():
         env.cmd('FLUSHALL')
         env.assertOk(env.cmd('bf.reserve', 'bf', '0.05', '1000'))
         yield 1
-        self.env.dumpAndReload()
+        dump_and_reload(self.env)
         yield 2
         if not VALGRIND:
             if server_version_at_least(self.env, '7.0.0'):
@@ -782,7 +782,7 @@ class testRedisBloomNoCodec():
         env.cmd('FLUSHALL')
         env.cmd('bf.reserve', 'poc', 0.0001, 1, 'EXPANSION', 1)
         env.cmd('bf.madd', 'poc', 'items', *[str(i) for i in range(10000, 15000)])
-        env.dumpAndReload()
+        dump_and_reload(env)
     
     def test_rdb_load_guards(self):
         env = self.env
@@ -801,4 +801,4 @@ class testRedisBloomNoCodec():
         env.cmd('FLUSHALL')
         env.cmd('bf.reserve', 'poc', 0.0001, 1, 'EXPANSION', 1)
         env.cmd('bf.madd', 'poc', 'items', *[str(i) for i in range(10000, 15000)])
-        env.dumpAndReload()
+        dump_and_reload(env)

--- a/tests/flow/test_tdigest.py
+++ b/tests/flow/test_tdigest.py
@@ -944,6 +944,7 @@ class testTDigest:
         # insert datapoints into sketch
         for _ in range(1, 101):
             self.assertOk(self.cmd("tdigest.add", "tdigest", 1.0))
+        wait_for_no_bgsave(self.env)
         self.assertEqual(True, self.cmd("SAVE"))
         mem_usage_prior_restart = self.cmd("MEMORY", "USAGE", "tdigest")
         tdigest_min = self.cmd("tdigest.min", "tdigest")

--- a/tests/flow/test_topk.py
+++ b/tests/flow/test_topk.py
@@ -220,6 +220,7 @@ class testTopK():
             self.env.cmd('TOPK.RESERVE', 'topkmyk1', '1', '1', '1', '0.99999')
             for i in range(2):
                 if with_reload:
+                    wait_for_no_bgsave(self.env)
                     self.env.dumpAndReload()
                 self.env.cmd('TOPK.ADD', 'topkmyk1', '%d' % i)
             results.append(self.env.cmd('TOPK.LIST', 'topkmyk1'))

--- a/tests/flow/test_topk.py
+++ b/tests/flow/test_topk.py
@@ -220,8 +220,7 @@ class testTopK():
             self.env.cmd('TOPK.RESERVE', 'topkmyk1', '1', '1', '1', '0.99999')
             for i in range(2):
                 if with_reload:
-                    wait_for_no_bgsave(self.env)
-                    self.env.dumpAndReload()
+                    dump_and_reload(self.env)
                 self.env.cmd('TOPK.ADD', 'topkmyk1', '%d' % i)
             results.append(self.env.cmd('TOPK.LIST', 'topkmyk1'))
         self.env.assertEqual(results[0], results[1])

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -8,7 +8,6 @@ READIES=$ROOT/deps/readies
 
 cd $HERE
 
-VALGRIND_REDIS_VER=6
 
 #----------------------------------------------------------------------------------------------
 
@@ -43,39 +42,12 @@ help() {
 
 setup_redis_server() {
 	if [[ -n $SAN ]]; then
-		if [[ $SAN == addr || $SAN == address ]]; then
-			REDIS_SERVER=${REDIS_SERVER:-redis-server-asan-6.2}
-			if ! command -v $REDIS_SERVER > /dev/null; then
-				echo Building Redis for clang-asan ...
-				$READIES/bin/getredis --force -v $VALGRIND_REDIS_VER --own-openssl --no-run \
-					--suffix asan --clang-asan --clang-san-blacklist /build/redis.blacklist
-			fi
-
-			export ASAN_OPTIONS=detect_odr_violation=0
-			# :detect_leaks=0
-			# for RLTest
-			export SANITIZER="$SAN"
-
-		elif [[ $SAN == mem || $SAN == memory ]]; then
-			REDIS_SERVER=${REDIS_SERVER:-redis-server-msan-6.2}
-			if ! command -v $REDIS_SERVER > /dev/null; then
-				echo Building Redis for clang-msan ...
-				$READIES/bin/getredis --force -v $VALGRIND_REDIS_VER --no-run --own-openssl \
-					--suffix msan --clang-msan --llvm-dir /opt/llvm-project/build-msan \
-					--clang-san-blacklist /build/redis.blacklist
-			fi
-		fi
-
-	elif [[ $VALGRIND == 1 ]]; then
-		REDIS_SERVER=${REDIS_SERVER:-redis-server-vg}
-		if ! is_command $REDIS_SERVER; then
-			echo Building Redis for Valgrind ...
-			$READIES/bin/getredis -v $VALGRIND_REDIS_VER --valgrind --suffix vg
-		fi
-
-	else
-		REDIS_SERVER=${REDIS_SERVER:-redis-server}
+		export ASAN_OPTIONS="detect_odr_violation=0:halt_on_error=0:detect_leaks=1:allocator_may_return_null=1"
+		# for RLTest
+		export SANITIZER="$SAN"
 	fi
+
+	REDIS_SERVER=${REDIS_SERVER:-redis-server}
 
 	if ! is_command $REDIS_SERVER; then
 		echo "Cannot find $REDIS_SERVER. Aborting."
@@ -206,7 +178,6 @@ OP=""
 [[ $VG == 1 ]] && VALGRIND=1
 [[ $SAN == addr ]] && SAN=address
 [[ $SAN == mem ]] && SAN=memory
-[[ -n $SAN ]] && QUICK=1
 
 if [[ $QUICK == 1 ]]; then
 	GEN=${GEN:-1}

--- a/tests/flow/tests.sh
+++ b/tests/flow/tests.sh
@@ -42,7 +42,15 @@ help() {
 
 setup_redis_server() {
 	if [[ -n $SAN ]]; then
-		export ASAN_OPTIONS="detect_odr_violation=0:halt_on_error=0:detect_leaks=1:allocator_may_return_null=1"
+		# No halt_on_error=0 here: this branch has no ASan log scanner (sbin/memcheck-summary
+		# does not exist on 2.4), so aborting the server on the first report is the only thing
+		# that can turn a module-side finding into a job failure. allocator_may_return_null=1
+		# still keeps the oversized-allocation hardening tests running -- those get NULL back
+		# instead of an ASan report.
+		export ASAN_OPTIONS="detect_odr_violation=0:detect_leaks=1:allocator_may_return_null=1"
+		# tells RLTest to redirect the ASan output into logs/*.asan.log, which the failure
+		# artifact upload collects
+		SAN_ARGS="--sanitizer $SAN"
 		# for RLTest
 		export SANITIZER="$SAN"
 	fi
@@ -179,16 +187,17 @@ OP=""
 [[ $SAN == addr ]] && SAN=address
 [[ $SAN == mem ]] && SAN=memory
 
+# the Makefile exports OSS_CLUSTER, not CLUSTER, so accept both names
 if [[ $QUICK == 1 ]]; then
 	GEN=${GEN:-1}
 	SLAVES=${SLAVES:-0}
 	AOF=${AOF:-0}
-	CLUSTER=${CLUSTER:-0}
+	CLUSTER=${CLUSTER:-${OSS_CLUSTER:-0}}
 else
 	GEN=${GEN:-1}
 	SLAVES=${SLAVES:-1}
 	AOF=${AOF:-1}
-	CLUSTER=${CLUSTER:-1}
+	CLUSTER=${CLUSTER:-${OSS_CLUSTER:-1}}
 fi
 
 MODULE=${MODULE:-$1}


### PR DESCRIPTION
The `linux-sanitizer` and `linux-valgrind` nightly jobs have both been failing on
this branch for a while ([sanitizer](https://github.com/RedisBloom/RedisBloom/actions/runs/30031037416/job/89287450606),
[valgrind](https://github.com/RedisBloom/RedisBloom/actions/runs/30031037416/job/89287443697)).
None of the failures were module bugs. Companion to #1051 (2.6).

## `tests/flow/tests.sh`

The sanitizer job aborted with `Cannot find redis-server-asan-6.2`:
`setup_redis_server` looked for that exact name, but `getredis --suffix asan` installs the
binary as plain `redis-server-asan`, so it never matched. The Docker image already builds
redis with `SANITIZER=address`, so rebuilding redis here was both redundant and broken —
dropped, and `redis-server` from `PATH` is used instead, as on 8.4. `ASAN_OPTIONS` gains
`allocator_may_return_null=1` so the oversized-allocation hardening tests do not abort the run.

The valgrind job crashed the server in
`test_cuckoo.py:test_number_of_buckets_does_not_overflow`. That test loads a crafted CF
header declaring 2^32 buckets, so `CFHeader_Load` callocs 4 GiB. `getredis --valgrind`
builds redis with `MALLOC=libc`, which routes that allocation through valgrind's own
allocator and makes valgrind run out of memory. Using the image's jemalloc redis keeps the
allocation out of valgrind's allocator; verified the exact `CF.LOADCHUNK` + `CF.INSERT`
sequence now passes under valgrind with an empty valgrind log and the server alive.

Also dropped `[[ -n $SAN ]] && QUICK=1` so sanitizer runs cover every topology, as on
8.4/master. In practice that line only ever suppressed the `oss-cluster` variant: the
Makefile exports `GEN`/`SLAVES`/`AOF`, so the `${VAR:-0}` defaults in the `QUICK` branch
could not turn those off, but it exports `OSS_CLUSTER` while this script reads `CLUSTER`,
leaving `CLUSTER` unset and defaulted to `0`.

## `.install/install_redis.sh`

Dropping the `getredis` path exposed two further problems behind it, both specific to this
branch's redis 6.2 pin:

1. **Redis only grew Makefile `SANITIZER` support in 7.0.** On 6.2 the flag is silently
   ignored (`grep -c SANITIZER redis/src/Makefile` → `0`), so the image shipped an
   uninstrumented server and the sanitized module could not even be `dlopen`'d:
   `undefined symbol: __asan_option_detect_stack_use_after_return`. The equivalent flags are
   now passed by hand when `src/Makefile` has no `ifdef SANITIZER`, mirroring what redis 7.x
   does for `SANITIZER=address` (it also forces libc malloc).

2. **Compiler mismatch.** The module is instrumented by clang (readies
   `mk/clang-sanitizer.defs`) while redis was built with gcc. A clang-built shared object links
   no ASan runtime of its own, so it resolves its `__asan_*` symbols against whatever runtime
   redis already loaded; with redis 6.2 built by gcc on jammy, module load aborted with a
   `global-buffer-overflow` in `RM_GetApi`. Redis is now built with `CC=clang LD=clang` whenever
   `SANITIZER` is set, so both sides use the same runtime. This is *not* a general gcc/clang
   incompatibility — see the review follow-up below.

Both `make` invocations get the same arguments so `make install` does not relink an
uninstrumented binary over the sanitized one.

## `tests/flow/{common,test_tdigest,test_topk}.py`

With the sanitizer job actually running, two tests raced the replica-sync BGSAVE under
`--use-slaves` and failed with `Background save already in progress`.
`repl-diskless-sync` defaults to `no` on redis 6.2, so attaching a replica forks a
disk-backed BGSAVE that blocks `SAVE` and `DEBUG RELOAD`; redis 7+ defaults to diskless,
which is why master never had to deal with this. Under a sanitizer the fork is slow enough
that the race is lost every time. Added `wait_for_no_bgsave()`, called before the direct `SAVE`
in `test_save_load`, and a `dump_and_reload()` wrapper that every `dumpAndReload()` call site
now goes through, so all four topologies stay covered rather than narrowing the job's scope.

## Verification

Ran in the `jammy` container locally. Sanitizer suite green across all four topologies:

| topology | result |
|---|---|
| general | 138 run / 0 failed |
| `--use-slaves` | 138 run / 0 failed |
| `--use-aof` | 138 run / 0 failed |
| `--env oss-cluster` | 138 run / 0 failed |

The local valgrind run is **not** a clean pass — see the note below.

## Open item for CI

Local valgrind runs (on **arm64**, whereas CI is x64) hit `TDIGEST.REVRANK` off-by-one
assertion failures in `test_tdigest_revrank` and `test_tdigest_rank_and_revrank`, e.g.
`[15, 14, 13, 10, 7, 2, -1]` vs `[15, 15, 13, 11, 7, 3, -1]`. These are numeric, not memory
errors, and 2.6 shows the same thing. I could not attribute them confidently: `VG=1` also
implies `DEBUG=1` and adds `-D_VALGRIND`, and valgrind's FP emulation differs by
architecture. The x64 valgrind job on this PR should settle whether it is real or an arm64
artifact.

## Review follow-ups

- `halt_on_error=0` had nothing to fall back on here: 2.4 has no `sbin/memcheck-summary`, and
  `$SAN_ARGS` — the only thing that makes RLTest pass `--sanitizer` and write
  `logs/*.asan.log` — was never assigned. A recoverable module-side finding would have printed
  into the server log and left the nightly green. `halt_on_error` is dropped so ASan aborts the
  server on the first report, and `SAN_ARGS` is now set so the report also lands in a file the
  `if: failure()` artifact upload collects. `allocator_may_return_null=1` still covers the
  oversized-allocation hardening tests. This may legitimately turn the job red on its first run
  if such a finding exists on this branch — that is the point.
- `tests.sh` read `$CLUSTER`/`$QUICK`, but the Makefile exports `OSS_CLUSTER`, so
  `make flow-tests OSS_CLUSTER=0` still ran the oss-cluster variant. That was masked by the
  `[[ -n $SAN ]] && QUICK=1` line this PR removes, so both branches now fall back to
  `OSS_CLUSTER`. Same fix on #1051.
- `wait_for_no_bgsave` covered only 2 of the ~9 exposed sites. `common.py` now has a
  `dump_and_reload(env, **kwargs)` wrapper and every `dumpAndReload()` call site goes through
  it (`test_cms.py`, `test_cuckoo.py` ×2, `test_overall.py` ×4, `test_topk.py`).
  `test_topk.py:62` keeps `restart=True` — the restart path does not issue `SAVE`, so it is not
  exposed — and the `retry_with_rdb_reload` aliases are left alone since every use of them is
  commented out.
- The `_halfRoundUp` attempt at the `TDIGEST.REVRANK` divergence has been **reverted** — over
  the reachable domain it is bit-for-bit `round()`, so it could not have changed the result,
  and its `int_part >= 0.0` guard was wrong for `(-1, 0)` where `modf` yields `-0.0`. `src/` is
  now byte-identical to `2.4`; the REVRANK item below stays open and belongs in its own PR.
- The `CC=clang` rationale is narrowed. It stays, because it is what was verified working on
  this branch, but it is not a general gcc/clang incompatibility: `master` builds redis with the
  image's gcc under `SANITIZER=address`, pairs it with the same clang-built module, and its
  `linux-sanitizer / x64-jammy` job is green (run 31906795267 and the three nightlies before
  it). What is genuinely specific to 2.4 is redis 6.2 having no `ifdef SANITIZER` at all, which
  the `REDIS_CFLAGS`/`REDIS_LDFLAGS`/`MALLOC=libc` branch fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI install scripts and test infrastructure; no module runtime logic is modified.
> 
> **Overview**
> Fixes failing **linux-sanitizer** and **linux-valgrind** nightly jobs on the 2.4 branch by aligning Redis builds, test harness setup, and persistence-related test timing with how newer branches run CI.
> 
> **Redis install (sanitizer):** When `SANITIZER` is set, `.install/install_redis.sh` now builds Redis with **clang** (matching the clang-instrumented module) and applies sanitizer flags correctly on the pinned **6.2** tree—either via Makefile `SANITIZER` on 7.0+ or manual `REDIS_CFLAGS`/`REDIS_LDFLAGS` plus `MALLOC=libc` when that target is missing. The same `make` arguments are passed to **`make install`** so install does not replace a sanitized binary.
> 
> **Flow test runner:** `tests/flow/tests.sh` stops looking up or building suffix-specific servers (`redis-server-asan-6.2`, valgrind `getredis` builds) and uses **`redis-server` from PATH** (image-built Redis). Sanitizer runs set **`ASAN_OPTIONS`** (including `allocator_may_return_null=1`), wire RLTest **`--sanitizer`**, and no longer force **`QUICK=1`** so all topologies (including OSS cluster via **`OSS_CLUSTER`**) still run.
> 
> **BGSAVE races:** `common.py` adds **`wait_for_no_bgsave`** and **`dump_and_reload`**; RDB reload call sites in CMS, Cuckoo, Bloom, TopK, and TDigest use them so **`SAVE` / `DEBUG RELOAD`** do not hit *Background save already in progress* under slow sanitizer forks with replicas on Redis &lt; 7.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf19ca5e50edf98b79dae7002b8f42e507a5f0d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
