### PR TITLE
MOD-17398 CMS Extention

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -503,6 +503,22 @@
       {
         "name": "depth",
         "type": "integer"
+      },
+      {
+        "name": "cellsize",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "cell_size",
+            "token": "CELL_SIZE",
+            "type": "pure-token"
+          },
+          {
+            "name": "size",
+            "type": "integer"
+          }
+        ]
       }
     ],
     "since": "2.0.0",
@@ -523,13 +539,29 @@
       {
         "name": "probability",
         "type": "double"
+      },
+      {
+        "name": "cellsize",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "cell_size",
+            "token": "CELL_SIZE",
+            "type": "pure-token"
+          },
+          {
+            "name": "size",
+            "type": "integer"
+          }
+        ]
       }
     ],
     "since": "2.0.0",
     "group": "cms"
   },
   "CMS.INCRBY": {
-    "summary": "Increases the count of one or more items by increment",
+    "summary": "Changes the count of one or more items by increment, which may be negative",
     "complexity": "O(n) where n is the number of items",
     "arguments": [
       {

--- a/commands.json
+++ b/commands.json
@@ -198,31 +198,31 @@
         "type": "oneof",
         "optional": true,
         "arguments": [
-            {
-              "name": "capacity",
-              "type": "pure-token",
-              "token": "CAPACITY"
-            },
-            {
-              "name": "size",
-              "type": "pure-token",
-              "token": "SIZE"
-            },
-            {
-              "name": "filters",
-              "type": "pure-token",
-              "token": "FILTERS"
-            },
-            {
-              "name": "items",
-              "type": "pure-token",
-              "token": "ITEMS"
-            },
-            {
-              "name": "expansion",
-              "type": "pure-token",
-              "token": "EXPANSION"
-            }
+          {
+            "name": "capacity",
+            "type": "pure-token",
+            "token": "CAPACITY"
+          },
+          {
+            "name": "size",
+            "type": "pure-token",
+            "token": "SIZE"
+          },
+          {
+            "name": "filters",
+            "type": "pure-token",
+            "token": "FILTERS"
+          },
+          {
+            "name": "items",
+            "type": "pure-token",
+            "token": "ITEMS"
+          },
+          {
+            "name": "expansion",
+            "type": "pure-token",
+            "token": "EXPANSION"
+          }
         ]
       }
     ],
@@ -561,7 +561,7 @@
     "group": "cms"
   },
   "CMS.INCRBY": {
-    "summary": "Changes the count of one or more items by increment, which may be negative",
+    "summary": "Increases the count of one or more items by increment, which may be negative",
     "complexity": "O(n) where n is the number of items",
     "arguments": [
       {
@@ -858,8 +858,7 @@
       {
         "name": "destination-key",
         "type": "key"
-      }
-      ,
+      },
       {
         "name": "numkeys",
         "type": "integer"

--- a/src/cmd_info/cms_info.c
+++ b/src/cmd_info/cms_info.c
@@ -26,7 +26,7 @@ static const RedisModuleCommandArg CMS_INCRBY_ARGS[] = {
 
 static const RedisModuleCommandInfo CMS_INCRBY_INFO = {
     .version = REDISMODULE_COMMAND_INFO_VERSION,
-    .summary = "Changes the count of one or more items by increment, which may be negative",
+    .summary = "Increases the count of one or more items by increment, which may be negative",
     .complexity = "O(n) where n is the number of items",
     .since = "2.0.0",
     .arity = -4,

--- a/src/cmd_info/cms_info.c
+++ b/src/cmd_info/cms_info.c
@@ -26,7 +26,7 @@ static const RedisModuleCommandArg CMS_INCRBY_ARGS[] = {
 
 static const RedisModuleCommandInfo CMS_INCRBY_INFO = {
     .version = REDISMODULE_COMMAND_INFO_VERSION,
-    .summary = "Increases the count of one or more items by increment",
+    .summary = "Changes the count of one or more items by increment, which may be negative",
     .complexity = "O(n) where n is the number of items",
     .since = "2.0.0",
     .arity = -4,
@@ -60,7 +60,7 @@ static const RedisModuleCommandInfo CMS_INFO_INFO = {
 };
 
 // ===============================
-// CMS.INITBYDIM key width depth
+// CMS.INITBYDIM key width depth [CELL_SIZE 1|2|4|8]
 // ===============================
 static const RedisModuleCommandKeySpec CMS_INITBYDIM_KEYSPECS[] = {
     {.flags = REDISMODULE_CMD_KEY_RW,
@@ -74,6 +74,16 @@ static const RedisModuleCommandArg CMS_INITBYDIM_ARGS[] = {
     {.name = "key", .type = REDISMODULE_ARG_TYPE_KEY, .key_spec_index = 0},
     {.name = "width", .type = REDISMODULE_ARG_TYPE_INTEGER},
     {.name = "depth", .type = REDISMODULE_ARG_TYPE_INTEGER},
+    {
+        .name = "cellsize",
+        .type = REDISMODULE_ARG_TYPE_BLOCK,
+        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+        .subargs = (RedisModuleCommandArg[]){{.name = "cell_size",
+                                              .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                              .token = "CELL_SIZE"},
+                                             {.name = "size", .type = REDISMODULE_ARG_TYPE_INTEGER},
+                                             {0}},
+    },
     {0}};
 
 static const RedisModuleCommandInfo CMS_INITBYDIM_INFO = {
@@ -81,13 +91,13 @@ static const RedisModuleCommandInfo CMS_INITBYDIM_INFO = {
     .summary = "Initializes a Count-Min Sketch to dimensions specified by user",
     .complexity = "O(1)",
     .since = "2.0.0",
-    .arity = 4,
+    .arity = -4,
     .key_specs = (RedisModuleCommandKeySpec *)CMS_INITBYDIM_KEYSPECS,
     .args = (RedisModuleCommandArg *)CMS_INITBYDIM_ARGS,
 };
 
 // ===============================
-// CMS.INITBYPROB key error probability
+// CMS.INITBYPROB key error probability [CELL_SIZE 1|2|4|8]
 // ===============================
 static const RedisModuleCommandKeySpec CMS_INITBYPROB_KEYSPECS[] = {
     {.flags = REDISMODULE_CMD_KEY_RW,
@@ -101,6 +111,16 @@ static const RedisModuleCommandArg CMS_INITBYPROB_ARGS[] = {
     {.name = "key", .type = REDISMODULE_ARG_TYPE_KEY, .key_spec_index = 0},
     {.name = "error", .type = REDISMODULE_ARG_TYPE_DOUBLE},
     {.name = "probability", .type = REDISMODULE_ARG_TYPE_DOUBLE},
+    {
+        .name = "cellsize",
+        .type = REDISMODULE_ARG_TYPE_BLOCK,
+        .flags = REDISMODULE_CMD_ARG_OPTIONAL,
+        .subargs = (RedisModuleCommandArg[]){{.name = "cell_size",
+                                              .type = REDISMODULE_ARG_TYPE_PURE_TOKEN,
+                                              .token = "CELL_SIZE"},
+                                             {.name = "size", .type = REDISMODULE_ARG_TYPE_INTEGER},
+                                             {0}},
+    },
     {0}};
 
 static const RedisModuleCommandInfo CMS_INITBYPROB_INFO = {
@@ -108,7 +128,7 @@ static const RedisModuleCommandInfo CMS_INITBYPROB_INFO = {
     .summary = "Initializes a Count-Min Sketch to accommodate requested tolerances.",
     .complexity = "O(1)",
     .since = "2.0.0",
-    .arity = 4,
+    .arity = -4,
     .key_specs = (RedisModuleCommandKeySpec *)CMS_INITBYPROB_KEYSPECS,
     .args = (RedisModuleCommandArg *)CMS_INITBYPROB_ARGS,
 };

--- a/src/cms.c
+++ b/src/cms.c
@@ -55,6 +55,15 @@ static inline void cellSet(CMSketch *cms, size_t loc, uint64_t value) {
     }
 }
 
+static void cmsUndoIncrByRows(CMSketch *cms, const char *item, size_t itemlen, size_t rowsApplied,
+                              int64_t value, uint64_t magnitude) {
+    for (size_t j = 0; j < rowsApplied; ++j) { // undo the rows already applied
+        const size_t undo = (CMS_HASH(item, itemlen, j) % cms->width) + (j * cms->width);
+        cellSet(cms, undo,
+                (value < 0) ? cellGet(cms, undo) + magnitude : cellGet(cms, undo) - magnitude);
+    }
+}
+
 CMSketch *NewCMSketch(size_t width, size_t depth, uint8_t cellSize) {
     assert(width > 0);
     assert(depth > 0);
@@ -123,12 +132,7 @@ CMSStatus CMS_IncrBy(CMSketch *cms, const char *item, size_t itemlen, int64_t va
 
         // On error path, undo changes and return the error
         if ((value > 0 && magnitude > cellMax - cell) || (value < 0 && magnitude > cell)) {
-            for (size_t j = 0; j < i; ++j) { // undo the rows already applied
-                const size_t undo = (CMS_HASH(item, itemlen, j) % cms->width) + (j * cms->width);
-                cellSet(cms, undo,
-                        (value < 0) ? cellGet(cms, undo) + magnitude
-                                    : cellGet(cms, undo) - magnitude);
-            }
+            cmsUndoIncrByRows(cms, item, itemlen, i, value, magnitude);
             return (value > 0) ? CMS_STATUS_OVERFLOW : CMS_STATUS_UNDERFLOW;
         }
 

--- a/src/cms.c
+++ b/src/cms.c
@@ -100,6 +100,10 @@ void CMS_Destroy(CMSketch *cms) {
     CMS_FREE(cms);
 }
 
+// 64 is the deepest sketch CMS_DimFromProb yields above a ~1e-19 error probability,
+// and costs only 512 B of stack.
+#define CMS_LOC_SCRATCH 64
+
 CMSStatus CMS_IncrBy(CMSketch *cms, const char *item, size_t itemlen, int64_t value,
                      uint64_t *count) {
     assert(cms);
@@ -109,11 +113,16 @@ CMSStatus CMS_IncrBy(CMSketch *cms, const char *item, size_t itemlen, int64_t va
     const uint64_t cellMax = CMS_CELL_MAX(cms->cellSize);
     const uint64_t magnitude = (value < 0) ? -(uint64_t)value : (uint64_t)value;
 
+    size_t scratch[CMS_LOC_SCRATCH];
+
     // First pass validates the whole operation, so that a rejected increment
     // leaves the sketch untouched.
     for (size_t i = 0; i < cms->depth; ++i) {
-        uint32_t hash = CMS_HASH(item, itemlen, i);
-        const uint64_t cell = cellGet(cms, (hash % cms->width) + (i * cms->width));
+        const size_t loc = (CMS_HASH(item, itemlen, i) % cms->width) + (i * cms->width);
+        if (i < CMS_LOC_SCRATCH) {
+            scratch[i] = loc;
+        }
+        const uint64_t cell = cellGet(cms, loc);
         if (value > 0 && magnitude > cellMax - cell) {
             return CMS_STATUS_OVERFLOW;
         }
@@ -135,8 +144,9 @@ CMSStatus CMS_IncrBy(CMSketch *cms, const char *item, size_t itemlen, int64_t va
 
     uint64_t minCount = UINT64_MAX;
     for (size_t i = 0; i < cms->depth; ++i) {
-        uint32_t hash = CMS_HASH(item, itemlen, i);
-        size_t loc = (hash % cms->width) + (i * cms->width);
+        const size_t loc = (i < CMS_LOC_SCRATCH)
+                               ? scratch[i]
+                               : (CMS_HASH(item, itemlen, i) % cms->width) + (i * cms->width);
         const uint64_t updated =
             (value < 0) ? cellGet(cms, loc) - magnitude : cellGet(cms, loc) + magnitude;
         cellSet(cms, loc, updated);

--- a/src/cms.c
+++ b/src/cms.c
@@ -20,11 +20,47 @@
 #define BIT64 64
 #define CMS_HASH(item, itemlen, i) MurmurHash2(item, itemlen, i)
 
-CMSketch *NewCMSketch(size_t width, size_t depth) {
+static inline uint64_t cellGet(const CMSketch *cms, size_t loc) {
+    switch (cms->cellSize) {
+    case 1:
+        return ((const uint8_t *)cms->array)[loc];
+    case 2:
+        return ((const uint16_t *)cms->array)[loc];
+    case 4:
+        return ((const uint32_t *)cms->array)[loc];
+    case 8:
+        return ((const uint64_t *)cms->array)[loc];
+    default:
+        assert(0); // unreachable
+        return 0;
+    }
+}
+
+static inline void cellSet(CMSketch *cms, size_t loc, uint64_t value) {
+    switch (cms->cellSize) {
+    case 1:
+        ((uint8_t *)cms->array)[loc] = (uint8_t)value;
+        break;
+    case 2:
+        ((uint16_t *)cms->array)[loc] = (uint16_t)value;
+        break;
+    case 4:
+        ((uint32_t *)cms->array)[loc] = (uint32_t)value;
+        break;
+    case 8:
+        ((uint64_t *)cms->array)[loc] = value;
+        break;
+    default:
+        assert(0); // unreachable
+    }
+}
+
+CMSketch *NewCMSketch(size_t width, size_t depth, uint8_t cellSize) {
     assert(width > 0);
     assert(depth > 0);
+    assert(CMS_IS_VALID_CELL_SIZE(cellSize));
 
-    if (width > SIZE_MAX / depth || width * depth > SIZE_MAX / sizeof(uint32_t)) {
+    if (width > SIZE_MAX / depth || width * depth > SIZE_MAX / cellSize) {
         return NULL;
     }
 
@@ -33,7 +69,8 @@ CMSketch *NewCMSketch(size_t width, size_t depth) {
     cms->width = width;
     cms->depth = depth;
     cms->counter = 0;
-    cms->array = CMS_TRYCALLOC(width * depth, sizeof(uint32_t));
+    cms->cellSize = cellSize;
+    cms->array = CMS_TRYCALLOC(width * depth, cellSize);
     if (!cms->array) {
         CMS_FREE(cms);
         return NULL;
@@ -63,34 +100,63 @@ void CMS_Destroy(CMSketch *cms) {
     CMS_FREE(cms);
 }
 
-size_t CMS_IncrBy(CMSketch *cms, const char *item, size_t itemlen, size_t value) {
+CMSStatus CMS_IncrBy(CMSketch *cms, const char *item, size_t itemlen, int64_t value,
+                     uint64_t *count) {
     assert(cms);
     assert(item);
+    assert(count);
 
-    size_t minCount = (size_t)-1;
+    const uint64_t cellMax = CMS_CELL_MAX(cms->cellSize);
+    const uint64_t magnitude = (value < 0) ? -(uint64_t)value : (uint64_t)value;
 
+    // First pass validates the whole operation, so that a rejected increment
+    // leaves the sketch untouched.
+    for (size_t i = 0; i < cms->depth; ++i) {
+        uint32_t hash = CMS_HASH(item, itemlen, i);
+        const uint64_t cell = cellGet(cms, (hash % cms->width) + (i * cms->width));
+        if (value > 0 && magnitude > cellMax - cell) {
+            return CMS_STATUS_OVERFLOW;
+        }
+        if (value < 0 && magnitude > cell) {
+            return CMS_STATUS_UNDERFLOW;
+        }
+    }
+    // The total count is replied as a RESP integer, so it is capped the same way
+    // a cell is: a row holds `width` cells, so it could otherwise exceed INT64_MAX.
+    if (value > 0 && magnitude > (uint64_t)INT64_MAX - cms->counter) {
+        return CMS_STATUS_OVERFLOW;
+    }
+    // No sequence of commands can make counter smaller than a row's cells, but a
+    // RESTORE payload can: the load path validates the dimensions and the buffer
+    // length, never counter against the array. Without this, counter would wrap.
+    if (value < 0 && magnitude > cms->counter) {
+        return CMS_STATUS_UNDERFLOW;
+    }
+
+    uint64_t minCount = UINT64_MAX;
     for (size_t i = 0; i < cms->depth; ++i) {
         uint32_t hash = CMS_HASH(item, itemlen, i);
         size_t loc = (hash % cms->width) + (i * cms->width);
-        cms->array[loc] += value;
-        if (cms->array[loc] < value) {
-            cms->array[loc] = UINT32_MAX;
-        }
-        minCount = min(minCount, cms->array[loc]);
+        const uint64_t updated =
+            (value < 0) ? cellGet(cms, loc) - magnitude : cellGet(cms, loc) + magnitude;
+        cellSet(cms, loc, updated);
+        minCount = min(minCount, updated);
     }
-    cms->counter += value;
-    return minCount;
+    cms->counter = (value < 0) ? cms->counter - magnitude : cms->counter + magnitude;
+
+    *count = minCount;
+    return CMS_STATUS_OK;
 }
 
-size_t CMS_Query(CMSketch *cms, const char *item, size_t itemlen) {
+uint64_t CMS_Query(CMSketch *cms, const char *item, size_t itemlen) {
     assert(cms);
     assert(item);
 
-    size_t minCount = (size_t)-1;
+    uint64_t minCount = UINT64_MAX;
 
     for (size_t i = 0; i < cms->depth; ++i) {
         uint32_t hash = CMS_HASH(item, itemlen, i);
-        minCount = min(minCount, cms->array[(hash % cms->width) + (i * cms->width)]);
+        minCount = min(minCount, cellGet(cms, (hash % cms->width) + (i * cms->width)));
     }
     return minCount;
 }
@@ -101,6 +167,7 @@ static int checkOverflow(CMSketch *dest, size_t quantity, const CMSketch **src,
     int64_t cmsCount = 0;
     size_t width = dest->width;
     size_t depth = dest->depth;
+    const int64_t cellMax = (int64_t)CMS_CELL_MAX(dest->cellSize);
 
     for (size_t i = 0; i < depth; ++i) {
         for (size_t j = 0; j < width; ++j) {
@@ -112,14 +179,15 @@ static int checkOverflow(CMSketch *dest, size_t quantity, const CMSketch **src,
                 int64_t mul = 0;
 
                 // Validation for:
-                //   itemCount += src[k]->array[(i * width) + j] * weights[k];
-                if (__builtin_mul_overflow(src[k]->array[(i * width) + j], weights[k], &mul) ||
+                //   itemCount += cellGet(src[k], (i * width) + j) * weights[k];
+                if (__builtin_mul_overflow((int64_t)cellGet(src[k], (i * width) + j), weights[k],
+                                           &mul) ||
                     (__builtin_add_overflow(itemCount, mul, &itemCount))) {
                     return -1;
                 }
             }
 
-            if (itemCount < 0 || itemCount > UINT32_MAX) {
+            if (itemCount < 0 || itemCount > cellMax) {
                 return -1;
             }
         }
@@ -160,9 +228,9 @@ int CMS_Merge(CMSketch *dest, size_t quantity, const CMSketch **src, const long 
         for (size_t j = 0; j < width; ++j) {
             itemCount = 0;
             for (size_t k = 0; k < quantity; ++k) {
-                itemCount += (int64_t)src[k]->array[(i * width) + j] * weights[k];
+                itemCount += (int64_t)cellGet(src[k], (i * width) + j) * weights[k];
             }
-            dest->array[(i * width) + j] = itemCount;
+            cellSet(dest, (i * width) + j, (uint64_t)itemCount);
         }
     }
 

--- a/src/cms.c
+++ b/src/cms.c
@@ -100,10 +100,6 @@ void CMS_Destroy(CMSketch *cms) {
     CMS_FREE(cms);
 }
 
-// 64 is the deepest sketch CMS_DimFromProb yields above a ~1e-19 error probability,
-// and costs only 512 B of stack.
-#define CMS_LOC_SCRATCH 64
-
 CMSStatus CMS_IncrBy(CMSketch *cms, const char *item, size_t itemlen, int64_t value,
                      uint64_t *count) {
     assert(cms);
@@ -113,42 +109,30 @@ CMSStatus CMS_IncrBy(CMSketch *cms, const char *item, size_t itemlen, int64_t va
     const uint64_t cellMax = CMS_CELL_MAX(cms->cellSize);
     const uint64_t magnitude = (value < 0) ? -(uint64_t)value : (uint64_t)value;
 
-    size_t scratch[CMS_LOC_SCRATCH];
-
-    // First pass validates the whole operation, so that a rejected increment
-    // leaves the sketch untouched.
-    for (size_t i = 0; i < cms->depth; ++i) {
-        const size_t loc = (CMS_HASH(item, itemlen, i) % cms->width) + (i * cms->width);
-        if (i < CMS_LOC_SCRATCH) {
-            scratch[i] = loc;
-        }
-        const uint64_t cell = cellGet(cms, loc);
-        if (value > 0 && magnitude > cellMax - cell) {
-            return CMS_STATUS_OVERFLOW;
-        }
-        if (value < 0 && magnitude > cell) {
-            return CMS_STATUS_UNDERFLOW;
-        }
-    }
-    // The total count is replied as a RESP integer, so it is capped the same way
-    // a cell is: a row holds `width` cells, so it could otherwise exceed INT64_MAX.
     if (value > 0 && magnitude > (uint64_t)INT64_MAX - cms->counter) {
         return CMS_STATUS_OVERFLOW;
     }
-    // No sequence of commands can make counter smaller than a row's cells, but a
-    // RESTORE payload can: the load path validates the dimensions and the buffer
-    // length, never counter against the array. Without this, counter would wrap.
     if (value < 0 && magnitude > cms->counter) {
         return CMS_STATUS_UNDERFLOW;
     }
 
     uint64_t minCount = UINT64_MAX;
     for (size_t i = 0; i < cms->depth; ++i) {
-        const size_t loc = (i < CMS_LOC_SCRATCH)
-                               ? scratch[i]
-                               : (CMS_HASH(item, itemlen, i) % cms->width) + (i * cms->width);
-        const uint64_t updated =
-            (value < 0) ? cellGet(cms, loc) - magnitude : cellGet(cms, loc) + magnitude;
+        const size_t loc = (CMS_HASH(item, itemlen, i) % cms->width) + (i * cms->width);
+        const uint64_t cell = cellGet(cms, loc);
+
+        // On error path, undo changes and return the error
+        if ((value > 0 && magnitude > cellMax - cell) || (value < 0 && magnitude > cell)) {
+            for (size_t j = 0; j < i; ++j) { // undo the rows already applied
+                const size_t undo = (CMS_HASH(item, itemlen, j) % cms->width) + (j * cms->width);
+                cellSet(cms, undo,
+                        (value < 0) ? cellGet(cms, undo) + magnitude
+                                    : cellGet(cms, undo) - magnitude);
+            }
+            return (value > 0) ? CMS_STATUS_OVERFLOW : CMS_STATUS_UNDERFLOW;
+        }
+
+        const uint64_t updated = (value < 0) ? cell - magnitude : cell + magnitude;
         cellSet(cms, loc, updated);
         minCount = min(minCount, updated);
     }

--- a/src/cms.c
+++ b/src/cms.c
@@ -161,6 +161,29 @@ uint64_t CMS_Query(CMSketch *cms, const char *item, size_t itemlen) {
     return minCount;
 }
 
+int CMS_ValidateLoaded(const CMSketch *cms) {
+    assert(cms);
+
+    // The total count is replied as a RESP integer, and CMS_IncrBy computes its
+    // headroom as INT64_MAX - counter, which wraps if counter is already above it.
+    if (cms->counter > (uint64_t)INT64_MAX) {
+        return -1;
+    }
+
+    // Only 8-byte cells can hold more than their maximum: the narrower widths
+    // cannot physically represent a value above CMS_CELL_MAX.
+    if (cms->cellSize == 8) {
+        const uint64_t cellMax = CMS_CELL_MAX(cms->cellSize);
+        for (size_t i = 0; i < cms->width * cms->depth; ++i) {
+            if (cellGet(cms, i) > cellMax) {
+                return -1;
+            }
+        }
+    }
+
+    return 0;
+}
+
 static int checkOverflow(CMSketch *dest, size_t quantity, const CMSketch **src,
                          const long long *weights) {
     int64_t itemCount = 0;

--- a/src/cms.h
+++ b/src/cms.h
@@ -22,11 +22,20 @@
 // #define CMS_FREE(ptr) free(ptr)
 #endif
 
+#define CMS_DEFAULT_CELL_SIZE 4
+
+#define CMS_IS_VALID_CELL_SIZE(cellSize)                                                           \
+    ((cellSize) == 1 || (cellSize) == 2 || (cellSize) == 4 || (cellSize) == 8)
+
+#define CMS_CELL_MAX(cellSize)                                                                     \
+    ((cellSize) == 8 ? (uint64_t)INT64_MAX : ((UINT64_C(1) << (8 * (uint64_t)(cellSize))) - 1))
+
 typedef struct CMS {
     size_t width;
     size_t depth;
-    uint32_t *array;
+    void *array;
     size_t counter;
+    uint8_t cellSize; // bytes per cell: 1, 2, 4 or 8
 } CMSketch;
 
 typedef struct {
@@ -36,8 +45,15 @@ typedef struct {
     long long *weights;
 } mergeParams;
 
-/* Creates a new Count-Min Sketch with dimensions of width * depth */
-CMSketch *NewCMSketch(size_t width, size_t depth);
+typedef enum {
+    CMS_STATUS_OK = 0,
+    CMS_STATUS_OVERFLOW,
+    CMS_STATUS_UNDERFLOW,
+} CMSStatus;
+
+/*  Creates a new Count-Min Sketch with dimensions of width * depth,
+    with cellSize bytes per cell */
+CMSketch *NewCMSketch(size_t width, size_t depth, uint8_t cellSize);
 
 /*  Recommends width & depth for expected n different items,
     with probability of an error  - prob and over estimation
@@ -46,15 +62,20 @@ void CMS_DimFromProb(double overEst, double prob, size_t *width, size_t *depth);
 
 void CMS_Destroy(CMSketch *cms);
 
-/*  Increases item count in value.
-    Value must be a non negative number */
-size_t CMS_IncrBy(CMSketch *cms, const char *item, size_t strlen, size_t value);
+/*  Changes item count by value. A negative value decrements the count.
+
+    On success returns CMS_STATUS_OK and stores the new estimate in count.
+    If the change would take any of the item's cells above the maximum value a
+    cell can hold, or below zero, the sketch is left untouched and
+    CMS_STATUS_OVERFLOW / CMS_STATUS_UNDERFLOW is returned. */
+CMSStatus CMS_IncrBy(CMSketch *cms, const char *item, size_t strlen, int64_t value,
+                     uint64_t *count);
 
 /* Returns an estimate counter for item */
-size_t CMS_Query(CMSketch *cms, const char *item, size_t strlen);
+uint64_t CMS_Query(CMSketch *cms, const char *item, size_t strlen);
 
 /*  Merges multiple CMSketches into a single one.
-    All sketches must have identical width and depth.
+    All sketches must have identical width, depth and cell size.
     dest must be already initialized.
 
     Returns non-zero if overflow validation fails. In this case,

--- a/src/cms.h
+++ b/src/cms.h
@@ -74,6 +74,13 @@ CMSStatus CMS_IncrBy(CMSketch *cms, const char *item, size_t strlen, int64_t val
 /* Returns an estimate counter for item */
 uint64_t CMS_Query(CMSketch *cms, const char *item, size_t strlen);
 
+/*  Checks a deserialized sketch for values no command could have produced: a cell
+    or a total count above what the cell size allows. RESTORE payloads are caller
+    controlled, and the headroom arithmetic in CMS_IncrBy relies on both bounds.
+
+    Returns non-zero if the sketch must be rejected. */
+int CMS_ValidateLoaded(const CMSketch *cms);
+
 /*  Merges multiple CMSketches into a single one.
     All sketches must have identical width, depth and cell size.
     dest must be already initialized.

--- a/src/rm_cms.c
+++ b/src/rm_cms.c
@@ -385,6 +385,11 @@ void *CMSRdbLoad(RedisModuleIO *io, int encver) {
         return NULL;
     }
 
+    if (CMS_ValidateLoaded(cms) != 0) {
+        err = true;
+        return NULL;
+    }
+
     return cms;
 }
 

--- a/src/rm_cms.c
+++ b/src/rm_cms.c
@@ -49,8 +49,31 @@ static int GetCMSKey(RedisModuleCtx *ctx, RedisModuleString *keyName, CMSketch *
     return REDISMODULE_OK;
 }
 
+static int parseCellSize(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+                         uint8_t *cellSize) {
+    *cellSize = CMS_DEFAULT_CELL_SIZE;
+    if (argc == 4) {
+        return REDISMODULE_OK;
+    }
+
+    size_t tokenlen;
+    const char *token = RedisModule_StringPtrLen(argv[4], &tokenlen);
+    if (strcasecmp(token, "CELL_SIZE") != 0) {
+        INNER_ERROR("CMS: unknown argument");
+    }
+
+    long long value = 0;
+    if (RedisModule_StringToLongLong(argv[5], &value) != REDISMODULE_OK ||
+        !CMS_IS_VALID_CELL_SIZE(value)) {
+        INNER_ERROR("CMS: CELL_SIZE must be 1, 2, 4 or 8");
+    }
+    *cellSize = (uint8_t)value;
+
+    return REDISMODULE_OK;
+}
+
 static int parseCreateArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
-                           long long *width, long long *depth) {
+                           long long *width, long long *depth, uint8_t *cellSize) {
 
     size_t cmdlen;
     const char *cmd = RedisModule_StringPtrLen(argv[0], &cmdlen);
@@ -78,17 +101,18 @@ static int parseCreateArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
         INNER_ERROR("CMS: invalid init arguments");
     }
 
-    return REDISMODULE_OK;
+    return parseCellSize(ctx, argv, argc, cellSize);
 }
 
 int CMSketch_Create(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_AutoMemory(ctx);
-    if (argc != 4) {
+    if (argc != 4 && argc != 6) {
         return RedisModule_WrongArity(ctx);
     }
 
     CMSketch *cms = NULL;
     long long width = 0, depth = 0;
+    uint8_t cellSize = CMS_DEFAULT_CELL_SIZE;
     RedisModuleString *keyName = argv[1];
     RedisModuleKey *key = RedisModule_OpenKey(ctx, keyName, REDISMODULE_READ | REDISMODULE_WRITE);
 
@@ -97,10 +121,10 @@ int CMSketch_Create(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return RedisModule_ReplyWithError(ctx, "CMS: key already exists");
     }
 
-    if (parseCreateArgs(ctx, argv, argc, &width, &depth) != REDISMODULE_OK)
+    if (parseCreateArgs(ctx, argv, argc, &width, &depth, &cellSize) != REDISMODULE_OK)
         return REDISMODULE_OK;
 
-    cms = NewCMSketch(width, depth);
+    cms = NewCMSketch(width, depth, cellSize);
     if (!cms) {
         RedisModule_CloseKey(key);
         RedisModule_ReplyWithError(ctx, "CMS: Insufficient memory to create the key");
@@ -123,8 +147,9 @@ static int parseIncrByArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
             REDISMODULE_OK) {
             INNER_ERROR("CMS: Cannot parse number");
         }
-        if ((*pairs)[i].value < 0) {
-            INNER_ERROR("CMS: Number cannot be negative");
+        // Negating LLONG_MIN is undefined, and no cell can hold its magnitude.
+        if ((*pairs)[i].value == LLONG_MIN) {
+            INNER_ERROR("CMS: invalid increment");
         }
     }
     return REDISMODULE_OK;
@@ -159,11 +184,18 @@ int CMSketch_IncrBy(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     }
     RedisModule_ReplyWithArray(ctx, pairCount);
     for (int i = 0; i < pairCount; ++i) {
-        size_t count = CMS_IncrBy(cms, pairArray[i].key, pairArray[i].keylen, pairArray[i].value);
-        if (count != UINT32_MAX) {
+        uint64_t count = 0;
+        switch (
+            CMS_IncrBy(cms, pairArray[i].key, pairArray[i].keylen, pairArray[i].value, &count)) {
+        case CMS_STATUS_OK:
             RedisModule_ReplyWithLongLong(ctx, (long long)count);
-        } else {
+            break;
+        case CMS_STATUS_OVERFLOW:
             RedisModule_ReplyWithError(ctx, "CMS: INCRBY overflow");
+            break;
+        case CMS_STATUS_UNDERFLOW:
+            RedisModule_ReplyWithError(ctx, "CMS: INCRBY underflow");
+            break;
         }
     }
     RedisModule_ReplicateVerbatim(ctx);
@@ -191,7 +223,7 @@ int CMSketch_Query(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
     RedisModule_ReplyWithArray(ctx, itemCount);
     for (int i = 0; i < itemCount; ++i) {
         const char *str = RedisModule_StringPtrLen(argv[2 + i], &length);
-        RedisModule_ReplyWithLongLong(ctx, CMS_Query(cms, str, length));
+        RedisModule_ReplyWithLongLong(ctx, (long long)CMS_Query(cms, str, length));
     }
 
     return REDISMODULE_OK;
@@ -220,6 +252,7 @@ static int parseMergeArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
 
     size_t width = params->dest->width;
     size_t depth = params->dest->depth;
+    uint8_t cellSize = params->dest->cellSize;
 
     for (int i = 0; i < numKeys; ++i) {
         if (pos == -1) {
@@ -233,6 +266,9 @@ static int parseMergeArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
         }
         if (params->cmsArray[i]->width != width || params->cmsArray[i]->depth != depth) {
             INNER_ERROR("CMS: width/depth is not equal");
+        }
+        if (params->cmsArray[i]->cellSize != cellSize) {
+            INNER_ERROR("CMS: cell size is not equal");
         }
     }
 
@@ -286,13 +322,15 @@ int CMSKetch_Info(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
         return REDISMODULE_OK;
     }
 
-    RedisModule_ReplyWithMapOrArray(ctx, 3 * 2, true);
+    RedisModule_ReplyWithMapOrArray(ctx, 4 * 2, true);
     RedisModule_ReplyWithSimpleString(ctx, "width");
     RedisModule_ReplyWithLongLong(ctx, cms->width);
     RedisModule_ReplyWithSimpleString(ctx, "depth");
     RedisModule_ReplyWithLongLong(ctx, cms->depth);
     RedisModule_ReplyWithSimpleString(ctx, "count");
     RedisModule_ReplyWithLongLong(ctx, cms->counter);
+    RedisModule_ReplyWithSimpleString(ctx, "cell size");
+    RedisModule_ReplyWithLongLong(ctx, cms->cellSize);
 
     return REDISMODULE_OK;
 }
@@ -302,8 +340,9 @@ void CMSRdbSave(RedisModuleIO *io, void *obj) {
     RedisModule_SaveUnsigned(io, cms->width);
     RedisModule_SaveUnsigned(io, cms->depth);
     RedisModule_SaveUnsigned(io, cms->counter);
+    RedisModule_SaveUnsigned(io, cms->cellSize);
     RedisModule_SaveStringBuffer(io, (const char *)cms->array,
-                                 sizeof *cms->array * cms->width * cms->depth);
+                                 cms->cellSize * cms->width * cms->depth);
 }
 
 void CMSFree(void *value) { CMS_Destroy(value); }
@@ -319,16 +358,27 @@ void *CMSRdbLoad(RedisModuleIO *io, int encver) {
     cms->width = LoadUnsigned_IOError(io, err, NULL);
     cms->depth = LoadUnsigned_IOError(io, err, NULL);
     cms->counter = LoadUnsigned_IOError(io, err, NULL);
+    // Sketches saved before CMS_ENC_VER 1 always used 4-byte cells.
+    uint64_t cellSize = CMS_DEFAULT_CELL_SIZE;
+    if (encver >= 1) {
+        cellSize = LoadUnsigned_IOError(io, err, NULL);
+    }
+
+    if (!CMS_IS_VALID_CELL_SIZE(cellSize)) {
+        err = true;
+        return NULL;
+    }
+    cms->cellSize = (uint8_t)cellSize;
 
     if (cms->width == 0 || cms->depth == 0 || cms->width > SIZE_MAX / cms->depth ||
-        cms->width * cms->depth > SIZE_MAX / sizeof(*cms->array)) {
+        cms->width * cms->depth > SIZE_MAX / cms->cellSize) {
         err = true;
         return NULL;
     }
 
-    size_t expected_length = sizeof(*cms->array) * cms->width * cms->depth;
+    size_t expected_length = cms->cellSize * cms->width * cms->depth;
     size_t length;
-    cms->array = (uint32_t *)LoadStringBuffer_IOError(io, &length, err, NULL);
+    cms->array = LoadStringBuffer_IOError(io, &length, err, NULL);
 
     if (length != expected_length) {
         err = true;
@@ -347,7 +397,7 @@ static int CMSDefrag(RedisModuleDefragCtx *ctx, RedisModuleString *key, void **v
 size_t CMSMemUsage(const void *value) {
     const CMSketch *cms = value;
     size_t size = sizeof *cms;
-    size += sizeof *cms->array * cms->width * cms->depth;
+    size += cms->cellSize * cms->width * cms->depth;
     return size;
 }
 

--- a/src/rm_cms.h
+++ b/src/rm_cms.h
@@ -15,7 +15,8 @@
 #define DEFAULT_WIDTH 2.7
 #define DEFAULT_DEPTH 5
 
-#define CMS_ENC_VER 0
+// Version 1 added the per-sketch cell size to the serialized form.
+#define CMS_ENC_VER 1
 
 static inline bool _is_resp3(RedisModuleCtx *ctx) {
     int ctxFlags = RedisModule_GetContextFlags(ctx);

--- a/src/study.c
+++ b/src/study.c
@@ -72,7 +72,8 @@ int statisticsTest(double width, int depth) {
     int *srcArray = calloc(AMOUNT, sizeof(int));
     int *errArray = calloc(AMOUNT, sizeof(int));
     double resArray[AMOUNT / STAT_SIZE][2];
-    CMSketch *cms = NewCMSketch(AMOUNT * width, depth);
+    CMSketch *cms = NewCMSketch(AMOUNT * width, depth, CMS_DEFAULT_CELL_SIZE);
+    uint64_t count = 0;
 
     srand(0);
     for (int i = 0; i < AMOUNT; ++i) {
@@ -84,7 +85,7 @@ int statisticsTest(double width, int depth) {
         for (j = 0; j < STAT_SIZE; ++j) {
             idx = STAT_SIZE * i + j;
             sprintf(str, "%d", idx);
-            CMS_IncrBy(cms, str, strlen(str), srcArray[idx]);
+            CMS_IncrBy(cms, str, strlen(str), srcArray[idx], &count);
         }
 
         for (k = 0, errIdx = 0; k < idx; ++k) {

--- a/src/studybloomcms.c
+++ b/src/studybloomcms.c
@@ -72,7 +72,8 @@ int statisticsTest(double width, int depth) {
     int *srcArray = calloc(AMOUNT, sizeof(int));
     int *errArray = calloc(AMOUNT, sizeof(int));
     double resArray[AMOUNT / STAT_SIZE][2];
-    CMSketch *cms = NewCMSketch(AMOUNT * width, depth);
+    CMSketch *cms = NewCMSketch(AMOUNT * width, depth, CMS_DEFAULT_CELL_SIZE);
+    uint64_t count = 0;
 
     srand(0);
     for (int i = 0; i < AMOUNT; ++i) {
@@ -85,7 +86,7 @@ int statisticsTest(double width, int depth) {
         for (j = 0; j < STAT_SIZE; ++j) {
             idx = STAT_SIZE * i + j;
             sprintf(str, "%d", idx);
-            CMS_IncrBy(cms, str, strlen(str), srcArray[idx]);
+            CMS_IncrBy(cms, str, strlen(str), srcArray[idx], &count);
         }
 
         /*for (k = 0, errIdx = 0; k < idx; ++k) {

--- a/tests/flow/rdb_corruption_utils.py
+++ b/tests/flow/rdb_corruption_utils.py
@@ -162,3 +162,77 @@ def rewrite_largest_module_string(dump_payload: bytes, transform_fn, require_sam
     )
     new_crc = crc64_redis(new_value + version)
     return new_value + version + struct.pack("<Q", new_crc)
+
+
+def rewrite_module_uint(dump_payload: bytes, index: int, new_value: int) -> bytes:
+    """Rewrite the index-th MODULE_OPCODE_UINT field and update the DUMP payload CRC.
+
+    Lets a test build a payload whose scalar fields disagree with the rest of the
+    value - a state no sequence of commands can reach, but a crafted RESTORE can.
+    """
+    if len(dump_payload) < 10:
+        raise RuntimeError("DUMP payload too small")
+    value = dump_payload[:-10]
+    version = dump_payload[-10:-8]
+
+    pos = 1
+    _, is_enc, pos, _ = load_len(value, pos)  # module id
+    if is_enc:
+        raise RuntimeError("Unexpected encoded module-id length")
+
+    out = bytearray(value[:pos])
+    seen = 0
+    rewritten = False
+    while pos < len(value):
+        op_start = pos
+        opcode, is_enc, pos, _ = load_len(value, pos)
+        if is_enc:
+            raise RuntimeError(f"Unexpected encoded opcode at pos={pos}")
+        after_opcode = pos
+
+        if opcode == RDB_MODULE_OPCODE_EOF:
+            out += value[op_start:]
+            break
+
+        if opcode == RDB_MODULE_OPCODE_UINT:
+            _, is_enc2, pos, _ = load_len(value, pos)
+            if is_enc2:
+                raise RuntimeError("Unexpected encoded value in MODULE_OPCODE_UINT")
+            if seen == index:
+                out += value[op_start:after_opcode] + encode_len(new_value)
+                rewritten = True
+            else:
+                out += value[op_start:pos]
+            seen += 1
+            continue
+
+        if opcode == RDB_MODULE_OPCODE_DOUBLE:
+            pos += 8
+            out += value[op_start:pos]
+            continue
+
+        if opcode == RDB_MODULE_OPCODE_STRING:
+            slen_or_enc, is_str_enc, pos, enc = load_len(value, pos)
+            if not is_str_enc:
+                pos += slen_or_enc
+            else:
+                if enc != RDB_ENC_LZF:
+                    raise RuntimeError(f"Unsupported encoded string type: {enc}")
+                clen, is_enc3, pos, _ = load_len(value, pos)
+                _, is_enc4, pos, _ = load_len(value, pos)  # uncompressed length
+                if is_enc3 or is_enc4:
+                    raise RuntimeError("Unexpected encoded compressed/uncompressed length")
+                pos += clen
+            if pos > len(value):
+                raise RuntimeError("String overruns buffer while parsing")
+            out += value[op_start:pos]
+            continue
+
+        raise RuntimeError(f"Unknown module opcode {opcode} at pos={pos}")
+
+    if not rewritten:
+        raise RuntimeError(f"No MODULE_OPCODE_UINT at index {index}")
+
+    new_body = bytes(out)
+    new_crc = crc64_redis(new_body + version)
+    return new_body + version + struct.pack("<Q", new_crc)

--- a/tests/flow/test_cms.py
+++ b/tests/flow/test_cms.py
@@ -688,11 +688,28 @@ class testCMS():
                                            lambda _old: cells, require_same_length=True)
         self.env.expect('RESTORE', 'bad', 0, bad).error().contains('Bad data format')
 
-    def test_incrby_across_loc_scratch_boundary(self):
-        # CMS_IncrBy caches one cell location per row in a fixed stack buffer
-        # (CMS_LOC_SCRATCH == 64) so its second pass skips the hash and the modulo.
-        # Above that depth the cache is disabled and the second pass recomputes, so
-        # both sides of the boundary must behave identically.
+    def test_incrby_rejection_undoes_partial_writes(self):
+        self.cmd('FLUSHALL')
+        self.assertOk(self.cmd('cms.initbydim', 'cms', '2', '4', 'CELL_SIZE', '1'))
+        self.assertEqual([200], self.cmd('cms.incrby', 'cms', 'filler', '200'))
+
+        before_a = self.cmd('cms.query', 'cms', 'a')
+        before_filler = self.cmd('cms.query', 'cms', 'filler')
+
+        res = self.cmd('cms.incrby', 'cms', 'a', '100')
+        self.env.assertResponseError(res[0], contained='CMS: INCRBY overflow')
+
+        self.assertEqual(before_a, self.cmd('cms.query', 'cms', 'a'))
+        self.assertEqual(before_filler, self.cmd('cms.query', 'cms', 'filler'))
+        self.assertEqual(['width', 2, 'depth', 4, 'count', 200, 'cell size', 1],
+                         self.cmd('cms.info', 'cms'))
+
+        # the sketch is still fully usable afterwards
+        self.assertEqual([201], self.cmd('cms.incrby', 'cms', 'filler', '1'))
+
+    def test_incrby_deep_sketches(self):
+        # Deep sketches walk many rows per operation; increments, decrements and
+        # rejected operations must behave the same at any depth.
         for depth in (63, 64, 65, 130):
             self.cmd('FLUSHALL')
             key = 'd{}'.format(depth)

--- a/tests/flow/test_cms.py
+++ b/tests/flow/test_cms.py
@@ -1,6 +1,7 @@
 
 from common import *
-from rdb_corruption_utils import rewrite_module_uint
+from rdb_corruption_utils import rewrite_module_uint, rewrite_largest_module_string
+import struct
 from random import randint
 import redis
 
@@ -653,6 +654,39 @@ class testCMS():
         self.assertEqual([0], self.cmd('cms.query', 'cms', other))
         self.assertEqual(['width', 100, 'depth', 1, 'count', maximum, 'cell size', 8],
                          self.cmd('cms.info', 'cms'))
+
+    def _raw_connection(self):
+        # DUMP payloads are binary, so they need a connection that does not decode
+        kwargs = dict(self.env.getConnection().connection_pool.connection_kwargs)
+        kwargs['decode_responses'] = False
+        return redis.Redis(**kwargs)
+
+    def test_rdb_load_rejects_out_of_range_counter(self):
+        # A total count above INT64_MAX cannot be produced by any command. Loading one
+        # would wrap the `INT64_MAX - counter` headroom check in CMS_IncrBy, letting
+        # the total escape the RESP integer range that check exists to protect.
+        self.cmd('FLUSHALL')
+        raw = self._raw_connection()
+        self.assertOk(self.cmd('cms.initbydim', 'src', '20', '5'))
+        self.assertEqual([7], self.cmd('cms.incrby', 'src', 'a', '7'))
+
+        bad = rewrite_module_uint(raw.execute_command('DUMP', 'src'), 2, 2 ** 63)
+        self.env.expect('RESTORE', 'bad', 0, bad).error().contains('Bad data format')
+
+    def test_rdb_load_rejects_out_of_range_cell(self):
+        # Only CELL_SIZE 8 can store a cell above its maximum, since CMS_CELL_MAX(8) is
+        # INT64_MAX while the slot holds a full uint64. Such a cell would wrap the
+        # `cellMax - cell` headroom check and make CMS.QUERY reply a negative count.
+        self.cmd('FLUSHALL')
+        raw = self._raw_connection()
+        self.assertOk(self.cmd('cms.initbydim', 'src', '20', '5', 'CELL_SIZE', '8'))
+        self.assertEqual([7], self.cmd('cms.incrby', 'src', 'a', '7'))
+
+        cell_count = 20 * 5
+        cells = struct.pack('<%dQ' % cell_count, *([2 ** 63] * cell_count))
+        bad = rewrite_largest_module_string(raw.execute_command('DUMP', 'src'),
+                                           lambda _old: cells, require_same_length=True)
+        self.env.expect('RESTORE', 'bad', 0, bad).error().contains('Bad data format')
 
     def test_incrby_underflow_corrupt_counter(self):
         # A sketch whose total count disagrees with its cell array cannot be reached by

--- a/tests/flow/test_cms.py
+++ b/tests/flow/test_cms.py
@@ -688,6 +688,33 @@ class testCMS():
                                            lambda _old: cells, require_same_length=True)
         self.env.expect('RESTORE', 'bad', 0, bad).error().contains('Bad data format')
 
+    def test_incrby_across_loc_scratch_boundary(self):
+        # CMS_IncrBy caches one cell location per row in a fixed stack buffer
+        # (CMS_LOC_SCRATCH == 64) so its second pass skips the hash and the modulo.
+        # Above that depth the cache is disabled and the second pass recomputes, so
+        # both sides of the boundary must behave identically.
+        for depth in (63, 64, 65, 130):
+            self.cmd('FLUSHALL')
+            key = 'd{}'.format(depth)
+            self.assertOk(self.cmd('cms.initbydim', key, '50', depth))
+            self.assertEqual([10], self.cmd('cms.incrby', key, 'a', '10'))
+            self.assertEqual([10], self.cmd('cms.query', key, 'a'))
+
+            # decrement, then a rejected decrement must leave everything untouched
+            self.assertEqual([4], self.cmd('cms.incrby', key, 'a', '-6'))
+            res = self.cmd('cms.incrby', key, 'a', '-5')
+            self.env.assertResponseError(res[0], contained='CMS: INCRBY underflow')
+            self.assertEqual([4], self.cmd('cms.query', key, 'a'))
+            self.assertEqual(['width', 50, 'depth', depth, 'count', 4, 'cell size', 4],
+                             self.cmd('cms.info', key))
+
+            # a rejected overflow must leave everything untouched too
+            self.assertOk(self.cmd('cms.initbydim', 'small', '50', depth, 'CELL_SIZE', '1'))
+            self.assertEqual([255], self.cmd('cms.incrby', 'small', 'b', '255'))
+            res = self.cmd('cms.incrby', 'small', 'b', '1')
+            self.env.assertResponseError(res[0], contained='CMS: INCRBY overflow')
+            self.assertEqual([255], self.cmd('cms.query', 'small', 'b'))
+
     def test_incrby_underflow_corrupt_counter(self):
         # A sketch whose total count disagrees with its cell array cannot be reached by
         # any sequence of commands - only by a crafted RESTORE, since the load path

--- a/tests/flow/test_cms.py
+++ b/tests/flow/test_cms.py
@@ -20,13 +20,13 @@ class testCMS():
         self.assertOk(self.cmd('cms.initbydim', 'cms1', '20', '5'))
         self.assertEqual([5], self.cmd('cms.incrby', 'cms1', 'a', '5'))
         self.assertEqual([5], self.cmd('cms.query', 'cms1', 'a'))
-        self.assertEqual(['width', 20, 'depth', 5, 'count', 5],
+        self.assertEqual(['width', 20, 'depth', 5, 'count', 5, 'cell size', 4],
                          self.cmd('cms.info', 'cms1'))
 
         self.assertOk(self.cmd('cms.initbyprob', 'cms2', '0.001', '0.01'))
         self.assertEqual([5], self.cmd('cms.incrby', 'cms2', 'a', '5'))
         self.assertEqual([5], self.cmd('cms.query', 'cms2', 'a'))
-        self.assertEqual(['width', 2000, 'depth', 7, 'count', 5],
+        self.assertEqual(['width', 2000, 'depth', 7, 'count', 5, 'cell size', 4],
                          self.cmd('cms.info', 'cms2'))
         yield 1
         self.env.dumpAndReload()
@@ -123,12 +123,12 @@ class testCMS():
 
         # empty small batch
         self.assertOk(self.cmd('cms.merge', 'small_3{1}', 2, 'small_1{1}', 'small_2{1}'))
-        self.assertEqual(['width', 20, 'depth', 5, 'count', 0],
+        self.assertEqual(['width', 20, 'depth', 5, 'count', 0, 'cell size', 4],
                          self.cmd('cms.info', 'small_3{1}'))
 
         # empty large batch
         self.assertOk(self.cmd('cms.merge', 'large_6{1}', 2, 'large_4{1}', 'large_5{1}'))
-        self.assertEqual(['width', 2000, 'depth', 10, 'count', 0],
+        self.assertEqual(['width', 2000, 'depth', 10, 'count', 0, 'cell size', 4],
                          self.cmd('cms.info', 'large_6{1}'))
 
         # non-empty small batch
@@ -172,7 +172,9 @@ class testCMS():
         self.assertOk(self.cmd('cms.initbydim', 'bar', '2000', '10'))
         self.assertOk(self.cmd('cms.initbydim', 'baz', '2000', '10'))
         self.assertRaises(ResponseError, self.cmd, 'cms.incrby', 'foo', 'item', 'foo')
-        self.assertRaises(ResponseError, self.cmd, 'cms.incrby', 'foo', 'item', '-1')
+        # a negative increment is valid syntax now, but underflows an empty sketch
+        res = self.cmd('cms.incrby', 'foo', 'item', '-1')
+        self.env.assertResponseError(res[0], contained='CMS: INCRBY underflow')
         self.assertRaises(ResponseError, self.cmd, 'cms.merge', 'foo', 2, 'foo')
         self.assertRaises(ResponseError, self.cmd, 'cms.merge', 'foo', 'B', 3, 'foo')
         self.assertRaises(ResponseError, self.cmd, 'cms.merge', 'foo', 1, 'bar', 'weights', 'B')
@@ -216,15 +218,19 @@ class testCMS():
         # result of insert is an error message
         self.env.assertResponseError(res[0], contained='CMS: INCRBY overflow')
         self.assertEqual(res[1:], [44, 51, 15])
-        # result of query in UINT32_MAX (large_val * 2 + 1)
-        self.assertEqual([large_val * 2 + 1, 51, 51, 15], self.cmd('cms.query', 'cms', 'a', 'b', 'c', 'd'))
+        # the rejected increment left 'a' untouched, the other items went through
+        self.assertEqual([large_val * 2, 51, 51, 15], self.cmd('cms.query', 'cms', 'a', 'b', 'c', 'd'))
+        # and it did not advance the total count either: two full rounds of
+        # (large_val + 10 + 7 + 5) plus one round without 'a'
+        info = dict(zip(*[iter(self.cmd('cms.info', 'cms'))] * 2))
+        self.assertEqual(2 * (large_val + 22) + 22, info['count'])
 
     def test_smallset(self):
         self.cmd('FLUSHALL')
         self.assertOk(self.cmd('cms.initbydim', 'cms1', '2', '2'))
         self.assertEqual([10, 42], self.cmd('cms.incrby', 'cms1', 'foo', '10', 'bar', '42'))
         self.assertEqual([10, 42], self.cmd('cms.query', 'cms1', 'foo', 'bar'))
-        self.assertEqual(['width', 2, 'depth', 2, 'count', 52],
+        self.assertEqual(['width', 2, 'depth', 2, 'count', 52, 'cell size', 4],
                          self.cmd('cms.info', 'cms1'))
         self.assertEqual([10, 42], self.cmd('cms.incrby', 'cms1', 'foo', '0', 'bar', '0'))
 
@@ -261,7 +267,7 @@ class testCMS():
 
         # Delete cms3{t} from cms5{t} and store in cms6{t}
         self.env.expect('cms.merge', 'cms6{t}', 2, 'cms5{t}', 'cms3{t}', 'weights', '1', '-1').ok()
-        self.assertEqual(['width', 1000, 'depth', 5, 'count', 200], self.cmd('cms.info', 'cms6{t}'))
+        self.assertEqual(['width', 1000, 'depth', 5, 'count', 200, 'cell size', 4], self.cmd('cms.info', 'cms6{t}'))
         # Validate cms6{t} has cms1{t} and cms2{t} only.
         for i in range(0, 100):
             self.assertEqual([1], self.cmd('cms.query', 'cms6{t}', 'foo' + str(i)))
@@ -270,7 +276,7 @@ class testCMS():
 
         # Same test as above, negative weight first.
         self.env.expect('cms.merge', 'cms6{t}', 2, 'cms3{t}', 'cms5{t}', 'weights', '-1', '1').ok()
-        self.assertEqual(['width', 1000, 'depth', 5, 'count', 200], self.cmd('cms.info', 'cms6{t}'))
+        self.assertEqual(['width', 1000, 'depth', 5, 'count', 200, 'cell size', 4], self.cmd('cms.info', 'cms6{t}'))
         # Validate cms6{t} has cms1{t} and cms2{t} only.
         for i in range(0, 100):
             self.assertEqual([1], self.cmd('cms.query', 'cms6{t}', 'foo' + str(i)))
@@ -298,7 +304,7 @@ class testCMS():
 
         self.env.expect('cms.merge', 'cms1{t}', 2, 'cms1{t}', 'cms2{t}',
                         'weights', '1', '-1').ok()
-        self.assertEqual(['width', 3000, 'depth', 30, 'count', 0],
+        self.assertEqual(['width', 3000, 'depth', 30, 'count', 0, 'cell size', 4],
                          self.cmd('cms.info', 'cms1{t}'))
 
         for i in range(0, 1000):
@@ -306,7 +312,7 @@ class testCMS():
 
         self.env.expect('cms.merge', 'cms1{t}', 2, 'cms1{t}', 'cms2{t}',
                         'weights', '1', '2').ok()
-        self.assertEqual(['width', 3000, 'depth', 30, 'count', 2000],
+        self.assertEqual(['width', 3000, 'depth', 30, 'count', 2000, 'cell size', 4],
                          self.cmd('cms.info', 'cms1{t}'))
 
         for i in range(0, 1000):
@@ -314,7 +320,7 @@ class testCMS():
 
         self.env.expect('cms.merge', 'cms1{t}', 2, 'cms1{t}', 'cms2{t}',
                         'weights', '1', '-1').ok()
-        self.assertEqual(['width', 3000, 'depth', 30, 'count', 1000],
+        self.assertEqual(['width', 3000, 'depth', 30, 'count', 1000, 'cell size', 4],
                          self.cmd('cms.info', 'cms1{t}'))
         for i in range(0, 1000):
             self.assertEqual([1], self.cmd('cms.query', 'cms1{t}', 'foo' + str(i)))
@@ -364,9 +370,9 @@ class testCMS():
                         'weights', '-1', '-1').error().contains('CMS: MERGE overflow')
 
         # Validate keys did not change
-        self.assertEqual(['width', 2, 'depth', 2, 'count', 4000000000],
+        self.assertEqual(['width', 2, 'depth', 2, 'count', 4000000000, 'cell size', 4],
                          self.cmd('cms.info', 'cms1{t}'))
-        self.assertEqual(['width', 2, 'depth', 2, 'count', 4000000000],
+        self.assertEqual(['width', 2, 'depth', 2, 'count', 4000000000, 'cell size', 4],
                          self.cmd('cms.info', 'cms2{t}'))
         self.assertEqual([4000000000], self.cmd('cms.query', 'cms1{t}', 'foo'))
         self.assertEqual([4000000000], self.cmd('cms.query', 'cms2{t}', 'foo'))
@@ -394,15 +400,15 @@ class testCMS():
                         'weights', '-5', '-4').error().contains('CMS: MERGE overflow')
 
         # Validate keys did not change
-        self.assertEqual(['width', 2, 'depth', 2, 'count', 4], self.cmd('cms.info', 'cms1{t}'))
-        self.assertEqual(['width', 2, 'depth', 2, 'count', 4], self.cmd('cms.info', 'cms2{t}'))
+        self.assertEqual(['width', 2, 'depth', 2, 'count', 4, 'cell size', 4], self.cmd('cms.info', 'cms1{t}'))
+        self.assertEqual(['width', 2, 'depth', 2, 'count', 4, 'cell size', 4], self.cmd('cms.info', 'cms2{t}'))
         self.assertEqual([4], self.cmd('cms.query', 'cms1{t}', 'foo'))
         self.assertEqual([4], self.cmd('cms.query', 'cms2{t}', 'foo'))
 
         # An extreme test for a success scenario
         self.env.expect('cms.merge', 'cms1{t}', 2, 'cms1{t}', 'cms2{t}',
                         'weights', '-922337203685477500', '922337203685477502').ok()
-        self.assertEqual(['width', 2, 'depth', 2, 'count', 8], self.cmd('cms.info', 'cms1{t}'))
+        self.assertEqual(['width', 2, 'depth', 2, 'count', 8, 'cell size', 4], self.cmd('cms.info', 'cms1{t}'))
         self.assertEqual([8], self.cmd('cms.query', 'cms1{t}', 'foo'))
 
     def test_watch(self):
@@ -427,6 +433,238 @@ class testCMS():
         self.env.expect('CMS.INITBYDIM',  'x', '1000000000', '1000000000').error().contains('CMS: Insufficient memory to create the key')
         self.env.expect('CMS.INITBYDIM',  'x', '2294967296', '2294967296').error().contains('CMS: Insufficient memory to create the key')
         self.env.expect('CMS.INITBYDIM',  'x', '100000000000000', '100000000000000').error().contains('CMS: invalid init arguments')
+
+
+    def test_cell_size_create(self):
+        self.cmd('FLUSHALL')
+        for cell_size, width, depth in ((1, 20, 5), (2, 20, 5), (4, 20, 5), (8, 20, 5)):
+            key = 'dim{}'.format(cell_size)
+            self.assertOk(self.cmd('cms.initbydim', key, width, depth, 'CELL_SIZE', cell_size))
+            self.assertEqual(['width', width, 'depth', depth, 'count', 0, 'cell size', cell_size],
+                             self.cmd('cms.info', key))
+
+            key = 'prob{}'.format(cell_size)
+            self.assertOk(self.cmd('cms.initbyprob', key, '0.001', '0.01', 'cell_size', cell_size))
+            self.assertEqual(['width', 2000, 'depth', 7, 'count', 0, 'cell size', cell_size],
+                             self.cmd('cms.info', key))
+
+        # no CELL_SIZE keeps the historical 4-byte cells
+        self.assertOk(self.cmd('cms.initbydim', 'default', '20', '5'))
+        self.assertEqual(['width', 20, 'depth', 5, 'count', 0, 'cell size', 4],
+                         self.cmd('cms.info', 'default'))
+
+    def test_cell_size_validation(self):
+        self.cmd('FLUSHALL')
+        for cell_size in ('0', '3', '5', '6', '7', '9', '16', '-1', '-4', 'blah', '', '4.5'):
+            self.env.expect('cms.initbydim', 'x', '20', '5', 'CELL_SIZE', cell_size) \
+                .error().contains('CMS: CELL_SIZE must be 1, 2, 4 or 8')
+            self.env.expect('cms.initbyprob', 'x', '0.001', '0.01', 'CELL_SIZE', cell_size) \
+                .error().contains('CMS: CELL_SIZE must be 1, 2, 4 or 8')
+
+        # unknown token in the optional slot
+        self.env.expect('cms.initbydim', 'x', '20', '5', 'CELLSIZE', '1') \
+            .error().contains('CMS: unknown argument')
+        self.env.expect('cms.initbyprob', 'x', '0.001', '0.01', 'OOR', '1') \
+            .error().contains('CMS: unknown argument')
+
+        # wrong arity: token without a value, or trailing junk
+        for args in (('x', '20', '5', 'CELL_SIZE'),
+                     ('x', '20', '5', 'CELL_SIZE', '1', '2'),
+                     ('x', '20', '5', '1')):
+            self.assertRaises(ResponseError, self.cmd, 'cms.initbydim', *args)
+
+        # width/depth are still validated when CELL_SIZE is given
+        self.env.expect('cms.initbydim', 'x', '0', '5', 'CELL_SIZE', '1') \
+            .error().contains('CMS: invalid width')
+        self.env.expect('cms.initbyprob', 'x', '2', '0.01', 'CELL_SIZE', '1') \
+            .error().contains('CMS: invalid overestimation value')
+
+    def test_cell_size_max_value(self):
+        # a 1x1 sketch has a single cell, so the estimate is exact
+        cell_max = {1: 2 ** 8 - 1, 2: 2 ** 16 - 1, 4: 2 ** 32 - 1, 8: 2 ** 63 - 1}
+        for cell_size, maximum in cell_max.items():
+            self.cmd('FLUSHALL')
+            self.assertOk(self.cmd('cms.initbydim', 'cms', '1', '1', 'CELL_SIZE', cell_size))
+            self.assertEqual([maximum], self.cmd('cms.incrby', 'cms', 'a', maximum))
+            self.assertEqual([maximum], self.cmd('cms.query', 'cms', 'a'))
+
+            res = self.cmd('cms.incrby', 'cms', 'a', 1)
+            self.env.assertResponseError(res[0], contained='CMS: INCRBY overflow')
+            self.assertEqual([maximum], self.cmd('cms.query', 'cms', 'a'))
+            self.assertEqual(['width', 1, 'depth', 1, 'count', maximum, 'cell size', cell_size],
+                             self.cmd('cms.info', 'cms'))
+
+    def test_cell_size_overflow_in_one_shot(self):
+        # an increment larger than the cell can ever hold is rejected outright
+        self.cmd('FLUSHALL')
+        self.assertOk(self.cmd('cms.initbydim', 'cms', '20', '5', 'CELL_SIZE', '1'))
+        res = self.cmd('cms.incrby', 'cms', 'a', 256)
+        self.env.assertResponseError(res[0], contained='CMS: INCRBY overflow')
+        self.assertEqual([0], self.cmd('cms.query', 'cms', 'a'))
+        self.assertEqual(['width', 20, 'depth', 5, 'count', 0, 'cell size', 1],
+                         self.cmd('cms.info', 'cms'))
+
+    def test_cell_size_persistence(self):
+        self.cmd('FLUSHALL')
+        for cell_size in (1, 2, 4, 8):
+            key = 'cms{}'.format(cell_size)
+            self.assertOk(self.cmd('cms.initbydim', key, '20', '5', 'CELL_SIZE', cell_size))
+            self.assertEqual([7], self.cmd('cms.incrby', key, 'a', '7'))
+
+        self.env.dumpAndReload()
+
+        for cell_size in (1, 2, 4, 8):
+            key = 'cms{}'.format(cell_size)
+            self.assertEqual(['width', 20, 'depth', 5, 'count', 7, 'cell size', cell_size],
+                             self.cmd('cms.info', key))
+            self.assertEqual([7], self.cmd('cms.query', key, 'a'))
+
+    def test_cell_size_dump_restore(self):
+        self.cmd('FLUSHALL')
+        # DUMP payloads are binary, so they need a connection that does not decode
+        kwargs = dict(self.env.getConnection().connection_pool.connection_kwargs)
+        kwargs['decode_responses'] = False
+        raw = redis.Redis(**kwargs)
+        for cell_size in (1, 2, 4, 8):
+            key = 'cms{}'.format(cell_size)
+            self.assertOk(self.cmd('cms.initbydim', key, '20', '5', 'CELL_SIZE', cell_size))
+            self.assertEqual([7], self.cmd('cms.incrby', key, 'a', '7'))
+            payload = raw.execute_command('DUMP', key)
+            raw.execute_command('RESTORE', key + '_copy', 0, payload)
+            self.assertEqual(['width', 20, 'depth', 5, 'count', 7, 'cell size', cell_size],
+                             self.cmd('cms.info', key + '_copy'))
+            self.assertEqual([7], self.cmd('cms.query', key + '_copy', 'a'))
+
+    def test_cell_size_memory(self):
+        if VALGRIND:
+            self.env.skip()
+        self.cmd('FLUSHALL')
+        usage = {}
+        for cell_size in (1, 2, 4, 8):
+            key = 'cms{}'.format(cell_size)
+            self.assertOk(self.cmd('cms.initbydim', key, '1000', '5', 'CELL_SIZE', cell_size))
+            usage[cell_size] = self.cmd('MEMORY USAGE', key)
+        # the array dominates, so a wider cell costs proportionally more
+        self.assertGreater(usage[2], usage[1])
+        self.assertGreater(usage[4], usage[2])
+        self.assertGreater(usage[8], usage[4])
+
+    def test_decrby(self):
+        self.cmd('FLUSHALL')
+        self.assertOk(self.cmd('cms.initbydim', 'cms', '1000', '5'))
+        self.assertEqual([100], self.cmd('cms.incrby', 'cms', 'a', '100'))
+        self.assertEqual([60], self.cmd('cms.incrby', 'cms', 'a', '-40'))
+        self.assertEqual([60], self.cmd('cms.query', 'cms', 'a'))
+        self.assertEqual(['width', 1000, 'depth', 5, 'count', 60, 'cell size', 4],
+                         self.cmd('cms.info', 'cms'))
+
+        # all the way down to zero
+        self.assertEqual([0], self.cmd('cms.incrby', 'cms', 'a', '-60'))
+        self.assertEqual([0], self.cmd('cms.query', 'cms', 'a'))
+        self.assertEqual(['width', 1000, 'depth', 5, 'count', 0, 'cell size', 4],
+                         self.cmd('cms.info', 'cms'))
+
+        # a zero increment is a no-op that reports the current estimate
+        self.assertEqual([0], self.cmd('cms.incrby', 'cms', 'a', '0'))
+
+    def test_decrby_underflow(self):
+        self.cmd('FLUSHALL')
+        self.assertOk(self.cmd('cms.initbydim', 'cms', '1000', '5'))
+        self.assertEqual([10], self.cmd('cms.incrby', 'cms', 'a', '10'))
+
+        # one past what was added
+        res = self.cmd('cms.incrby', 'cms', 'a', '-11')
+        self.env.assertResponseError(res[0], contained='CMS: INCRBY underflow')
+        self.assertEqual([10], self.cmd('cms.query', 'cms', 'a'))
+        self.assertEqual(['width', 1000, 'depth', 5, 'count', 10, 'cell size', 4],
+                         self.cmd('cms.info', 'cms'))
+
+        # an item that was never added
+        res = self.cmd('cms.incrby', 'cms', 'never_added', '-1')
+        self.env.assertResponseError(res[0], contained='CMS: INCRBY underflow')
+        self.assertEqual([0], self.cmd('cms.query', 'cms', 'never_added'))
+
+        # failures do not stop the other pairs in the same command
+        res = self.cmd('cms.incrby', 'cms', 'a', '-100', 'b', '3', 'a', '-4')
+        self.env.assertResponseError(res[0], contained='CMS: INCRBY underflow')
+        self.assertEqual(res[1:], [3, 6])
+        self.assertEqual([6, 3], self.cmd('cms.query', 'cms', 'a', 'b'))
+        self.assertEqual(['width', 1000, 'depth', 5, 'count', 9, 'cell size', 4],
+                         self.cmd('cms.info', 'cms'))
+
+    def test_decrby_cell_sizes(self):
+        for cell_size in (1, 2, 4, 8):
+            self.cmd('FLUSHALL')
+            self.assertOk(self.cmd('cms.initbydim', 'cms', '1', '1', 'CELL_SIZE', cell_size))
+            self.assertEqual([200], self.cmd('cms.incrby', 'cms', 'a', '200'))
+            self.assertEqual([50], self.cmd('cms.incrby', 'cms', 'a', '-150'))
+            res = self.cmd('cms.incrby', 'cms', 'a', '-51')
+            self.env.assertResponseError(res[0], contained='CMS: INCRBY underflow')
+            self.assertEqual([50], self.cmd('cms.query', 'cms', 'a'))
+
+    def test_decrby_validation(self):
+        self.cmd('FLUSHALL')
+        self.assertOk(self.cmd('cms.initbydim', 'cms', '20', '5'))
+        # LLONG_MIN cannot be negated
+        self.env.expect('cms.incrby', 'cms', 'a', '-9223372036854775808') \
+            .error().contains('CMS: invalid increment')
+        self.env.expect('cms.incrby', 'cms', 'a', 'blah') \
+            .error().contains('CMS: Cannot parse number')
+
+    def test_merge_cell_size(self):
+        self.cmd('FLUSHALL')
+        for name in ('a', 'b', 'dest'):
+            self.assertOk(self.cmd('cms.initbydim', name + '{t}', '20', '5', 'CELL_SIZE', '2'))
+        self.assertEqual([10], self.cmd('cms.incrby', 'a{t}', 'x', '10'))
+        self.assertEqual([7], self.cmd('cms.incrby', 'b{t}', 'x', '7'))
+        self.assertOk(self.cmd('cms.merge', 'dest{t}', '2', 'a{t}', 'b{t}'))
+        self.assertEqual([17], self.cmd('cms.query', 'dest{t}', 'x'))
+        self.assertEqual(['width', 20, 'depth', 5, 'count', 17, 'cell size', 2],
+                         self.cmd('cms.info', 'dest{t}'))
+
+        # merging past the destination cell maximum is rejected
+        self.assertOk(self.cmd('cms.merge', 'dest{t}', '2', 'a{t}', 'b{t}', 'WEIGHTS', '1000', '1'))
+        self.env.expect('cms.merge', 'dest{t}', '2', 'a{t}', 'b{t}',
+                        'WEIGHTS', '10000', '1').error().contains('CMS: MERGE overflow')
+
+    def test_merge_cell_size_mismatch(self):
+        self.cmd('FLUSHALL')
+        self.assertOk(self.cmd('cms.initbydim', 'small{t}', '20', '5', 'CELL_SIZE', '1'))
+        self.assertOk(self.cmd('cms.initbydim', 'large{t}', '20', '5', 'CELL_SIZE', '4'))
+        self.env.expect('cms.merge', 'large{t}', '1', 'small{t}') \
+            .error().contains('CMS: cell size is not equal')
+        self.env.expect('cms.merge', 'small{t}', '1', 'large{t}') \
+            .error().contains('CMS: cell size is not equal')
+
+    def test_total_count_overflow(self):
+        # the total count is a RESP integer too, so it is capped at INT64_MAX even
+        # when the item's own cells still have room
+        maximum = 2 ** 63 - 1
+        self.cmd('FLUSHALL')
+        self.assertOk(self.cmd('cms.initbydim', 'cms', '100', '1', 'CELL_SIZE', '8'))
+        self.assertEqual([maximum], self.cmd('cms.incrby', 'cms', 'a', maximum))
+
+        # an item that landed in a different cell, so its own cell is empty
+        other = next(item for item in ('x{}'.format(i) for i in range(1000))
+                     if self.cmd('cms.query', 'cms', item) == [0])
+        res = self.cmd('cms.incrby', 'cms', other, '1')
+        self.env.assertResponseError(res[0], contained='CMS: INCRBY overflow')
+        self.assertEqual([0], self.cmd('cms.query', 'cms', other))
+        self.assertEqual(['width', 100, 'depth', 1, 'count', maximum, 'cell size', 8],
+                         self.cmd('cms.info', 'cms'))
+
+    def test_rdb_load_encver_0(self):
+        # A CMS.INITBYDIM 20 5 sketch with 'a' incremented by 7 and 'b' by 3,
+        # dumped by a module version that predates the CELL_SIZE support
+        # (encoding version 0). It must load as a 4-byte-cell sketch.
+        self.cmd('FLUSHALL')
+        rdb_payload = b"\x07\x81\x08\xc4\xa4\xf96\x0f\x10\x00\x02\x14\x02\x05\x02\n\x05\xc34A\x90\x01\x00\x00\xe0-\x00\x00\x07\xa06\x00\x03\xa0\x07\xe0\x03\x00\xe0\x03\x13\xc0'\xe03\x00\xe0\x03C\xe0\x03[\xe0c\x00\xc0w\xe0\x03\x8b\xe0+\x00\xc0G\xe0\x07\x00\x80W\x01\x00\x00\x00\x0f\x00\xf8\xb3|^\xc6\xb6\xadO"
+        self.env.getConnection().execute_command('RESTORE', 'legacy', 0, rdb_payload)
+        self.assertEqual(['width', 20, 'depth', 5, 'count', 10, 'cell size', 4],
+                         self.cmd('cms.info', 'legacy'))
+        self.assertEqual([7, 3], self.cmd('cms.query', 'legacy', 'a', 'b'))
+        # and it takes part in the new operations
+        self.assertEqual([5], self.cmd('cms.incrby', 'legacy', 'a', '-2'))
 
     def test_rdb_load_overflow(self):
         self.cmd('FLUSHALL')

--- a/tests/flow/test_cms.py
+++ b/tests/flow/test_cms.py
@@ -1,5 +1,6 @@
 
 from common import *
+from rdb_corruption_utils import rewrite_module_uint
 from random import randint
 import redis
 
@@ -652,6 +653,39 @@ class testCMS():
         self.assertEqual([0], self.cmd('cms.query', 'cms', other))
         self.assertEqual(['width', 100, 'depth', 1, 'count', maximum, 'cell size', 8],
                          self.cmd('cms.info', 'cms'))
+
+    def test_incrby_underflow_corrupt_counter(self):
+        # A sketch whose total count disagrees with its cell array cannot be reached by
+        # any sequence of commands - only by a crafted RESTORE, since the load path
+        # validates the dimensions and the buffer length but never counter against the
+        # array. Decrementing such a sketch must be refused, not wrap the counter.
+        self.cmd('FLUSHALL')
+        kwargs = dict(self.env.getConnection().connection_pool.connection_kwargs)
+        kwargs['decode_responses'] = False
+        raw = redis.Redis(**kwargs)
+
+        self.assertOk(self.cmd('cms.initbydim', 'honest', '20', '5'))
+        self.assertEqual([7], self.cmd('cms.incrby', 'honest', 'a', '7'))
+
+        # CMSRdbSave writes width, depth, counter, cellSize -> counter is UINT #2
+        bad = rewrite_module_uint(raw.execute_command('DUMP', 'honest'), 2, 0)
+        raw.execute_command('RESTORE', 'bad', 0, bad)
+
+        # the cells still hold 7 while the total count claims 0
+        self.assertEqual(['width', 20, 'depth', 5, 'count', 0, 'cell size', 4],
+                         self.cmd('cms.info', 'bad'))
+        self.assertEqual([7], self.cmd('cms.query', 'bad', 'a'))
+
+        # every cell has exactly enough for this decrement, so only the counter check
+        # can reject it - this is what pins the counter guard in CMS_IncrBy
+        res = self.cmd('cms.incrby', 'bad', 'a', '-7')
+        self.env.assertResponseError(res[0], contained='CMS: INCRBY underflow')
+        self.assertEqual([7], self.cmd('cms.query', 'bad', 'a'))
+        self.assertEqual(['width', 20, 'depth', 5, 'count', 0, 'cell size', 4],
+                         self.cmd('cms.info', 'bad'))
+
+        # the honest sketch is unaffected and still decrements normally
+        self.assertEqual([0], self.cmd('cms.incrby', 'honest', 'a', '-7'))
 
     def test_rdb_load_encver_0(self):
         # A CMS.INITBYDIM 20 5 sketch with 'a' incremented by 7 and 'b' by 3,

--- a/tests/flow/test_docs_help.py
+++ b/tests/flow/test_docs_help.py
@@ -270,7 +270,7 @@ class testCommandDocsAndHelp():
             env.skip()
         assert_docs(
             env, 'cms.incrby',
-            summary='Changes the count of one or more items by increment, which may be negative',
+            summary='Increases the count of one or more items by increment, which may be negative',
             complexity='O(n) where n is the number of items',
             arity=-4,
             since='2.0.0',

--- a/tests/flow/test_docs_help.py
+++ b/tests/flow/test_docs_help.py
@@ -270,7 +270,7 @@ class testCommandDocsAndHelp():
             env.skip()
         assert_docs(
             env, 'cms.incrby',
-            summary='Increases the count of one or more items by increment',
+            summary='Changes the count of one or more items by increment, which may be negative',
             complexity='O(n) where n is the number of items',
             arity=-4,
             since='2.0.0',
@@ -300,9 +300,10 @@ class testCommandDocsAndHelp():
             env, 'cms.initbydim',
             summary='Initializes a Count-Min Sketch to dimensions specified by user',
             complexity='O(1)',
-            arity=4,
+            arity=-4,
             since='2.0.0',
-            args=[('key', 'key'), ('width', 'integer'), ('depth', 'integer')],
+            args=[('key', 'key'), ('width', 'integer'), ('depth', 'integer'),
+                  ('cellsize', 'block')],
             key_pos=1,
         )
 
@@ -314,9 +315,10 @@ class testCommandDocsAndHelp():
             env, 'cms.initbyprob',
             summary='Initializes a Count-Min Sketch to accommodate requested tolerances.',
             complexity='O(1)',
-            arity=4,
+            arity=-4,
             since='2.0.0',
-            args=[('key', 'key'), ('error', 'double'), ('probability', 'double')],
+            args=[('key', 'key'), ('error', 'double'), ('probability', 'double'),
+                  ('cellsize', 'block')],
             key_pos=1,
         )
 

--- a/tests/flow/test_resp3.py
+++ b/tests/flow/test_resp3.py
@@ -121,7 +121,7 @@ class testResp3():
         env.assertEqual(env.cmd('cms.initbyprob', 'cms2', '0.001', '0.01'), b'OK')
         env.assertEqual([5], env.cmd('cms.incrby', 'cms2', 'a', '5'))
         env.assertEqual([5], env.cmd('cms.query', 'cms2', 'a'))
-        env.assertEqual({b'width': 2000, b'depth': 7, b'count': 5},
+        env.assertEqual({b'width': 2000, b'depth': 7, b'count': 5, b'cell size': 4},
                             env.cmd('cms.info', 'cms2'))
 
         env.assertEqual(env.cmd("tdigest.create", "tdigest"), b'OK')

--- a/tests/unit/test_cms.c
+++ b/tests/unit/test_cms.c
@@ -24,20 +24,21 @@ int main() {
 }
 
 int visualTest() {
-    CMSketch *a = NewCMSketch(20, 5);
-    CMSketch *b = NewCMSketch(20, 5);
+    uint64_t count = 0;
+    CMSketch *a = NewCMSketch(20, 5, CMS_DEFAULT_CELL_SIZE);
+    CMSketch *b = NewCMSketch(20, 5, CMS_DEFAULT_CELL_SIZE);
 
-    CMS_IncrBy(a, "C", 1, 1);
+    CMS_IncrBy(a, "C", 1, 1, &count);
     CMS_Print(a);
-    CMS_IncrBy(a, "C", 1, 15);
+    CMS_IncrBy(a, "C", 1, 15, &count);
     CMS_Print(a);
-    CMS_IncrBy(b, "C", 1, 100);
+    CMS_IncrBy(b, "C", 1, 100, &count);
     CMS_Print(b);
-    CMS_IncrBy(b, "M", 1, 35);
+    CMS_IncrBy(b, "M", 1, 35, &count);
     CMS_Print(b);
-    CMS_IncrBy(b, "S", 1, 87);
+    CMS_IncrBy(b, "S", 1, 87, &count);
     CMS_Print(b);
-    CMS_IncrBy(b, "CMS", 3, 12);
+    CMS_IncrBy(b, "CMS", 3, 12, &count);
     CMS_Print(b);
 
     printf("C count at a is %lu\n", CMS_Query(a, "C", 1));
@@ -46,7 +47,7 @@ int visualTest() {
     printf("S count at b is %lu\n", CMS_Query(b, "S", 1));
     printf("CMS count at b is %lu\n", CMS_Query(b, "CMS", 3));
 
-    CMSketch *c = NewCMSketch(20, 5);
+    CMSketch *c = NewCMSketch(20, 5, CMS_DEFAULT_CELL_SIZE);
     const CMSketch *list[2] = {a, b};
     long long weight[2] = {3, 2};
     CMS_Merge(c, 2, list, weight);
@@ -62,7 +63,8 @@ int visualTest() {
 }
 
 int massiveTest() {
-    CMSketch *cms = NewCMSketch(AMOUNT * 2.7, 5);
+    CMSketch *cms = NewCMSketch(AMOUNT * 2.7, 5, CMS_DEFAULT_CELL_SIZE);
+    uint64_t count = 0;
     int original[AMOUNT] = {0};
     int result[AMOUNT] = {0};
     int totalErr = 0;
@@ -77,7 +79,7 @@ int massiveTest() {
     for (int i = 0; i < AMOUNT; ++i) {
         sprintf(str, "%d", i);
         for (int j = 0; j < original[i]; ++j) {
-            CMS_IncrBy(cms, str, strlen(str), 1);
+            CMS_IncrBy(cms, str, strlen(str), 1, &count);
         }
     }
     clock_t end = clock();


### PR DESCRIPTION
Features

- `CELL_SIZE 1|2|4|8` — `CMS.INITBYDIM` and `CMS.INITBYPROB` accept an optional trailing `CELL_SIZE` argument selecting bytes per counter cell, cutting memory up to 4× for low-count workloads (1000×5 sketch: 5072 B at `CELL_SIZE` 1 vs 40072 B at 8).
- Negative `CMS.INCRBY` — increments may now be negative, decrementing an item's count when every one of its cells holds at least that magnitude.
- `CMS.INFO` reports cell size — the reply grows from 3 to 4 field pairs so clients can discover a sketch's cell width after creation.

Behavior changes

- Over/underflow is atomic — a rejected increment now leaves every cell and the total count untouched, replacing the old behavior of saturating cells to `UINT32_MAX`, advancing the total count, and returning an error.
- `CMS.MERGE` requires a matching cell size across destination and all sources, erroring with CMS: cell size is not equal rather than reinterpreting a source's bytes at the wrong stride.
- The total count is capped at `INT64_MAX` so `CMS.INFO` count cannot exceed what a RESP integer can carry (a row holds width cells each up to `INT64_MAX`).

Fixes

- Overflow detection moved out of band — `rm_cms.c` previously inferred overflow from a returned sentinel of `UINT32_MAX`, which with `CELL_SIZE` 1 would have reported a legitimate count of 255 as an error; `CMS_IncrBy` now returns an explicit `CMSStatus`.
- `LLONG_MIN` increments are rejected at the parse boundary with CMS: invalid increment, since its magnitude (`2⁶³`) exceeds every cell maximum by one and could only ever underflow.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CMS persistence format, overflow semantics (breaking for clients relying on saturation), and core counter arithmetic paths; extensive new tests mitigate regressions.
> 
> **Overview**
> Extends Count-Min Sketch with **configurable counter width** and safer arithmetic, plus several **behavior changes** clients should know about.
> 
> **`CMS.INITBYDIM` / `CMS.INITBYPROB`** accept optional **`CELL_SIZE 1|2|4|8`** (default remains 4-byte cells). Sketches store counters in variable-width cells via `cellGet`/`cellSet`, which reduces memory for low-count workloads. **`CMS.INFO`** adds a **`cell size`** field; RDB encoding bumps to **version 1** (still loads old dumps as 4-byte cells).
> 
> **`CMS.INCRBY`** now allows **negative increments** (decrement) with explicit **`CMS: INCRBY underflow`** errors; **`LLONG_MIN`** is rejected at parse time. Overflow/underflow handling is **all-or-nothing**: failed updates **roll back** partial row writes and leave the total **`count`** unchanged—replacing the old saturate-to-`UINT32_MAX` behavior. **`CMS_IncrBy`** returns **`CMSStatus`** instead of inferring overflow from a sentinel.
> 
> **`CMS.MERGE`** requires matching **cell size** across sketches. **`RESTORE`/RDB load** runs **`CMS_ValidateLoaded`** to reject crafted payloads with impossible counters or 8-byte cell values above **`INT64_MAX`**. Command metadata in **`commands.json`** and **`cms_info.c`** is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 985b375edefd26306730637b5c454d670da78e2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->